### PR TITLE
Add stale PR closing workflow

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,24 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity.'
+          close-pr-message: 'Closing this PR because it has been inactive for more than 30 days.'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: ''
+          close-issue-message: ''

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 주요 개발 도구 및 앱 자동 설치/설정
 - GitHub Actions 기반 CI로 macOS/Linux(x86_64, aarch64) 빌드 및 테스트
 - 멀티플랫폼 matrix smoke 테스트로 기본 빌드 오류 조기 확인
+- 오래된 PR은 자동으로 stale로 표시 후 닫힘
 
 ## Directory Layout
 


### PR DESCRIPTION
## Summary
- add a workflow that auto closes stale pull requests
- document the stale PR automation in README

## Testing
- `pre-commit run --files README.md .github/workflows/close-stale-prs.yml` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684007ae65a4832fb66a6263f63419c6