### PR TITLE
Fix zsh init for cross‑platform CI

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -21,7 +21,7 @@ let name = "Jiho Lee";
       }
     ];
 
-    initExtraFirst = ''
+    initContent = lib.mkBefore ''
       if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
         . /nix/var/nix/profiles/default/etc/profile.d/nix.sh


### PR DESCRIPTION
## Summary
- fix deprecated `initExtraFirst` usage in zsh module for multi-platform CI

## Testing
- `pre-commit run --files modules/shared/home-manager.nix`
- `nix flake check --system x86_64-linux --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68400902b44c832fa6f9b580538d2ae9