### PR TITLE
Add Makefile and unify CI scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run lint
+        run: make lint
 
   smoke:
     needs: lint
@@ -49,7 +50,7 @@ jobs:
             ${{ runner.os }}-nix-
       - name: Run smoke test
         run: |
-          nix flake check --system ${{ matrix.system }} --no-build
+          make smoke SYSTEM=${{ matrix.system }}
 
   build-test:
     needs: [lint, smoke]
@@ -91,4 +92,4 @@ jobs:
           nix build --no-link ".#${{ matrix.build_attr }}"
       - name: Run Nix flake checks
         run: |
-          nix flake check --system ${{ matrix.system }} --no-build
+          make smoke SYSTEM=${{ matrix.system }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+.DEFAULT_GOAL := help
+
+ARCH := $(shell uname -m)
+OS := $(shell uname -s | tr A-Z a-z)
+
+help:
+	@echo "Available targets:"
+	@echo "  lint   - Run pre-commit lint"
+	@echo "  smoke  - Run nix flake checks for all systems"
+	@echo "  build  - Build all Darwin and NixOS configurations"
+	@echo "  switch - Apply configuration on the current machine (HOST=<system> optional)"
+
+lint:
+	pre-commit run --all-files
+
+ifdef SYSTEM
+smoke:
+	nix flake check --system $(SYSTEM) --no-build
+else
+smoke:
+	nix flake check --system x86_64-linux --no-build
+	nix flake check --system aarch64-linux --no-build
+	nix flake check --system x86_64-darwin --no-build
+	nix flake check --system aarch64-darwin --no-build
+endif
+
+build-linux:
+	nix build --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel"
+	nix build --no-link ".#nixosConfigurations.aarch64-linux.config.system.build.toplevel"
+
+build-darwin:
+	nix build --no-link ".#darwinConfigurations.x86_64-darwin.system"
+	nix build --no-link ".#darwinConfigurations.aarch64-darwin.system"
+
+build: build-linux build-darwin
+
+switch:
+	@OS=$$(uname -s); \
+	ARCH=$$(uname -m); \
+	if [ "$${OS}" = "Darwin" ]; then \
+	  DEFAULT_SYSTEM="$${ARCH}-darwin"; \
+	else \
+	  DEFAULT_SYSTEM="$${ARCH}-linux"; \
+	fi; \
+	TARGET=${HOST-$${DEFAULT_SYSTEM}}; \
+	if [ "$${OS}" = "Darwin" ]; then \
+	  nix --extra-experimental-features 'nix-command flakes' build .#darwinConfigurations.$${TARGET}.system; \
+	  sudo ./result/sw/bin/darwin-rebuild switch --flake .#$${TARGET}; \
+	  unlink ./result; \
+	else \
+	  sudo SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --flake .#$${TARGET}; \
+	fi
+
+.PHONY: help lint smoke build build-linux build-darwin switch

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - GitHub Actions 기반 CI로 macOS/Linux(x86_64, aarch64) 빌드 및 테스트
 - 멀티플랫폼 matrix smoke 테스트로 기본 빌드 오류 조기 확인
 - 오래된 PR은 자동으로 stale로 표시 후 닫힘
+- Makefile 기반 로컬/CI 명령어 통합
 
 ## Directory Layout
 
@@ -72,19 +73,13 @@ cd dotfiles
 #### macOS
 
 ```sh
-nix run .#switch
-# 또는
-./apps/x86_64-darwin/build-switch
-# 또는
-./apps/aarch64-darwin/build-switch
-# 또는
-sudo darwin-rebuild switch --flake .#<host>
+make switch HOST=<host>
 ```
 
 #### NixOS
 
 ```sh
-sudo nixos-rebuild switch --flake .#<host>
+make switch HOST=<host>
 ```
 
 #### Home Manager만 적용
@@ -97,22 +92,15 @@ home-manager switch --flake .#<host>
 
 1. 설정 파일 수정
 2. 아래 명령어로 적용/테스트
-   - `nix flake check`
-   - `nix run .#switch`
-   - `darwin-rebuild switch --flake .#<host>`
+   - `make lint`
+   - `make smoke`
+   - `make build`
+   - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`
-   - `pre-commit run --all-files`
 
 ## Smoke Tests
 
-GitHub Actions에서 각 플랫폼(macOS, Linux)의 x86_64와 aarch64 환경에 대해 smoke test를 실행해 빌드 오류를 조기에 확인합니다. 로컬에서도 다음 명령어로 동일하게 테스트할 수 있습니다.
-
-```sh
-nix flake check --system x86_64-linux --no-build
-nix flake check --system aarch64-linux --no-build
-nix flake check --system x86_64-darwin --no-build
-nix flake check --system aarch64-darwin --no-build
-```
+GitHub Actions에서 각 플랫폼(macOS, Linux)의 x86_64와 aarch64 환경에 대해 smoke test를 실행해 빌드 오류를 조기에 확인합니다. 로컬에서는 `make smoke` 명령어로 동일한 테스트를 수행할 수 있습니다.
 
 ## How to Add/Modify Modules
 


### PR DESCRIPTION
## Summary
- add Makefile providing common targets
- update README with Makefile usage
- update CI workflow to use Makefile commands

## Testing
- `pre-commit run --files Makefile README.md .github/workflows/test.yml`
- `nix flake check --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6840207ce960832fba17ae93414d9711