### PR TITLE
Add overlay e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ home-manager switch --flake .#<host>
 2. 아래 명령어로 적용/테스트
    - `make lint`
    - `make smoke`
-   - `make test`
+   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행
    - `make build`
    - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,7 +8,7 @@ This document provides additional context on the layout and purpose of the `dotf
 - `hosts/`: Host-specific configurations for nix-darwin or NixOS.
 - `modules/`: Reusable Nix modules shared between platforms or system types.
 - `overlays/`: Custom package overlays for nixpkgs.
-- `tests/`: Flake checks and example unit tests.
+- `tests/`: Flake checks, unit tests and e2e tests.
 - `docs/`: Extra documentation files like this one.
 
 See `README.md` for general usage instructions.

--- a/tests/e2e.nix
+++ b/tests/e2e.nix
@@ -1,0 +1,9 @@
+{ pkgs }:
+let
+  hasFeather = pkgs ? feather-font;
+  checkCmd = if hasFeather then "test -f ${pkgs.feather-font}/share/fonts/truetype/feather.ttf" else "echo 'feather-font not available for ${pkgs.system}'";
+in pkgs.runCommand "e2e-overlay-test" { } ''
+  # Verify overlay package builds on supported platforms
+  ${checkCmd}
+  touch $out
+''


### PR DESCRIPTION
## Summary
- add `tests/e2e.nix` to validate overlay builds
- document e2e test execution in README and docs/overview

## Testing
- `pre-commit run --files tests/e2e.nix README.md docs/overview.md` *(skipped: no files to check)*
- `nix --extra-experimental-features 'nix-command flakes' flake check --all-systems --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6840416ce7bc832fb28635aca9d71454