### PR TITLE
Enforce USER env var for flake evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 │   ├── darwin/
 │   ├── nixos/
 │   └── shared/
+├── lib/            # 공통 Nix 함수
 ├── overlays/       # Nixpkgs 오버레이
 ├── legacy/         # 이전 버전/백업/마이그레이션 자료
 ├── tests/          # flake checks and unit tests
@@ -48,6 +49,7 @@
 - **apps/**: `nix run .#switch` 등으로 실행할 수 있는 Nix 앱 정의 (플랫폼별)
 - **hosts/**: 각 호스트별 시스템/유저 설정(nix-darwin, home-manager, nixos)
 - **modules/**: 공통/프로그램별/서비스별 Nix 모듈 (darwin, nixos, shared)
+- **lib/**: 공통 함수 모음 (`get-user.nix`은 `USER`를 읽음)
 - **overlays/**: 패치, 커스텀 패키지
 - **legacy/**: 이전 구조/마이그레이션 자료
 - **tests/**: flake checks and unit tests
@@ -70,6 +72,9 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ```sh
 git clone https://github.com/yourname/dotfiles.git
 cd dotfiles
+# 필요 시 USER 환경변수로 대상 계정을 지정할 수 있습니다.
+export USER=<username>
+# USER가 비어 있으면 flake 평가 단계에서 오류가 발생합니다.
 ```
 
 ### 3. 환경 적용

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,8 @@
 
   outputs = { self, darwin, nix-homebrew, homebrew-bundle, homebrew-core, homebrew-cask, home-manager, nixpkgs, disko } @inputs:
     let
-      user = "baleen";
+      getUser = import ./lib/get-user.nix { };
+      user = getUser;
       linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
       darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs (linuxSystems ++ darwinSystems) f;
@@ -77,7 +78,7 @@
         import ./tests { pkgs = nixpkgs.legacyPackages.${system}; });
 
       darwinConfigurations = nixpkgs.lib.genAttrs darwinSystems (system: let
-        user = "baleen";
+        user = getUser;
       in
         darwin.lib.darwinSystem {
           inherit system;

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -1,6 +1,9 @@
 { config, pkgs, ... }:
 
-let user = "baleen"; in
+let
+  getUser = import ../../lib/get-user.nix { };
+  user = getUser;
+in
 
 {
   imports = [

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -1,6 +1,8 @@
 { config, inputs, pkgs, ... }:
 
-let user = "baleen";
+let
+  getUser = import ../../lib/get-user.nix { };
+  user = getUser;
     keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOk8iAnIaa1deoc7jw8YACPNVka1ZFJxhnU4G74TmS+p" ]; in
 {
   imports = [

--- a/lib/get-user.nix
+++ b/lib/get-user.nix
@@ -1,0 +1,6 @@
+{ envVar ? "USER" }:
+let
+  envValue = builtins.getEnv envVar; # read from USER environment variable
+in
+  if envValue != "" then envValue else
+    builtins.throw "Environment variable ${envVar} must be set"

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -1,8 +1,9 @@
 { config, pkgs, lib, home-manager, ... }:
 
 let
-  # The main user for this configuration
-  user = "baleen";
+  # Resolve user from USER env var
+  getUser = import ../../lib/get-user.nix { };
+  user = getUser;
   sharedFiles = import ../shared/files.nix { inherit config pkgs; };
   additionalFiles = import ./files.nix { inherit user config pkgs; };
 in

--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -1,8 +1,9 @@
 { config, pkgs, lib, ... }:
 
 let
-  # The main user for this configuration
-  user = "baleen";
+  # Resolve user from USER env var
+  getUser = import ../../lib/get-user.nix { };
+  user = getUser;
   xdg_configHome  = "/home/${user}/.config";
   shared-programs = import ../shared/home-manager.nix { inherit config pkgs lib; };
   shared-files = import ../shared/files.nix { inherit config pkgs; };

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -1,7 +1,8 @@
 { config, pkgs, lib, ... }:
 
 let name = "Jiho Lee";
-    user = "baleen";
+    getUser = import ../../lib/get-user.nix { };
+    user = getUser;
     email = "baleen37@gmail.com"; in
 {
   # Shared shell configuration

--- a/tests/get-user.nix
+++ b/tests/get-user.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+pkgs.runCommand "get-user-test" {} ''
+  export USER=codex
+  result=$(${pkgs.nix}/bin/nix eval --impure --extra-experimental-features nix-command --expr 'import ../lib/get-user.nix {}')
+  if [ "$result" != "\"codex\"" ]; then
+    echo "expected codex but got $result"
+    exit 1
+  fi
+  unset USER
+  if ${pkgs.nix}/bin/nix eval --impure --extra-experimental-features nix-command --expr 'import ../lib/get-user.nix {}' >/tmp/out 2>&1; then
+    echo "expected failure when USER unset"
+    exit 1
+  fi
+  grep -q "must be set" /tmp/out
+  touch $out
+''


### PR DESCRIPTION
## Summary
- add helper to read `$USER` for configuration
- integrate helper throughout flake and modules
- test failure when `$USER` is unset
- document requirement in README

## Testing
- `pre-commit run --files README.md`
- `nix --extra-experimental-features 'nix-command flakes' flake check --system x86_64-linux --no-build --impure`
- `nix --extra-experimental-features 'nix-command flakes' flake check --system aarch64-linux --no-build --impure`
- `nix --extra-experimental-features 'nix-command flakes' flake check --system x86_64-darwin --no-build --impure`
- `nix --extra-experimental-features 'nix-command flakes' flake check --system aarch64-darwin --no-build --impure`
- `nix --extra-experimental-features 'nix-command flakes' build .#checks.x86_64-linux.get-user --impure --no-link` *(fails: permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68403f8efb98832fb8de907b26802cc8