### PR TITLE
Fix nix run build for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 └── README.md
 ```
 
-- **apps/**: `nix run .#switch` 등으로 실행할 수 있는 Nix 앱 정의 (플랫폼별)
+- **apps/**: `nix run .#switch` 또는 `nix run .#build` 등으로 실행할 수 있는 Nix 앱 정의 (플랫폼별)
 - **hosts/**: 각 호스트별 시스템/유저 설정(nix-darwin, home-manager, nixos)
 - **modules/**: 공통/프로그램별/서비스별 Nix 모듈 (darwin, nixos, shared)
 - **lib/**: 공통 함수 모음 (`get-user.nix`은 `USER`를 읽음)

--- a/apps/x86_64-linux/build
+++ b/apps/x86_64-linux/build
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+NC='\033[0m'
+
+SYSTEM=$(uname -m)
+
+case "$SYSTEM" in
+  x86_64)
+    FLAKE_TARGET="x86_64-linux"
+    ;;
+  aarch64)
+    FLAKE_TARGET="aarch64-linux"
+    ;;
+  *)
+    echo -e "${RED}Unsupported architecture: $SYSTEM${NC}"
+    exit 1
+    ;;
+esac
+
+export NIXPKGS_ALLOW_UNFREE=1
+
+echo -e "${YELLOW}Starting build...${NC}"
+nix --extra-experimental-features 'nix-command flakes' build .#nixosConfigurations.${FLAKE_TARGET}.config.system.build.toplevel "$@"
+
+echo -e "${YELLOW}Cleaning up...${NC}"
+unlink ./result
+
+echo -e "${GREEN}Build complete!${NC}"

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
       };
       mkLinuxApps = system: {
         "apply" = mkApp "apply" system;
+        "build" = mkApp "build" system;
         "build-switch" = mkApp "build-switch" system;
         "copy-keys" = mkApp "copy-keys" system;
         "create-keys" = mkApp "create-keys" system;

--- a/tests/build-app.nix
+++ b/tests/build-app.nix
@@ -1,0 +1,9 @@
+{ pkgs }:
+pkgs.runCommand "build-app-test" {} ''
+  export USER=baleen
+  if ! ${pkgs.nix}/bin/nix eval --impure --extra-experimental-features nix-command --expr ".#apps.${pkgs.system}.build.program" >/dev/null; then
+    echo "build app not found for ${pkgs.system}"
+    exit 1
+  fi
+  touch $out
+''


### PR DESCRIPTION
## Summary
- enable `nix run .#build` on Linux by providing a build script
- document usage in README
- add unit test ensuring the build app exists

## Testing
- `pre-commit run --files flake.nix tests/build-app.nix README.md apps/x86_64-linux/build`
- `USER=baleen nix --extra-experimental-features 'nix-command flakes' flake check --impure --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684048052c84832fbf5623e75c7d023a