### PR TITLE
Fix flake checks with default Nix flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 ARCH := $(shell uname -m)
 OS := $(shell uname -s | tr A-Z a-z)
+NIX_FLAGS ?= --impure --extra-experimental-features 'nix-command flakes'
 
 help:
 	@echo "Available targets:"
@@ -16,22 +17,22 @@ lint:
 
 ifdef SYSTEM
 smoke:
-	nix flake check --system $(SYSTEM) --no-build $(ARGS)
+        nix $(NIX_FLAGS) flake check --system $(SYSTEM) --no-build $(ARGS)
 else
 smoke:
-	nix flake check --all-systems --no-build $(ARGS)
+        nix $(NIX_FLAGS) flake check --all-systems --no-build $(ARGS)
 endif
 
 test:
-	nix flake check --no-build
+        nix $(NIX_FLAGS) flake check --no-build
 
 build-linux:
-	nix build --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)
-	nix build --no-link ".#nixosConfigurations.aarch64-linux.config.system.build.toplevel" $(ARGS)
+        nix $(NIX_FLAGS) build --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)
+        nix $(NIX_FLAGS) build --no-link ".#nixosConfigurations.aarch64-linux.config.system.build.toplevel" $(ARGS)
 
 build-darwin:
-	nix build --no-link ".#darwinConfigurations.x86_64-darwin.system" $(ARGS)
-	nix build --no-link ".#darwinConfigurations.aarch64-darwin.system" $(ARGS)
+        nix $(NIX_FLAGS) build --no-link ".#darwinConfigurations.x86_64-darwin.system" $(ARGS)
+        nix $(NIX_FLAGS) build --no-link ".#darwinConfigurations.aarch64-darwin.system" $(ARGS)
 
 build: build-linux build-darwin
 
@@ -44,12 +45,12 @@ switch:
 	  DEFAULT_SYSTEM="$${ARCH}-linux"; \
 	fi; \
 	TARGET=${HOST-$${DEFAULT_SYSTEM}}; \
-	if [ "$${OS}" = "Darwin" ]; then \
-	  nix --extra-experimental-features 'nix-command flakes' build .#darwinConfigurations.$${TARGET}.system $(ARGS); \
-	  sudo ./result/sw/bin/darwin-rebuild switch --flake .#$${TARGET} $(ARGS); \
-	  unlink ./result; \
-	else \
-	  sudo SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --flake .#$${TARGET} $(ARGS); \
-	fi
+        if [ "$${OS}" = "Darwin" ]; then \
+          nix $(NIX_FLAGS) build .#darwinConfigurations.$${TARGET}.system $(ARGS); \
+          sudo ./result/sw/bin/darwin-rebuild switch --flake .#$${TARGET} $(ARGS); \
+          unlink ./result; \
+        else \
+          sudo SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --impure --flake .#$${TARGET} $(ARGS); \
+        fi
 
 .PHONY: help lint smoke test build build-linux build-darwin switch

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ home-manager switch --flake .#<host>
 
 프로젝트 수정 후에는 아래 명령을 순서대로 실행해 CI와 동일한 검증을 로컬에서 진행합니다.
 
+Makefile은 `NIX_FLAGS` 환경변수로 Nix 옵션을 전달합니다. 필요한 경우 아래와 같이 설정합니다.
+
+```sh
+export USER=<username>
+export NIX_FLAGS="--impure --extra-experimental-features 'nix-command flakes'"
+```
+
 ```sh
 make lint   # pre-commit run --all-files
 make smoke  # nix flake check --all-systems --no-build


### PR DESCRIPTION
## Summary
- pass `--impure` and experimental features in Makefile via `NIX_FLAGS`
- document new environment variable in README

## Testing
- `pre-commit run --files Makefile README.md`
- `env USER=codex NIX_CONFIG='extra-experimental-features = nix-command flakes' nix flake check --impure --all-systems --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684048ba8e80832f83986733fc8fb425