### PR TITLE
Fix test target for nix flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ smoke:
 endif
 
 test:
-	$(NIX) flake check --no-build
+	@USER=$${USER:-codex} $(NIX) flake check --impure --no-build
 
 build-linux:
 	$(NIX) build --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ home-manager switch --flake .#<host>
 2. 아래 명령어로 적용/테스트
    - `make lint`
    - `make smoke`
-   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행
+   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. 환경변수 `USER`가 없으면 `codex`로 설정합니다.
    - `make build`
    - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`


### PR DESCRIPTION
## Summary
- ensure `make test` passes USER to `nix flake check`
- document default USER in README

## Testing
- `make test`
- `pre-commit run --files Makefile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684049b49098832fabfa32db04f25dfc