### PR TITLE
Ensure USER env survives switch scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ switch:
 	fi; \
 	TARGET=${HOST-$${DEFAULT_SYSTEM}}; \
 	if [ "$${OS}" = "Darwin" ]; then \
-	nix --extra-experimental-features 'nix-command flakes' build --impure .#darwinConfigurations.$${TARGET}.system $(ARGS); \
-	sudo ./result/sw/bin/darwin-rebuild switch --flake .#$${TARGET} $(ARGS); \
-	unlink ./result; \
-	else \
-	sudo SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --impure --flake .#$${TARGET} $(ARGS); \
-	fi
+        nix --extra-experimental-features 'nix-command flakes' build --impure .#darwinConfigurations.$${TARGET}.system $(ARGS); \
+        sudo --preserve-env=USER ./result/sw/bin/darwin-rebuild switch --flake .#$${TARGET} $(ARGS); \
+        unlink ./result; \
+        else \
+        sudo --preserve-env=USER SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --impure --flake .#$${TARGET} $(ARGS); \
+        fi
 
 .PHONY: help lint smoke test build build-linux build-darwin switch

--- a/apps/aarch64-darwin/build-switch
+++ b/apps/aarch64-darwin/build-switch
@@ -15,7 +15,7 @@ nix --extra-experimental-features 'nix-command flakes' build .#$FLAKE_SYSTEM $@
 
 echo "${YELLOW}Switching to new generation...${NC}"
 # See https://github.com/nix-darwin/nix-darwin/issues/1457 on why we need sudo
-sudo ./result/sw/bin/darwin-rebuild switch --flake .#${SYSTEM_TYPE} $@
+sudo --preserve-env=USER ./result/sw/bin/darwin-rebuild switch --flake .#${SYSTEM_TYPE} "$@"
 
 echo "${YELLOW}Cleaning up...${NC}"
 unlink ./result

--- a/apps/x86_64-darwin/build-switch
+++ b/apps/x86_64-darwin/build-switch
@@ -15,7 +15,7 @@ nix --extra-experimental-features 'nix-command flakes' build .#$FLAKE_SYSTEM $@
 
 echo "${YELLOW}Switching to new generation...${NC}"
 # See https://github.com/nix-darwin/nix-darwin/issues/1457 on why we need sudo
-sudo ./result/sw/bin/darwin-rebuild switch --flake .#${SYSTEM_TYPE} $@
+sudo --preserve-env=USER ./result/sw/bin/darwin-rebuild switch --flake .#${SYSTEM_TYPE} "$@"
 
 echo "${YELLOW}Cleaning up...${NC}"
 unlink ./result

--- a/apps/x86_64-linux/build-switch
+++ b/apps/x86_64-linux/build-switch
@@ -25,6 +25,6 @@ esac
 echo -e "${YELLOW}Starting...${NC}"
 
 # We pass SSH from user to root so root can download secrets from our private Github
-sudo SSH_AUTH_SOCK=$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --flake .#$FLAKE_TARGET $@
+sudo --preserve-env=USER SSH_AUTH_SOCK=$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --flake .#$FLAKE_TARGET "$@"
 
 echo -e "${GREEN}Switch to new generation complete!${NC}"

--- a/tests/sudo-preserve-env.nix
+++ b/tests/sudo-preserve-env.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+pkgs.runCommand "sudo-preserve-env-test" {} ''
+  grep -q -- "sudo --preserve-env=USER" ${../apps/x86_64-linux/build-switch}
+  grep -q -- "sudo --preserve-env=USER" ${../apps/x86_64-darwin/build-switch}
+  grep -q -- "sudo --preserve-env=USER" ${../apps/aarch64-darwin/build-switch}
+  grep -q -- "--preserve-env=USER" ${../Makefile}
+  touch $out
+''


### PR DESCRIPTION
## Summary
- preserve `USER` env when calling rebuild scripts via sudo
- test that build-switch commands include `--preserve-env=USER`

## Testing
- `nix --extra-experimental-features 'nix-command flakes' build .#checks.x86_64-linux.sudo-preserve-env --no-link`


------
https://chatgpt.com/codex/tasks/task_e_68404e6a8c58832fbefc3679d1aab677