### PR TITLE
Fix sudo user detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ git clone https://github.com/yourname/dotfiles.git
 cd dotfiles
 # 필요 시 USER 환경변수로 대상 계정을 지정할 수 있습니다.
 export USER=<username>
-# USER가 비어 있으면 flake 평가 단계에서 오류가 발생합니다.
+# USER가 없으면 SUDO_USER, LOGNAME, USERNAME 값을 순서대로 찾고, 모두 없으면 오류가 발생합니다.
 ```
 
 ### 3. 환경 적용

--- a/lib/get-user.nix
+++ b/lib/get-user.nix
@@ -1,6 +1,13 @@
-{ envVar ? "USER" }:
+{ envVar ? "USER", altVars ? ["LOGNAME" "USERNAME"] }:
 let
-  envValue = builtins.getEnv envVar; # read from USER environment variable
+  sudoUser = builtins.getEnv "SUDO_USER"; # original user when run via sudo
+  envValue = builtins.getEnv envVar;
+  fallback = builtins.foldl' (acc: var: if acc != "" then acc else builtins.getEnv var) "" altVars;
+  result =
+    if sudoUser != "" then sudoUser
+    else if envValue != "" then envValue
+    else fallback;
 in
-  if envValue != "" then envValue else
+  if result != "" then result else
     builtins.throw "Environment variable ${envVar} must be set"
+


### PR DESCRIPTION
## Summary
- handle SUDO_USER before USER fallback in helper
- error when no user variables are found
- adjust unit test for new sudo logic
- document the new lookup order in README

## Testing
- `pre-commit run --files lib/get-user.nix tests/get-user.nix README.md`
- `nix --extra-experimental-features "nix-command flakes" flake check --impure --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68404a05d464832fbb93c539d33bf051