### PR TITLE
Scope USER default to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ smoke:
 	$(NIX) flake check --impure --all-systems --no-build $(ARGS)
 endif
 
+test: export USER ?= codex
 test:
 	$(NIX) flake check --impure --no-build
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ home-manager switch --flake .#<host>
 2. 아래 명령어로 적용/테스트
    - `make lint`
    - `make smoke`
-   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. 환경변수 `USER`가 없으면 `codex`로 설정합니다.
+  - `make test` - unit 및 e2e(`tests/e2e.nix`) 테스트 실행. `USER`가 없으면 이 타겟을 실행할 때만 `codex`로 설정됩니다.
    - `make build`
    - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`


### PR DESCRIPTION
## Summary
- only set `USER=codex` when running `make test`
- clarify test-only USER behavior in README

## Testing
- `make lint`
- `USER=codex make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6840cf57cf88832f9bc2a0a255ccf48e