### PR TITLE
Fix tests by defaulting USER variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 ARCH := $(shell uname -m)
 OS := $(shell uname -s | tr A-Z a-z)
 NIX := nix --extra-experimental-features 'nix-command flakes'
+TEST_USER ?= codex
 
 help:
 	@echo "Available targets:"
@@ -24,7 +25,7 @@ smoke:
 endif
 
 test:
-	$(NIX) flake check --impure --no-build
+	USER=$(TEST_USER) $(NIX) flake check --impure --no-build
 
 build-linux:
 	$(NIX) build --impure --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ home-manager switch --flake .#<host>
 2. 아래 명령어로 적용/테스트
    - `make lint`
    - `make smoke`
-   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. 환경변수 `USER`가 없으면 `codex`로 설정합니다.
+  - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. `TEST_USER` 변수(기본 `codex`)로 USER를 설정합니다.
    - `make build`
    - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`


### PR DESCRIPTION
## Summary
- set `TEST_USER` default in Makefile and use it when running tests
- document the `TEST_USER` variable in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684124e416e8832facc8fe45fb35f0d5