### PR TITLE
Fix CI by providing USER variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Run smoke test
         run: |
           make smoke SYSTEM=${{ matrix.system }}
+        env:
+          USER: codex
 
   build-test:
     needs: [lint, smoke]
@@ -82,6 +84,10 @@ jobs:
       - name: Build flake outputs
         run: |
           nix build --no-link ".#${{ matrix.build_attr }}"
+        env:
+          USER: codex
       - name: Run Nix flake checks
         run: |
           make smoke SYSTEM=${{ matrix.system }}
+        env:
+          USER: codex

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 ARCH := $(shell uname -m)
 OS := $(shell uname -s | tr A-Z a-z)
 NIX := nix --extra-experimental-features 'nix-command flakes'
+# Use current user when USER not provided
+RUNUSER := $(if $(USER),$(USER),codex)
 
 help:
 	@echo "Available targets:"
@@ -17,22 +19,22 @@ lint:
 
 ifdef SYSTEM
 smoke:
-	$(NIX) flake check --impure --system $(SYSTEM) --no-build $(ARGS)
+	USER=$(RUNUSER) $(NIX) flake check --impure --system $(SYSTEM) --no-build $(ARGS)
 else
 smoke:
-	$(NIX) flake check --impure --all-systems --no-build $(ARGS)
+	USER=$(RUNUSER) $(NIX) flake check --impure --all-systems --no-build $(ARGS)
 endif
 
 test:
-	$(NIX) flake check --impure --no-build
+	USER=$(RUNUSER) $(NIX) flake check --impure --no-build
 
 build-linux:
-	$(NIX) build --impure --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)
-	$(NIX) build --impure --no-link ".#nixosConfigurations.aarch64-linux.config.system.build.toplevel" $(ARGS)
+	USER=$(RUNUSER) $(NIX) build --impure --no-link ".#nixosConfigurations.x86_64-linux.config.system.build.toplevel" $(ARGS)
+	USER=$(RUNUSER) $(NIX) build --impure --no-link ".#nixosConfigurations.aarch64-linux.config.system.build.toplevel" $(ARGS)
 
 build-darwin:
-	$(NIX) build --impure --no-link ".#darwinConfigurations.x86_64-darwin.system" $(ARGS)
-	$(NIX) build --impure --no-link ".#darwinConfigurations.aarch64-darwin.system" $(ARGS)
+	USER=$(RUNUSER) $(NIX) build --impure --no-link ".#darwinConfigurations.x86_64-darwin.system" $(ARGS)
+	USER=$(RUNUSER) $(NIX) build --impure --no-link ".#darwinConfigurations.aarch64-darwin.system" $(ARGS)
 
 build: build-linux build-darwin
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - 주요 개발 도구 및 앱 자동 설치/설정
 - GitHub Actions 기반 CI로 macOS/Linux(x86_64, aarch64) 빌드 및 테스트
 - 멀티플랫폼 matrix smoke 테스트로 기본 빌드 오류 조기 확인
+- CI 환경에서는 `USER` 값이 없을 때 자동으로 `codex` 계정을 사용해 flake 평가가 실패하지 않도록 합니다.
 - 오래된 PR은 자동으로 stale로 표시 후 닫힘
 - Makefile 기반 로컬/CI 명령어 통합
 
@@ -74,7 +75,7 @@ git clone https://github.com/yourname/dotfiles.git
 cd dotfiles
 # 필요 시 USER 환경변수로 대상 계정을 지정할 수 있습니다.
 export USER=<username>
-# USER가 비어 있으면 flake 평가 단계에서 오류가 발생합니다.
+# USER가 비어 있으면 Makefile이 기본 사용자 `codex`를 사용합니다.
 ```
 
 ### 3. 환경 적용
@@ -103,12 +104,12 @@ home-manager switch --flake .#<host>
 2. 아래 명령어로 적용/테스트
    - `make lint`
    - `make smoke`
-   - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. 환경변수 `USER`가 없으면 `codex`로 설정합니다.
+  - `make test` - unit 및 e2e( `tests/e2e.nix` ) 테스트 실행. `USER`가 비어 있으면 기본 사용자 `codex`로 실행합니다.
    - `make build`
    - `make switch HOST=<host>`
    - `home-manager switch --flake .#<host>`
    
-Makefile targets internally run `nix` with `--extra-experimental-features 'nix-command flakes'` and `--impure` so that the `USER` environment variable is respected.
+Makefile targets internally run `nix` with `--extra-experimental-features 'nix-command flakes'` and `--impure` so that the `USER` environment variable is respected. 값이 없을 경우 자동으로 `codex`를 사용합니다.
 Even if these features are not globally enabled, the commands will still work.
 
 ## Contributing & Testing


### PR DESCRIPTION
## Summary
- ensure CI sets USER so flake evaluation succeeds
- document automatic USER fallback in features list

## Testing
- `pre-commit run --files README.md .github/workflows/test.yml`
- `make lint`
- `make smoke`
- `make test`
- `make build` *(failed: interrupted by user)*
- `make smoke`

------
https://chatgpt.com/codex/tasks/task_e_68414f2974a8832f930a1476e610db9d