### PR TITLE
feat: add direnv integration and comprehensive global gitignore

### DIFF
--- a/modules/nixos/packages.nix
+++ b/modules/nixos/packages.nix
@@ -27,7 +27,6 @@ shared-packages ++ [
   pavucontrol # Pulse audio controls
 
   # Testing and development tools
-  direnv
   rofi
   rofi-calc
   postgresql

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -59,12 +59,45 @@ let name = "Jiho Lee";
 
       # Always color ls and group directories
       alias ls='ls --color=auto'
+
+      # Initialize direnv
+      eval "$(direnv hook zsh)"
     '';
   };
 
   git = {
     enable = true;
-    ignores = [ "*.swp" ];
+    ignores = [
+      # Editor files
+      "*.swp"
+      "*.swo"
+      "*~"
+      ".vscode/"
+      ".idea/"
+      
+      # OS files
+      ".DS_Store"
+      "Thumbs.db"
+      "desktop.ini"
+      
+      # Development files
+      ".direnv/"
+      "result"
+      "result-*"
+      "node_modules/"
+      ".env.local"
+      ".env.*.local"
+      
+      # Temporary files
+      "*.tmp"
+      "*.log"
+      ".cache/"
+      
+      # Build artifacts
+      "dist/"
+      "build/"
+      "target/"
+    ];
     userName = name;
     userEmail = email;
     lfs = {
@@ -278,6 +311,12 @@ let name = "Jiho Lee";
         "/Users/${user}/.ssh/config_external"
       )
     ];
+  };
+
+  direnv = {
+    enable = true;
+    enableZshIntegration = true;
+    nix-direnv.enable = true;
   };
 
   tmux = {

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -34,6 +34,9 @@ with pkgs; [
   # Terminal applications
   wezterm
 
+  # Development tools
+  direnv
+
   # Python packages
   python3
   virtualenv


### PR DESCRIPTION
## Summary
• Add cross-platform direnv integration for automatic project environment switching with nix-direnv optimization
• Expand global gitignore patterns to cover editor files, OS artifacts, development tools, and build outputs

## Test plan
- [ ] Verify direnv package is available on all platforms after switch
- [ ] Test .envrc with "use flake" works in development projects  
- [ ] Confirm global gitignore patterns properly exclude development artifacts
- [ ] Validate Home Manager direnv integration functions correctly