### PR TITLE
fix: replace builtins.isDerivation with compatible derivation check

### DIFF
--- a/tests/package-availability.nix
+++ b/tests/package-availability.nix
@@ -7,7 +7,7 @@ let
   
   # Test that packages can be built/accessed
   testPackage = pkg: 
-    if builtins.isDerivation pkg then
+    if builtins.isAttrs pkg && builtins.hasAttr "type" pkg && pkg.type or null == "derivation" then
       builtins.seq pkg.name true
     else if builtins.isString pkg then
       builtins.hasAttr pkg pkgs


### PR DESCRIPTION
## Summary
- Replace `builtins.isDerivation` with manual attribute check for compatibility
- Fixes test failures on older Nix versions that don't have `isDerivation` builtin

## Test plan
- [x] Run `make test` to verify all tests pass
- [x] Run `make smoke` to verify flake check passes on all systems
- [x] Verify CI pipeline will pass with compatible Nix versions

🤖 Generated with [Claude Code](https://claude.ai/code)