### PR TITLE
fix: 테스트 실패 문제 해결 및 사용자 처리 개선

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,12 @@
       devShells = forAllSystems devShell;
       apps = nixpkgs.lib.genAttrs linuxSystems mkLinuxApps // nixpkgs.lib.genAttrs darwinSystems mkDarwinApps;
       checks = forAllSystems (system:
-        import ./tests { pkgs = nixpkgs.legacyPackages.${system}; });
+        import ./tests { 
+          pkgs = import nixpkgs { 
+            inherit system; 
+            config.allowUnfree = true; 
+          }; 
+        });
 
       darwinConfigurations = nixpkgs.lib.genAttrs darwinSystems (system: let
         user = getUser;

--- a/lib/get-user.nix
+++ b/lib/get-user.nix
@@ -1,7 +1,9 @@
 { envVar ? "USER", default ? null }:
 let
   envValue = builtins.getEnv envVar; # read from USER environment variable
+  sudoUser = builtins.getEnv "SUDO_USER"; # get original user when using sudo
 in
-  if envValue != "" then envValue
+  if sudoUser != "" then sudoUser
+  else if envValue != "" then envValue
   else if default != null then default
   else builtins.throw "Environment variable ${envVar} must be set"


### PR DESCRIPTION
## Summary
- 테스트에서 unfree 패키지(1password-cli) 허용하도록 flake 구성 수정
- sudo 사용 시 SUDO_USER 환경변수를 통해 원래 사용자 자동 감지하도록 get-user.nix 개선

## Test plan
- [x] make test 통과 확인
- [x] make smoke 통과 확인  
- [x] 모든 플랫폼에서 테스트 성공 검증