### PR TITLE
feat: DeterminateSystems magic-nix-cache로 CI 빌드 성능 개선

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Cache Nix store  
-        uses: actions/cache@v4
-        with:
-          path: /nix/store
-          key: ${{ runner.os }}-nix-${{ hashFiles('flake.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-nix-
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Run smoke test
         run: |
           make smoke SYSTEM=${{ matrix.system }}
@@ -61,17 +53,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v25
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-
-      - name: Cache Nix store  
-        uses: actions/cache@v4
-        with:
-          path: /nix/store
-          key: ${{ runner.os }}-nix-${{ hashFiles('flake.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-nix-
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Build flake outputs
         run: |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - 주요 개발 도구 및 앱 자동 설치/설정
 - GitHub Actions 기반 CI로 macOS/Linux(x86_64, aarch64) 빌드 및 테스트
 - 멀티플랫폼 matrix smoke 테스트로 기본 빌드 오류 조기 확인
+- FlakeHub를 활용한 Nix cache로 CI 빌드 시간 단축
 - 오래된 PR은 자동으로 stale로 표시 후 닫힘
 - Makefile 기반 로컬/CI 명령어 통합
 


### PR DESCRIPTION
## Summary
- GitHub Actions의 기본 cache를 DeterminateSystems/magic-nix-cache-action으로 교체하여 Nix 빌드 성능 최적화
- cachix/install-nix-action을 nix-installer-action으로 변경하여 더 나은 Nix 설치 환경 제공

## Test plan
- [ ] CI smoke 테스트 통과 확인
- [ ] CI build-test 통과 확인  
- [ ] 빌드 시간 개선 효과 측정