### PR TITLE
fix: GitHub Actions에서 누락된 'automated' 라벨 참조 제거

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -158,7 +158,7 @@ jobs:
             --body-file pr_body.md \
             --base main \
             --head "${{ steps.create-branch.outputs.branch-name }}" \
-            --label "dependencies,automated")
+            --label "dependencies")
           
           PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]\+$')
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
• GitHub Actions 자동 업데이트 워크플로우에서 존재하지 않는 'automated' 라벨 참조 제거
• dependencies 라벨만 사용하도록 수정하여 워크플로우 실패 방지

## Test plan
- [x] 워크플로우 파일 문법 검증
- [ ] 자동 업데이트 워크플로우 정상 실행 확인
- [ ] PR 생성 시 라벨 오류 발생하지 않음 확인

🤖 Generated with [Claude Code](https://claude.ai/code)