### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1749526396,
-        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
+        "lastModified": 1749657191,
+        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
+        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1749597345,
-        "narHash": "sha256-Yt+f+ANQU5WvT78+h0cOIRkTTvzuvAmveXjGfMZF88Y=",
+        "lastModified": 1749690858,
+        "narHash": "sha256-QyoGhkzfGvktT0SJY4LnP0Z5qOXkfbVAp350wPqbEcc=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "4405854775af4d8e3828bacd3fc9ac0716450533",
+        "rev": "2a83947035e7df3af5ce0ae944abd21ec9dfc7b4",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1749600292,
-        "narHash": "sha256-kPuJEGV8DzSDRpLlrYAoemks5NoBUnUnP3Giq5MLDiw=",
+        "lastModified": 1749688817,
+        "narHash": "sha256-CUwuYJGGQg4TnouSE9b+p/+Vpy0SRLqjD9b+wYtVnAQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "57bac8e9e0ce800add13e23ce768c3d4c1ce18cf",
+        "rev": "cae42a13d4a2e2eae9f7da7cfade1e71c61604a5",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit d3326ec76b0a3f0a1cce9280ab782d168a855141
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Thu Jun 12 01:24:51 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'home-manager':
        'github:nix-community/home-manager/427c96044f11a5da50faf6adaf38c9fa47e6d044' (2025-06-10)
      → 'github:nix-community/home-manager/faeab32528a9360e9577ff4082de2d35c6bbe1ce' (2025-06-11)
    • Updated input 'home-manager/nixpkgs':
        'github:NixOS/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d' (2025-06-05)
      → 'github:NixOS/nixpkgs/3e3afe5174c561dee0df6f2c2b2236990146329f' (2025-06-07)
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/4405854775af4d8e3828bacd3fc9ac0716450533' (2025-06-10)
      → 'github:homebrew/homebrew-cask/2a83947035e7df3af5ce0ae944abd21ec9dfc7b4' (2025-06-12)
    • Updated input 'homebrew-core':
        'github:homebrew/homebrew-core/57bac8e9e0ce800add13e23ce768c3d4c1ce18cf' (2025-06-11)
      → 'github:homebrew/homebrew-core/cae42a13d4a2e2eae9f7da7cfade1e71c61604a5' (2025-06-12)

 flake.lock | 24 ++++++++++++------------
 1 file changed, 12 insertions(+), 12 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
