### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1749690858,
-        "narHash": "sha256-QyoGhkzfGvktT0SJY4LnP0Z5qOXkfbVAp350wPqbEcc=",
+        "lastModified": 1749691635,
+        "narHash": "sha256-13otCd92XAIU6zfJeYpmzu0l2PyKCD8h4yn33IR1O8c=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "2a83947035e7df3af5ce0ae944abd21ec9dfc7b4",
+        "rev": "3ec2207c817c40970722872ad0effc4f015fa7db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit ea0a034cdd1a666b1a7cccdfcd29b7ee1965ab2c
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Thu Jun 12 02:09:37 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/2a83947035e7df3af5ce0ae944abd21ec9dfc7b4' (2025-06-12)
      → 'github:homebrew/homebrew-cask/3ec2207c817c40970722872ad0effc4f015fa7db' (2025-06-12)

 flake.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
