### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194393,
-        "narHash": "sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo=",
+        "lastModified": 1749739639,
+        "narHash": "sha256-oubMGIrW/vBdX+xw47LEcxrqYqZUdLYPE8xrLDKoBE8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "19346808c445f23b08652971be198b9df6c33edc",
+        "rev": "72c88d5928196159e3a0d03e67b25d8044546ca6",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1749657191,
-        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
+        "lastModified": 1749821119,
+        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
+        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1749690858,
-        "narHash": "sha256-QyoGhkzfGvktT0SJY4LnP0Z5qOXkfbVAp350wPqbEcc=",
+        "lastModified": 1749852985,
+        "narHash": "sha256-eHWg1RXidShnNdorI+EilZl24kP5MOper0KXLIKdUwY=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "2a83947035e7df3af5ce0ae944abd21ec9dfc7b4",
+        "rev": "ff846dba6a20569d83ddb7142538f77edba1fabd",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1749688817,
-        "narHash": "sha256-CUwuYJGGQg4TnouSE9b+p/+Vpy0SRLqjD9b+wYtVnAQ=",
+        "lastModified": 1749859429,
+        "narHash": "sha256-SsOYriUG+GGWusRlyypmx4wX8YaIwc2/3VRN99CZeaM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "cae42a13d4a2e2eae9f7da7cfade1e71c61604a5",
+        "rev": "8270714d1f2f48517a2977367ee9646dcc67afac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit 99cafa1424aeb506a3f0b147bf639adbf253e7fe
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Sat Jun 14 00:12:21 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'darwin':
        'github:LnL7/nix-darwin/19346808c445f23b08652971be198b9df6c33edc' (2025-06-06)
      → 'github:LnL7/nix-darwin/72c88d5928196159e3a0d03e67b25d8044546ca6' (2025-06-12)
    • Updated input 'home-manager':
        'github:nix-community/home-manager/faeab32528a9360e9577ff4082de2d35c6bbe1ce' (2025-06-11)
      → 'github:nix-community/home-manager/79dfd9aa295e53773aad45480b44c131da29f35b' (2025-06-13)
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/2a83947035e7df3af5ce0ae944abd21ec9dfc7b4' (2025-06-12)
      → 'github:homebrew/homebrew-cask/ff846dba6a20569d83ddb7142538f77edba1fabd' (2025-06-13)
    • Updated input 'homebrew-core':
        'github:homebrew/homebrew-core/cae42a13d4a2e2eae9f7da7cfade1e71c61604a5' (2025-06-12)
      → 'github:homebrew/homebrew-core/8270714d1f2f48517a2977367ee9646dcc67afac' (2025-06-14)

 flake.lock | 24 ++++++++++++------------
 1 file changed, 12 insertions(+), 12 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
