### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1749821119,
-        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
+        "lastModified": 1749944797,
+        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
+        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1749899595,
-        "narHash": "sha256-WnnHDDYmJPpQ0Cc+6l7o5P/FavnKMkfNBWaxZyvDbbg=",
+        "lastModified": 1749938846,
+        "narHash": "sha256-wuv3+rNWoc0WQpWnNsUQ3oyGLGd480yYBFYR8LQuPGE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "c0214dde5a49e8ceaf0a3ee95b7d53545b1cf576",
+        "rev": "f935c548c1341d79d8ffa9eecbb2eda17d9b776b",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1749901897,
-        "narHash": "sha256-V16LEbkKKZGopg7nJYSLWU4HOm6zTycmATPI9xUp5XM=",
+        "lastModified": 1749944660,
+        "narHash": "sha256-Oxy1ESXdwgoVsvfuuxmtqzXGA5SWHCI22RwfEZ10l2w=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "9eb6fbee0812060214bfbc83939f6d74926a4f42",
+        "rev": "0f730e6ce031653b3c3c3255ed6a7ce64929df00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit 115a5b6a989f6b1f8ae5cb2d7d8925c9527ccd12
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Sun Jun 15 00:14:25 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'home-manager':
        'github:nix-community/home-manager/79dfd9aa295e53773aad45480b44c131da29f35b' (2025-06-13)
      → 'github:nix-community/home-manager/c5f345153397f62170c18ded1ae1f0875201d49a' (2025-06-14)
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/c0214dde5a49e8ceaf0a3ee95b7d53545b1cf576' (2025-06-14)
      → 'github:homebrew/homebrew-cask/f935c548c1341d79d8ffa9eecbb2eda17d9b776b' (2025-06-14)
    • Updated input 'homebrew-core':
        'github:homebrew/homebrew-core/9eb6fbee0812060214bfbc83939f6d74926a4f42' (2025-06-14)
      → 'github:homebrew/homebrew-core/0f730e6ce031653b3c3c3255ed6a7ce64929df00' (2025-06-14)

 flake.lock | 18 +++++++++---------
 1 file changed, 9 insertions(+), 9 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
