### PR TITLE
feat: Python 개발 도구 및 claude-monitor 자동 설치 기능 추가

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -89,6 +89,14 @@ in
       if [[ -x "$HOME/dotfiles/scripts/auto-update-dotfiles" ]]; then
         (nohup "$HOME/dotfiles/scripts/auto-update-dotfiles" --silent &>/dev/null &)
       fi
+
+      # Auto-install claude-monitor via uv if not already installed
+      if command -v uv >/dev/null 2>&1; then
+        if ! uv tool list | grep -q "claude-monitor"; then
+          echo "Installing claude-monitor via uv..."
+          uv tool install claude-monitor
+        fi
+      fi
     '';
   };
 

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -48,5 +48,7 @@ with pkgs; [
 
   # Python packages
   python3
+  python3Packages.pipx
   virtualenv
+  uv
 ]


### PR DESCRIPTION
## 요약
Python 개발 환경을 개선하고 claude-monitor를 자동으로 설치하는 기능을 추가했습니다.

## 변경사항
- **pipx**: Python 패키지를 격리된 환경에서 설치할 수 있는 도구 추가
- **uv**: 빠른 Python 패키지 관리 도구 추가  
- **claude-monitor 자동 설치**: uv가 사용 가능할 때 claude-monitor를 자동으로 설치하는 스크립트 추가

## 기술적 세부사항

### 패키지 추가 (modules/shared/packages.nix)
```nix
# Python packages
python3
python3Packages.pipx  # 새로 추가
virtualenv
uv                    # 새로 추가
```

### 자동 설치 스크립트 (modules/shared/home-manager.nix)
```bash
# Auto-install claude-monitor via uv if not already installed
if command -v uv >/dev/null 2>&1; then
  if \! uv tool list | grep -q "claude-monitor"; then
    echo "Installing claude-monitor via uv..."
    uv tool install claude-monitor
  fi
fi
```

## 혜택
- **향상된 Python 개발 환경**: pipx와 uv를 통해 더 나은 패키지 관리
- **자동화된 도구 설치**: claude-monitor가 자동으로 설치되어 개발 경험 개선
- **성능 향상**: uv는 pip보다 훨씬 빠른 패키지 설치 속도 제공

## 테스트 완료
- ✅ 린트 검사 통과
- ✅ 스모크 테스트 통과
- ✅ 빌드 검사 완료