### PR TITLE
fix: Auto Branch Update 워크플로우 인증 문제 해결

### DIFF
--- a/.github/workflows/auto-branch-update.yml
+++ b/.github/workflows/auto-branch-update.yml
@@ -7,15 +7,18 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Update PR branches
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr list --state open --json number,headRefName | jq -r '.[] | "\(.number):\(.headRefName)"' | while IFS=':' read pr branch; do
             if [ "$(git rev-list --count "origin/$branch..main")" -gt 0 ]; then


### PR DESCRIPTION
## 문제
Auto Branch Update 워크플로우에서 PAT_TOKEN 인증 문제로 인해 다음 에러가 발생:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## 해결방법  
- PAT_TOKEN을 더 안정적인 GITHUB_TOKEN으로 변경
- 필요한 권한(contents: write, pull-requests: write) 명시적 추가

## 테스트
- [x] make lint 통과
- [x] 워크플로우 구문 검증 완료