### PR TITLE
fix: use REPO_PAT instead of GITHUB_TOKEN in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-flake.yml
+++ b/.github/workflows/auto-update-flake.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0
 
       - name: Install Nix
@@ -155,7 +155,7 @@ jobs:
         if: steps.check-changes.outputs.has-changes == 'true'
         id: create-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           echo "::group::Creating Pull Request"
 
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: Wait for CI checks to be created
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           echo "::group::Waiting for CI checks to be created"
 
@@ -214,7 +214,7 @@ jobs:
 
       - name: Enable auto-merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           echo "::group::Enabling auto-merge"
 


### PR DESCRIPTION
## Summary
Resolves the issue where auto-generated dependency update PRs don't trigger CI workflows due to GitHub's security restrictions. By switching from GITHUB_TOKEN to a Personal Access Token (REPO_PAT), the auto-update workflow will now properly trigger CI pipelines and enable seamless auto-merge functionality.

## Changes
- Updated `.github/workflows/auto-update-flake.yml` to use `REPO_PAT` instead of `GITHUB_TOKEN`
- Applied changes to all GitHub API interactions in the workflow:
  - Repository checkout
  - Pull request creation  
  - CI checks monitoring
  - Auto-merge enablement

## Problem Solved
- **Before**: Auto-update PRs were created but CI never triggered (GitHub security policy)
- **After**: Auto-update PRs will automatically trigger CI and merge when tests pass

## Test Plan
- [x] REPO_PAT secret registered in repository
- [x] Workflow file updated with new token reference
- [x] Local testing and validation completed
- [ ] CI pipeline verification on this PR
- [ ] Next auto-update PR should trigger CI automatically

## Benefits
✅ Fully automated dependency updates  
✅ No manual intervention required  
✅ Complete CI validation before merge  
✅ Faster security updates and bug fixes  

🤖 Generated with [Claude Code](https://claude.ai/code)