### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750572051,
-        "narHash": "sha256-01NcVvfAco+eiIbOHZFrtMEoCTEDMqNoN4YZyvRWQn4=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "04a34128012730be97af192f6e112d25204c97e9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750040002,
-        "narHash": "sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84=",
+        "lastModified": 1750680230,
+        "narHash": "sha256-kD88T/NqmcgfOBFAwphN30ccaUdj6K6+LG0XdM2w2LA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "7f1857b31522062a6a00f88cbccf86b43acceed1",
+        "rev": "8fd2d6c75009ac75f9a6fb18c33a239806778d01",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750304462,
-        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
+        "lastModified": 1750798083,
+        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
+        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1750598803,
-        "narHash": "sha256-uh18Aat3M8jNgK0vtX2U9q7YKKEgLDqusqix1/qPdqY=",
+        "lastModified": 1750850152,
+        "narHash": "sha256-LOAlcw52qYu3cd7L8FUAymcaXycbUpEk6We+PWYAbjQ=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "668781a085a7c2cc1165c18bf1aefbf478a7fdae",
+        "rev": "17a5f796835fb706458bc29a504b17847f4b33d7",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1750602765,
-        "narHash": "sha256-cVwVbcLO0lZheYAZ6CTSrHvOXxsVjo7Og3/5ZhizqSg=",
+        "lastModified": 1750851611,
+        "narHash": "sha256-8M3Vf5jpBI8vxfLltPzfI69/11ntAjS8CWHiWE502mY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "4eb72c4110446a9bd150b8b44ce261593a63db70",
+        "rev": "ce0421ebe092d6082585ad7a88fe2f4dc21101ca",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1750365781,
+        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1750365781,
-        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
+        "lastModified": 1750741721,
+        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
+        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit 4582b01926503b475fb59ae33b60bd9d2b171957
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Wed Jun 25 11:55:42 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'darwin':
        'github:LnL7/nix-darwin/04a34128012730be97af192f6e112d25204c97e9' (2025-06-22)
      → 'github:LnL7/nix-darwin/1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5' (2025-06-22)
    • Updated input 'disko':
        'github:nix-community/disko/7f1857b31522062a6a00f88cbccf86b43acceed1' (2025-06-16)
      → 'github:nix-community/disko/8fd2d6c75009ac75f9a6fb18c33a239806778d01' (2025-06-23)
    • Updated input 'home-manager':
        'github:nix-community/home-manager/863842639722dd12ae9e37ca83bcb61a63b36f6c' (2025-06-19)
      → 'github:nix-community/home-manager/ff31a4677c1a8ae506aa7e003a3dba08cb203f82' (2025-06-24)
    • Updated input 'home-manager/nixpkgs':
        'github:NixOS/nixpkgs/9e83b64f727c88a7711a2c463a7b16eedb69a84c' (2025-06-17)
      → 'github:NixOS/nixpkgs/08f22084e6085d19bcfb4be30d1ca76ecb96fe54' (2025-06-19)
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/668781a085a7c2cc1165c18bf1aefbf478a7fdae' (2025-06-22)
      → 'github:homebrew/homebrew-cask/17a5f796835fb706458bc29a504b17847f4b33d7' (2025-06-25)
    • Updated input 'homebrew-core':
        'github:homebrew/homebrew-core/4eb72c4110446a9bd150b8b44ce261593a63db70' (2025-06-22)
      → 'github:homebrew/homebrew-core/ce0421ebe092d6082585ad7a88fe2f4dc21101ca' (2025-06-25)
    • Updated input 'nixpkgs':
        'github:nixos/nixpkgs/08f22084e6085d19bcfb4be30d1ca76ecb96fe54' (2025-06-19)
      → 'github:nixos/nixpkgs/4b1164c3215f018c4442463a27689d973cffd750' (2025-06-24)

 flake.lock | 42 +++++++++++++++++++++---------------------
 1 file changed, 21 insertions(+), 21 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
