### PR TITLE
feat: brainstorm 명령어에 자율 리서치 기능 추가

### DIFF
--- a/modules/shared/config/claude/commands/brainstorm.md
+++ b/modules/shared/config/claude/commands/brainstorm.md
@@ -16,7 +16,24 @@ Uncover all requirements, constraints, and success criteria through iterative di
 - Number each question for tracking
 - Probe deeper when answers are vague
 - Challenge assumptions respectfully
+- After each answer, autonomously research unclear concepts
+- Use web search or documentation to fill knowledge gaps
+- Think deeply about implications before next question
 </discovery_method>
+
+<self_exploration>
+When user provides answers containing:
+- Technical terms you don't fully understand
+- References to specific tools or frameworks
+- Domain-specific concepts
+- Ambiguous requirements
+
+IMMEDIATELY:
+1. Use WebSearch to understand the concept
+2. Read relevant documentation if available
+3. Consider multiple interpretations
+4. Formulate more informed follow-up questions
+</self_exploration>
 
 <question_categories>
 1. **Problem Definition**: What pain points are we solving?
@@ -77,13 +94,33 @@ Good questions are:
 ✓ Built on previous answers
 ✓ Designed to uncover hidden assumptions
 ✓ Aimed at reducing ambiguity
+✓ Informed by research when needed
+✓ Demonstrate understanding of context
 
 Avoid:
 ❌ Multiple questions at once
 ❌ Yes/no questions without follow-up
 ❌ Assumptions about user intentions
 ❌ Technical jargon without explanation
+❌ Asking without understanding context
+❌ Superficial questions when depth is needed
 </question_quality>
+
+<autonomous_research>
+**Think Hard Protocol**:
+1. Parse user's answer for unfamiliar concepts
+2. Identify knowledge gaps that could lead to poor questions
+3. Research using available tools (WebSearch, docs)
+4. Synthesize findings into deeper understanding
+5. Formulate next question based on enhanced knowledge
+
+Example flow:
+User: "We need a GraphQL API with subscription support"
+→ Research: What are GraphQL subscriptions?
+→ Research: Common implementation patterns
+→ Research: Performance considerations
+→ Next question: "What real-time events will clients subscribe to, and what's the expected frequency of updates?"
+</autonomous_research>
 
 <completion_workflow>
 After specification is complete:
@@ -98,10 +135,19 @@ After specification is complete:
 - ONE question at a time, always
 - Number each question for tracking
 - Build on previous answers
+- THINK HARD: Research unfamiliar concepts before asking
 - Dig deeper when answers are vague
+- Self-explore technical terms and frameworks
 - Save complete spec as spec.md when done
 
-🛑 **STOP**: After each answer, pause to ask the next logical question.
+🧠 **THINK HARD PROTOCOL**:
+After each user answer:
+1. Identify concepts needing research
+2. Use WebSearch/docs to understand deeply
+3. Synthesize knowledge before next question
+4. Show you understand their context
+
+🛑 **STOP**: After each answer, research → think → then ask the next logical question.
 </critical_reminders>
 
 Here's the idea:


### PR DESCRIPTION
## 개요
brainstorm 명령어에 독립적인 리서치 기능을 추가하여, 모르는 개념에 대해 사용자에게 묻기 전에 먼저 탐색하도록 개선했습니다.

## 변경사항
- **Think Hard 프로토콜 구현**: 익숙하지 않은 개념을 만났을 때 자율적으로 리서치 수행
- **독립적 정보 수집**: WebSearch와 WebFetch 도구를 활용한 맥락 구축
- **개선된 질문 생성**: 수집한 정보를 바탕으로 더 구체적이고 유익한 질문 생성
- **사용자 경험 향상**: 불필요한 기본 질문을 줄이고 더 깊이 있는 대화 가능

## 테스트 계획
- [ ] 새로운 기술 스택에 대한 brainstorm 테스트
- [ ] 리서치 기능이 올바르게 작동하는지 확인
- [ ] 질문의 품질이 향상되었는지 검증