### PR TITLE
docs: deadcode 금지 규칙 추가

### DIFF
--- a/modules/shared/config/claude/CLAUDE.md
+++ b/modules/shared/config/claude/CLAUDE.md
@@ -37,6 +37,14 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 - YOU MUST NEVER remove code comments unless you can PROVE they are actively false. Comments are important documentation and must be preserved.
 - YOU MUST NEVER refer to temporal context in comments (like "recently refactored" "moved") or code. Comments should be evergreen and describe the code as it is. If you name something "new" or "enhanced" or "improved", you've probably made a mistake and MUST STOP and ask me what to do.
 - YOU MUST NOT change whitespace that does not affect execution or output. Otherwise, use a formatting tool.
+- **DEADCODE PROHIBITION**: YOU MUST NEVER leave behind any deadcode, including but not limited to:
+  - Commented-out code blocks (except for essential documentation purposes)
+  - Backup files (`.bak`, `.old`, `.backup`, etc.)
+  - Test dummy files or temporary test data
+  - Unused functions, classes, or variables
+  - Experimental code branches that didn't make it to production
+  - YOU MUST actively search for and remove such deadcode during development
+  - YOU MUST verify no deadcode remains before committing changes
 
 
 ## Version Control


### PR DESCRIPTION
## Summary
CLAUDE.md에 deadcode 금지 규칙을 추가하여 코드 품질 관리를 강화합니다.

## Changes
- **DEADCODE PROHIBITION** 섹션 추가
- 금지되는 deadcode 유형들 명시:
  - 주석 처리된 코드 블록 (문서화 목적 제외)
  - 백업 파일 (.bak, .old, .backup 등)
  - 테스트 더미 파일이나 임시 테스트 데이터
  - 사용하지 않는 함수, 클래스, 변수
  - 프로덕션에 사용되지 않은 실험적인 코드 브랜치
- 개발 중 적극적인 deadcode 검색 및 제거 의무화
- 커밋 전 deadcode 제거 검증 의무화

## Test Plan
- [x] Lint 체크 통과
- [x] 문서 형식 검증 완료

## Checklist
- [x] 코드 스타일 가이드라인 준수
- [x] 셀프 리뷰 완료
- [x] 문서 업데이트 완료

🤖 Claude Code로 생성됨