### PR TITLE
fix: auto-branch-update가 REPO_PAT 토큰을 사용하도록 수정

### DIFF
--- a/.github/workflows/auto-branch-update.yml
+++ b/.github/workflows/auto-branch-update.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Git
         run: |
@@ -24,7 +24,7 @@ jobs:
 
       - name: Update PR branches
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
         run: |
           # Get all open PRs
           gh pr list --state open --json number,headRefName --jq '.[] | "\(.number):\(.headRefName)"' | while IFS=':' read pr branch; do


### PR DESCRIPTION
## Summary
auto-branch-update 워크플로우가 REPO_PAT을 사용하도록 수정하여 CI 실패 문제를 해결합니다.

## Changes
- GITHUB_TOKEN 대신 REPO_PAT 사용으로 브랜치 push 권한 문제 해결
- protected branch 업데이트 권한 강화  
- 자동 브랜치 업데이트 시스템 정상화

## Test Plan
- [x] smoke test 통과
- [x] 로컬 검증 완료
- [ ] CI 검사 통과 대기

## 관련 이슈
- PR #185 CI 실패 문제 해결
- auto-branch-update 시스템 권한 부족 문제 해결

🤖 Generated with Claude Code