### PR TITLE
feat: migrate 1password from Nix packages to Homebrew casks

### DIFF
--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -24,6 +24,10 @@ _:
   # Productivity Tools
   "raycast"
 
+  # Password Management
+  "1password"
+  "1password-cli"
+
   # Browsers
   "google-chrome"
   "brave-browser"

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -18,8 +18,6 @@ with pkgs; [
   terragrunt         # Terraform wrapper for DRY configurations
   tflint             # Terraform linter
 
-  # Password management
-  _1password-cli
 
   # Media-related packages
   ffmpeg


### PR DESCRIPTION
## Summary
- 1Password CLI와 GUI를 Nix 패키지에서 Homebrew casks로 마이그레이션
- macOS에서 더 나은 통합성과 일관된 패키지 관리 제공

## Changes
- `modules/shared/packages.nix`에서 `_1password-cli` 제거
- `modules/darwin/casks.nix`에 `1password-cli`와 `1password` GUI 추가

## Test Results
- [x] `make lint` 통과
- [x] `make build` (Darwin) 통과  
- [x] `make smoke` 통과

## Related Issue
Closes #190

🤖 Generated with [Claude Code](https://claude.ai/code)