### PR TITLE
fix: remove passwordless sudo for reboot command

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -270,19 +270,6 @@ in
     };
   };
 
-  # Don't require password for users in `wheel` group for these commands
-  security.sudo = {
-    enable = true;
-    extraRules = [{
-      commands = [
-        {
-          command = "${pkgs.systemd}/bin/reboot";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-      groups = [ "wheel" ];
-    }];
-  };
 
   fonts.packages = with pkgs; [
     dejavu_fonts


### PR DESCRIPTION
## Summary
- Removes passwordless sudo configuration for reboot command from NixOS hosts
- Improves security by requiring password authentication for all sudo operations
- Addresses security vulnerability identified in issue #218

## Test plan
- [x] Lint checks pass (`make lint`)
- [x] Flake validation succeeds (`make smoke`)
- [ ] NixOS systems will require password for reboot after applying this change

🤖 Generated with [Claude Code](https://claude.ai/code)