### PR TITLE
chore: 자동 flake 의존성 업데이트 2025-06-29

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750973805,
-        "narHash": "sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS+Y=",
+        "lastModified": 1751146119,
+        "narHash": "sha256-gvjG95TCnUVJkvQvLMlnC4NqiqFyBdJk3o8/RwuHeaU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "080e8b48b0318b38143d5865de9334f46d51fce3",
+        "rev": "76d0c31fce2aa0c71409de953e2f9113acd5b656",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1751033907,
-        "narHash": "sha256-SmjRYJBTEmSu1GSmlzpxFlWV7BXioVM4TtTv43n20QM=",
+        "lastModified": 1751162481,
+        "narHash": "sha256-NVcugMtm/Zjg0ibL2iC61eXFYIu0G3ZE1iiYNGsAYRY=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "b8f633bfcd7b45e620845d078c9c889d3707896e",
+        "rev": "f95e8d89e115a362116945126d03cbe7d1d3aab2",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1751035498,
-        "narHash": "sha256-9JvYoL0X7t2LM/maBS0vCqjEjQITF2CblGitmY8gEJo=",
+        "lastModified": 1751165819,
+        "narHash": "sha256-HPKfjxDxQX+52N+Qf8np3jJ4/u3r8OkWURrhu4tDq9w=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "d73b10d638ae00598edb31f24c62554d999a4959",
+        "rev": "4dc6ffc7f13b226ad281cd6dabfeaae993496676",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 의존성 업데이트 요약

다음 의존성들이 업데이트되었습니다:

- `flake.lock`

## 상세 변경사항

```
commit 4fab61edb2af613afaa2f26c14c4103eb5c95cf1
Author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Date:   Sun Jun 29 03:42:30 2025 +0000

    flake.lock: Update
    
    Flake lock file updates:
    
    • Updated input 'home-manager':
        'github:nix-community/home-manager/080e8b48b0318b38143d5865de9334f46d51fce3' (2025-06-26)
      → 'github:nix-community/home-manager/76d0c31fce2aa0c71409de953e2f9113acd5b656' (2025-06-28)
    • Updated input 'homebrew-cask':
        'github:homebrew/homebrew-cask/b8f633bfcd7b45e620845d078c9c889d3707896e' (2025-06-27)
      → 'github:homebrew/homebrew-cask/f95e8d89e115a362116945126d03cbe7d1d3aab2' (2025-06-29)
    • Updated input 'homebrew-core':
        'github:homebrew/homebrew-core/d73b10d638ae00598edb31f24c62554d999a4959' (2025-06-27)
      → 'github:homebrew/homebrew-core/4dc6ffc7f13b226ad281cd6dabfeaae993496676' (2025-06-29)
    • Updated input 'nixpkgs':
        'github:nixos/nixpkgs/30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf' (2025-06-24)
      → 'github:nixos/nixpkgs/30e2e2857ba47844aa71991daa6ed1fc678bcbb7' (2025-06-27)

 flake.lock | 24 ++++++++++++------------
 1 file changed, 12 insertions(+), 12 deletions(-)
```

## 테스트 계획
- [ ] 모든 플랫폼에서 빌드 성공
- [ ] CI 파이프라인 통과
- [ ] 스모크 테스트 통과

🤖 자동으로 생성된 PR입니다. CI 테스트가 통과하면 자동으로 머지됩니다.
