### PR TITLE
feat: Add iTerm2 to Darwin casks configuration

### DIFF
--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -4,6 +4,7 @@ _:
   # Development Tools
   "homebrew/cask/docker"
   "intellij-idea"
+  "iterm2"  # Terminal emulator for macOS
 
   # Communication Tools
   "discord"


### PR DESCRIPTION
## Summary
Add iTerm2 to the Darwin-specific Homebrew casks configuration as part of migrating from WezTerm to iTerm2.

## Changes
- Added `iterm2` to the Development Tools section in `modules/darwin/casks.nix`

## Testing
- [x] `make lint` passes
- [x] Nix configuration validates with dry-run build
- [ ] iTerm2 installs correctly via `make switch` (to be tested after merge)

## Related Issues
- Resolves #257
- Part of #258 (WezTerm to iTerm2 migration)

## Notes
iTerm2 will be installed via Homebrew cask, which is the standard approach for macOS GUI applications in this dotfiles setup.