### PR TITLE
docs: create-worktree 명령어에 cd 단계 필수 알림 추가

### DIFF
--- a/modules/shared/config/claude/commands/create-worktree.md
+++ b/modules/shared/config/claude/commands/create-worktree.md
@@ -46,6 +46,7 @@
     - **Verify State**: Confirm the worktree is clean (`git status --porcelain` should be empty).
       - **IF NOT CLEAN**: Report "New worktree is not clean. Investigate further." and **STOP**.
     - **Report Success**: Inform the user that the worktree is ready for development at the specified path.
+    - **⚠️ CRITICAL**: **ALWAYS** remind the user to run `cd <worktree-path>` to enter the new worktree directory before starting work.
   </step>
 
 </workflow>
@@ -55,6 +56,7 @@
   - All worktrees **must** be created under the `./.local/` directory.
   - **Always** prioritize discovered repository conventions over default patterns.
   - If no clear convention exists, **ask the user** for their preferred naming format.
+  - **CRITICAL**: **Always** remind the user to `cd` into the new worktree directory after creation.
 </constraints>
 
 <validation>


### PR DESCRIPTION
## 요약

create-worktree 명령어 문서에 worktree 생성 후 `cd` 단계를 필수로 수행하도록 강화했습니다.

## 변경 사항

- **5단계 "Verify and Report"에 cd 필수 알림 추가**: `⚠️ CRITICAL` 표시와 함께 사용자에게 새 worktree 디렉토리로 이동하라는 명확한 지시사항 추가
- **constraints 섹션에 critical 요구사항 추가**: `cd` 실행을 항상 상기시키도록 제약 조건에 명시

## 개선 효과

- ✅ **실수 방지**: worktree 생성 후 cd를 잊어버리는 일반적인 실수 방지
- ✅ **명확한 지시**: 사용자가 다음에 해야 할 단계를 명확하게 안내
- ✅ **일관된 워크플로**: worktree 생성과 이동을 하나의 완전한 프로세스로 정립

## 테스트

- [x] `make lint` 통과
- [x] `make smoke` 통과  
- [x] 문서 내용 및 형식 검증 완료
- [x] 기존 워크플로에 미치는 영향 없음 확인