### PR TITLE
fix: standardize environment variable handling across CI and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Validate flake
         run: |
-          export USER=ci
+          export USER=${USER:-ci}
           nix flake check --impure --no-build --all-systems
 
   # Core build stage (2-4 minutes) - Only essential platforms
@@ -106,7 +106,7 @@ jobs:
       - name: Build configuration
         timeout-minutes: 30
         run: |
-          export USER=ci
+          export USER=${USER:-ci}
           echo "🏗️ Building ${{ matrix.name }} (${{ matrix.system }}) - Type: ${{ matrix.build_type }}"
 
           case "${{ matrix.system }}" in
@@ -157,7 +157,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 15
         run: |
-          export USER=ci
+          export USER=${USER:-ci}
           echo "🧪 Running ${{ matrix.category }} tests"
           nix run --impure .#test-${{ matrix.category }}
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Quick smoke test
         run: |
-          export USER=ci
+          export USER=${USER:-ci}
           nix flake check --impure --no-build --all-systems
           echo "✅ Smoke test passed - Draft PR validation complete"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       # Comprehensive flake validation (skip if nix not available)
       - id: nix-flake-check
         name: Nix Flake Check
-        entry: bash -c 'if command -v nix >/dev/null 2>&1; then USER=$(whoami) nix flake check --impure --all-systems --no-build; else echo "Nix not available, skipping flake check"; fi'
+        entry: bash -c 'if command -v nix >/dev/null 2>&1; then export USER=${USER:-$(whoami)} && nix flake check --impure --all-systems --no-build; else echo "Nix not available, skipping flake check"; fi'
         language: system
         files: \\.nix$
         pass_filenames: false
@@ -70,7 +70,7 @@ repos:
       # Run quick tests when .nix files change
       - id: test-quick
         name: Quick Test Suite
-        entry: bash -c 'USER=$(whoami) nix run --impure .#test-smoke'
+        entry: bash -c 'export USER=${USER:-$(whoami)} && nix run --impure .#test-smoke'
         language: system
         files: '\.nix$'
         pass_filenames: false


### PR DESCRIPTION
## Summary
Resolves inconsistent environment variable handling between CI and pre-commit hooks by standardizing the USER variable resolution pattern.

## Changes
- **CI workflow**: Changed from hardcoded `USER=ci` to dynamic `USER=${USER:-ci}`
- **Pre-commit hooks**: Standardized to use consistent `export USER=${USER:-$(whoami)}` pattern
- Both environments now use the same fallback logic for USER variable resolution

## Problem Solved
- Eliminates environment-specific failures due to different USER variable handling
- Ensures consistent behavior between local development and CI execution
- Provides proper fallback mechanism when USER is not set

## Testing
- ✅ Pre-commit hooks work with custom USER values
- ✅ Pre-commit hooks fallback correctly when USER is unset  
- ✅ Flake validation passes in both scenarios
- ✅ CI-style commands work with new dynamic approach

## Files Modified
- `.github/workflows/ci.yml` - Updated 4 locations to use dynamic USER handling
- `.pre-commit-config.yaml` - Updated 2 locations to match CI pattern

Fixes #241