### PR TITLE
feat: add performance tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        category: [unit, integration]
+        category: [unit, integration, perf]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add missing `perf` test category to CI test matrix
- Improve test coverage without affecting CI performance
- Ensure all defined test categories run in CI pipeline

## Problem Solved
Fixes #242 - CI was only running `unit` and `integration` tests but ignoring available `perf` tests, reducing confidence in deployments.

## Changes
- Updated `.github/workflows/ci.yml` line 137 to include `perf` in test matrix
- Performance tests run quickly (~3 seconds) so no separate job needed

## Test Plan
- [x] Performance tests run successfully locally
- [x] Pre-commit hooks pass
- [x] Flake validation passes
- [x] CI will now run all defined test categories

## Additional Notes
The issue mentioned "e2e" tests, but these are actually implemented as `workflow` tests and aliased as `integration` tests (already running in CI). The only missing test category was `perf`.

🤖 Generated with [Claude Code](https://claude.ai/code)