### PR TITLE
fix: replace deprecated gitAndTools.gitFull with git

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -281,7 +281,7 @@ in
   ];
 
   environment.systemPackages = with pkgs; [
-    gitAndTools.gitFull
+    git
     inetutils
   ];
 


### PR DESCRIPTION
## Summary
Replace deprecated `gitAndTools.gitFull` with modern `git` package reference in NixOS configuration.

## Changes
- Update `hosts/nixos/default.nix:284` to use `git` instead of `gitAndTools.gitFull`

## Testing
- [x] Lint checks pass (`make lint`)
- [x] Flake validation passes (`nix flake check --impure --no-build`)  
- [x] Build completes successfully (`nix run --impure .#build`)
- [x] No functional changes to git functionality

🤖 Generated with [Claude Code](https://claude.ai/code)