### PR TITLE
fix: resolve build-switch logging module path issue

### DIFF
--- a/apps/aarch64-darwin/lib/build-logic.sh
+++ b/apps/aarch64-darwin/lib/build-logic.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Build Logic Module for Build Scripts
+# Contains core build, switch, and orchestration functions
+
+# Execute nix build with parallelization
+run_build() {
+    perf_start_phase "build"
+
+    log_step "Building system configuration"
+    log_info "Target: ${SYSTEM_TYPE}"
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        log_info "User: ${USER}"
+    fi
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+    log_info "Using ${JOBS} parallel jobs for build"
+
+    if [ "$VERBOSE" = "true" ]; then
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" || {
+            log_error "Build failed"
+            log_footer "failed"
+            exit 1
+        }
+    else
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" 2>/dev/null || {
+            log_error "Build failed. Run with --verbose for details"
+            log_footer "failed"
+            exit 1
+        }
+    fi
+
+    perf_end_phase "build"
+    log_success "Build completed"
+}
+
+# Execute platform-specific switch
+run_switch() {
+    perf_start_phase "switch"
+
+    echo ""
+    log_step "Applying system configuration"
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        log_info "Administrator privileges will be requested for system changes"
+        if [ "$PLATFORM_TYPE" = "linux" ] && [ -n "${SSH_AUTH_SOCK:-}" ]; then
+            log_info "SSH forwarding enabled for private repositories"
+        fi
+    else
+        log_info "Running with current privileges"
+    fi
+
+    SUDO_PREFIX=$(get_sudo_prefix)
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+
+    if [ "$VERBOSE" = "true" ]; then
+        log_info "Command: ${REBUILD_COMMAND} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE}"
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                log_error "Switch failed (exit code: $?)"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    else
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                log_error "Switch failed. Run with --verbose for details"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    fi
+
+    perf_end_phase "switch"
+    log_success "Configuration applied"
+}
+
+# Cleanup function
+run_cleanup() {
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        echo ""
+        log_step "Cleaning up"
+        unlink ./result >/dev/null 2>&1
+        log_success "Cleanup completed"
+    fi
+}
+
+# Main execution function
+execute_build_switch() {
+    # Start performance monitoring
+    perf_start_total
+
+    # Check if sudo will be needed
+    if ! check_sudo_requirement; then
+        log_error "Cannot proceed without administrator privileges"
+        exit 1
+    fi
+
+    # Acquire sudo privileges EARLY if needed
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        if ! acquire_sudo_early; then
+            log_error "Failed to acquire administrator privileges"
+            exit 1
+        fi
+    fi
+
+    # Main execution
+    log_header
+
+    # Build phase (Darwin) or Build & Switch phase (Linux)
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        # Darwin: separate build and switch phases
+        run_build "$@"
+        run_switch "$@"
+    else
+        # Linux: combined build & switch phase
+        perf_start_phase "build"
+        log_step "Building and switching system configuration"
+        log_info "Target: ${SYSTEM_TYPE}"
+        if [ "$SUDO_REQUIRED" = "true" ]; then
+            log_info "Administrator privileges will be requested for system changes"
+            if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+                log_info "SSH forwarding enabled for private repositories"
+            fi
+        else
+            log_info "Running with current privileges"
+        fi
+
+        SUDO_PREFIX=$(get_sudo_prefix)
+        JOBS=$(detect_optimal_jobs)
+        log_info "Using ${JOBS} parallel jobs for build and switch"
+
+        if [ "$VERBOSE" = "true" ]; then
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        else
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+
+        perf_end_phase "build"
+        log_success "Build and switch completed"
+    fi
+
+    # Cleanup
+    run_cleanup
+
+    # Show performance summary
+    perf_show_summary
+
+    # Footer
+    log_footer "success"
+
+    # Cleanup handlers
+    register_cleanup
+    cleanup_sudo_session
+}

--- a/apps/aarch64-darwin/lib/logging.sh
+++ b/apps/aarch64-darwin/lib/logging.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Logging Module for Build Scripts
+# Contains all logging functions and color constants
+
+# Color constants
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+BLUE='\033[1;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Logging functions
+log_header() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  ${PLATFORM_NAME} Build & Switch${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+log_step() {
+    echo "${YELLOW}▶${NC} $1"
+}
+
+log_info() {
+    echo "${DIM}  $1${NC}"
+}
+
+log_warning() {
+    echo "${YELLOW}⚠️  $1${NC}"
+}
+
+log_success() {
+    echo "${GREEN}✅ $1${NC}"
+}
+
+log_error() {
+    echo "${RED}❌ $1${NC}"
+}
+
+log_footer() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    if [ "$VERBOSE" = "true" ]; then
+        echo "${DIM}  ℹ️  Verbose mode enabled${NC}"
+        echo "${DIM}  📁 Working directory: $(pwd)${NC}"
+        echo "${DIM}  👤 User: ${USER:-unknown}${NC}"
+        echo "${DIM}  💻 Platform: ${PLATFORM_NAME}${NC}"
+    fi
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}

--- a/apps/aarch64-darwin/lib/performance.sh
+++ b/apps/aarch64-darwin/lib/performance.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Performance Monitoring Module for Build Scripts
+# Contains performance measurement and monitoring functions
+
+# Performance monitoring variables
+PERF_START_TIME=""
+PERF_BUILD_START_TIME=""
+PERF_SWITCH_START_TIME=""
+PERF_BUILD_DURATION=""
+PERF_SWITCH_DURATION=""
+
+# Performance monitoring functions
+perf_start_total() {
+    PERF_START_TIME=$(date +%s)
+}
+
+perf_start_phase() {
+    case "$1" in
+        "build")
+            PERF_BUILD_START_TIME=$(date +%s)
+            ;;
+        "switch")
+            PERF_SWITCH_START_TIME=$(date +%s)
+            ;;
+    esac
+}
+
+perf_end_phase() {
+    local end_time=$(date +%s)
+    case "$1" in
+        "build")
+            if [ -n "$PERF_BUILD_START_TIME" ]; then
+                PERF_BUILD_DURATION=$((end_time - PERF_BUILD_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Build phase completed in ${PERF_BUILD_DURATION}s"
+                fi
+            fi
+            ;;
+        "switch")
+            if [ -n "$PERF_SWITCH_START_TIME" ]; then
+                PERF_SWITCH_DURATION=$((end_time - PERF_SWITCH_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Switch phase completed in ${PERF_SWITCH_DURATION}s"
+                fi
+            fi
+            ;;
+    esac
+}
+
+perf_show_summary() {
+    if [ -n "$PERF_START_TIME" ]; then
+        local end_time=$(date +%s)
+        local total_duration=$((end_time - PERF_START_TIME))
+
+        echo ""
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo "${BLUE}  Performance Summary${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+        if [ -n "$PERF_BUILD_DURATION" ] && [ -n "$PERF_SWITCH_DURATION" ]; then
+            echo "${DIM}  Build phase:  ${PERF_BUILD_DURATION}s${NC}"
+            echo "${DIM}  Switch phase: ${PERF_SWITCH_DURATION}s${NC}"
+        fi
+        echo "${DIM}  Total time:   ${total_duration}s${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+    fi
+}
+
+# CPU core detection for parallel builds
+detect_optimal_jobs() {
+    local CORES
+
+    if command -v nproc >/dev/null 2>&1; then
+        # Linux
+        CORES=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        # macOS
+        CORES=$(sysctl -n hw.ncpu)
+    else
+        # Fallback
+        CORES=2
+    fi
+
+    # Check if we're in CI environment
+    if [ -n "$CI" ]; then
+        # CI: Use fewer cores to avoid overwhelming runners
+        CORES=$([ "$CORES" -gt 4 ] && echo 4 || echo "$CORES")
+    else
+        # Local development: Use more cores but cap at 8 for safety
+        CORES=$([ "$CORES" -gt 8 ] && echo 8 || echo "$CORES")
+    fi
+
+    # Return cores (minimum 1)
+    echo "$([ "$CORES" -gt 0 ] && echo "$CORES" || echo 1)"
+}

--- a/apps/aarch64-darwin/lib/platform-config.sh
+++ b/apps/aarch64-darwin/lib/platform-config.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Platform Configuration Module for Apply Scripts
+# Contains platform detection and configuration loading
+
+# Detect current platform
+detect_platform() {
+  local os=$(uname)
+  local arch=$(uname -m)
+
+  # Convert architecture names to Nix format
+  case "$arch" in
+    "arm64") arch="aarch64" ;;
+    "x86_64") arch="x86_64" ;;
+    *)
+      _print "${RED}Unsupported architecture: $arch${NC}"
+      exit 1
+      ;;
+  esac
+
+  # Convert OS names to Nix format
+  case "$os" in
+    "Darwin")
+      export PLATFORM_TYPE="darwin"
+      export PLATFORM_SYSTEM="$arch-darwin"
+      ;;
+    "Linux")
+      export PLATFORM_TYPE="linux"
+      export PLATFORM_SYSTEM="$arch-linux"
+      ;;
+    *)
+      _print "${RED}Unsupported operating system: $os${NC}"
+      exit 1
+      ;;
+  esac
+
+  export ARCH="$arch"
+  export OS="$os"
+
+  _print "${GREEN}Detected platform: $PLATFORM_SYSTEM${NC}"
+}
+
+# Load platform-specific configuration
+load_platform_config() {
+  detect_platform
+
+  local config_file="$(dirname "$0")/config.sh"
+
+  if [ -f "$config_file" ]; then
+    . "$config_file"
+    _print "${GREEN}Loaded platform config: $config_file${NC}"
+  else
+    _print "${YELLOW}Warning: No platform config found at $config_file${NC}"
+  fi
+}
+
+# Setup platform-specific environment
+setup_platform_environment() {
+  load_platform_config
+
+  # Linux-specific setup
+  if [ "$PLATFORM_TYPE" = "linux" ]; then
+    # Primary network interface detection
+    if command -v ip >/dev/null 2>&1; then
+      export PRIMARY_IFACE=$(ip -o -4 route show to default | awk '{print $5}')
+      _print "${GREEN}Found primary network interface: $PRIMARY_IFACE${NC}"
+    fi
+  fi
+}

--- a/apps/aarch64-darwin/lib/sudo-management.sh
+++ b/apps/aarch64-darwin/lib/sudo-management.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Sudo Management Module for Build Scripts
+# Contains privilege management and sudo-related functions
+
+# Sudo session management
+SUDO_REQUIRED=false
+
+# Basic sudo management functions
+check_current_privileges() {
+    [ "$(id -u)" -eq 0 ]
+}
+
+acquire_sudo_early() {
+    # Skip if already root
+    if check_current_privileges; then
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment - sudo may fail"
+        fi
+        return 0
+    fi
+
+    # Simple sudo validation
+    if ! sudo -v; then
+        if command -v log_error >/dev/null 2>&1; then
+            log_error "Failed to acquire sudo privileges"
+        fi
+        return 1
+    fi
+
+    if command -v log_success >/dev/null 2>&1; then
+        log_success "Sudo privileges acquired"
+    fi
+    return 0
+}
+
+# Register cleanup handlers
+register_cleanup() {
+    return 0
+}
+
+# Cleanup sudo session
+cleanup_sudo_session() {
+    return 0
+}
+
+# Explain why sudo is required for system changes
+explain_sudo_requirement() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  Administrator Privileges Required${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "${YELLOW}▶ Why sudo is needed:${NC}"
+    echo "${DIM}  • System configuration changes require administrator privileges${NC}"
+    echo "${DIM}  • ${PLATFORM_NAME} rebuild commands must modify system files${NC}"
+    echo "${DIM}  • This ensures your system is properly configured and secure${NC}"
+    echo ""
+    echo "${YELLOW}▶ What will happen:${NC}"
+    echo "${DIM}  • You'll be prompted for your password once${NC}"
+    echo "${DIM}  • Privileges will be used only for system configuration${NC}"
+    echo "${DIM}  • Session will be cleaned up automatically when done${NC}"
+    echo ""
+}
+
+# Determine if sudo will be needed later
+check_sudo_requirement() {
+    # Skip if already root
+    if check_current_privileges; then
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment (Claude Code)
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment detected"
+        fi
+        if command -v log_info >/dev/null 2>&1; then
+            log_info "System changes will require manual sudo execution"
+        fi
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Explain why sudo is needed
+    explain_sudo_requirement
+
+    SUDO_REQUIRED=true
+    return 0
+}
+
+get_sudo_prefix() {
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        echo "sudo"
+    else
+        echo ""
+    fi
+}

--- a/apps/aarch64-darwin/lib/token-replacement.sh
+++ b/apps/aarch64-darwin/lib/token-replacement.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Token Replacement Module for Apply Scripts
+# Contains logic for replacing tokens in configuration files
+
+# Replace tokens in a file
+replace_tokens_in_file() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  if [ ! -f "$file" ]; then
+    _print "${RED}Error: File not found: $file${NC}"
+    return 1
+  fi
+
+  # Replace common tokens
+  sed "s/REPLACE_USERNAME/$USERNAME/g; s/REPLACE_GIT_EMAIL/$GIT_EMAIL/g; s/REPLACE_GIT_NAME/$GIT_NAME/g" "$file" > "$temp_file"
+
+  # Move temp file back to original
+  mv "$temp_file" "$file"
+
+  _print "${GREEN}Tokens replaced in: $file${NC}"
+}
+
+# Replace tokens in multiple files
+replace_tokens() {
+  local target_dir="$1"
+
+  if [ ! -d "$target_dir" ]; then
+    _print "${RED}Error: Directory not found: $target_dir${NC}"
+    return 1
+  fi
+
+  _print "${YELLOW}Replacing tokens in configuration files...${NC}"
+
+  # Find and process configuration files
+  find "$target_dir" -type f \( -name "*.nix" -o -name "*.conf" -o -name "*.toml" \) | while read -r file; do
+    if grep -q "REPLACE_" "$file"; then
+      replace_tokens_in_file "$file"
+    fi
+  done
+
+  _print "${GREEN}Token replacement completed${NC}"
+}

--- a/apps/aarch64-darwin/lib/ui-utils.sh
+++ b/apps/aarch64-darwin/lib/ui-utils.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# UI Utilities Module for Apply Scripts
+# Contains color codes and UI helper functions
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Custom print function with OS-specific handling
+_print() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo -e "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Custom prompt function for user input
+_prompt() {
+  local message="$1"
+  local variable="$2"
+
+  _print "$message"
+  read -r $variable
+}
+
+# Ask for GitHub star (platform-specific)
+ask_for_star() {
+  local OS=$(uname)
+
+  _print "${YELLOW}Would you like to support my work by starring my GitHub repo? yes/no [yes]: ${NC}"
+  local response
+  read -r response
+  response=${response:-yes} # Set default response to 'yes' if input is empty
+
+  if echo "$response" | grep -qi "^y"; then
+    if [ "$OS" = "Darwin" ]; then
+      open "https://github.com/dustinlyons/nixos-config"
+    else
+      xdg-open "https://github.com/dustinlyons/nixos-config"
+    fi
+  fi
+}

--- a/apps/aarch64-darwin/lib/user-input.sh
+++ b/apps/aarch64-darwin/lib/user-input.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# User Input Module for Apply Scripts
+# Contains user information collection and validation
+
+# Fetch username from the system
+get_username() {
+  local username=$(whoami)
+
+  # If the username is 'nixos' or 'root', ask the user for their username
+  if [ "$username" = "nixos" ] || [ "$username" = "root" ]; then
+    _prompt "${YELLOW}You're running as $username. Please enter your desired username: ${NC}" username
+  fi
+
+  export USERNAME="$username"
+}
+
+# Get git configuration
+get_git_config() {
+  if command -v git >/dev/null 2>&1; then
+    # Fetch email and name from git config
+    export GIT_EMAIL=$(git config --get user.email)
+    export GIT_NAME=$(git config --get user.name)
+
+    # If either is empty, prompt for them
+    if [ -z "$GIT_EMAIL" ]; then
+      _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    fi
+
+    if [ -z "$GIT_NAME" ]; then
+      _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+    fi
+  else
+    # Git not available, ask for info
+    _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+  fi
+}
+
+# Collect all user information
+collect_user_info() {
+  get_username
+  get_git_config
+
+  # Display collected information
+  _print "${GREEN}Collected user information:${NC}"
+  _print "  Username: $USERNAME"
+  _print "  Email: $GIT_EMAIL"
+  _print "  Name: $GIT_NAME"
+}

--- a/apps/aarch64-linux/lib/build-logic.sh
+++ b/apps/aarch64-linux/lib/build-logic.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Build Logic Module for Build Scripts
+# Contains core build, switch, and orchestration functions
+
+# Execute nix build with parallelization
+run_build() {
+    perf_start_phase "build"
+
+    log_step "Building system configuration"
+    log_info "Target: ${SYSTEM_TYPE}"
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        log_info "User: ${USER}"
+    fi
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+    log_info "Using ${JOBS} parallel jobs for build"
+
+    if [ "$VERBOSE" = "true" ]; then
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" || {
+            log_error "Build failed"
+            log_footer "failed"
+            exit 1
+        }
+    else
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" 2>/dev/null || {
+            log_error "Build failed. Run with --verbose for details"
+            log_footer "failed"
+            exit 1
+        }
+    fi
+
+    perf_end_phase "build"
+    log_success "Build completed"
+}
+
+# Execute platform-specific switch
+run_switch() {
+    perf_start_phase "switch"
+
+    echo ""
+    log_step "Applying system configuration"
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        log_info "Administrator privileges will be requested for system changes"
+        if [ "$PLATFORM_TYPE" = "linux" ] && [ -n "${SSH_AUTH_SOCK:-}" ]; then
+            log_info "SSH forwarding enabled for private repositories"
+        fi
+    else
+        log_info "Running with current privileges"
+    fi
+
+    SUDO_PREFIX=$(get_sudo_prefix)
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+
+    if [ "$VERBOSE" = "true" ]; then
+        log_info "Command: ${REBUILD_COMMAND} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE}"
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                log_error "Switch failed (exit code: $?)"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    else
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                log_error "Switch failed. Run with --verbose for details"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    fi
+
+    perf_end_phase "switch"
+    log_success "Configuration applied"
+}
+
+# Cleanup function
+run_cleanup() {
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        echo ""
+        log_step "Cleaning up"
+        unlink ./result >/dev/null 2>&1
+        log_success "Cleanup completed"
+    fi
+}
+
+# Main execution function
+execute_build_switch() {
+    # Start performance monitoring
+    perf_start_total
+
+    # Check if sudo will be needed
+    if ! check_sudo_requirement; then
+        log_error "Cannot proceed without administrator privileges"
+        exit 1
+    fi
+
+    # Acquire sudo privileges EARLY if needed
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        if ! acquire_sudo_early; then
+            log_error "Failed to acquire administrator privileges"
+            exit 1
+        fi
+    fi
+
+    # Main execution
+    log_header
+
+    # Build phase (Darwin) or Build & Switch phase (Linux)
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        # Darwin: separate build and switch phases
+        run_build "$@"
+        run_switch "$@"
+    else
+        # Linux: combined build & switch phase
+        perf_start_phase "build"
+        log_step "Building and switching system configuration"
+        log_info "Target: ${SYSTEM_TYPE}"
+        if [ "$SUDO_REQUIRED" = "true" ]; then
+            log_info "Administrator privileges will be requested for system changes"
+            if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+                log_info "SSH forwarding enabled for private repositories"
+            fi
+        else
+            log_info "Running with current privileges"
+        fi
+
+        SUDO_PREFIX=$(get_sudo_prefix)
+        JOBS=$(detect_optimal_jobs)
+        log_info "Using ${JOBS} parallel jobs for build and switch"
+
+        if [ "$VERBOSE" = "true" ]; then
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        else
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+
+        perf_end_phase "build"
+        log_success "Build and switch completed"
+    fi
+
+    # Cleanup
+    run_cleanup
+
+    # Show performance summary
+    perf_show_summary
+
+    # Footer
+    log_footer "success"
+
+    # Cleanup handlers
+    register_cleanup
+    cleanup_sudo_session
+}

--- a/apps/aarch64-linux/lib/logging.sh
+++ b/apps/aarch64-linux/lib/logging.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Logging Module for Build Scripts
+# Contains all logging functions and color constants
+
+# Color constants
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+BLUE='\033[1;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Logging functions
+log_header() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  ${PLATFORM_NAME} Build & Switch${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+log_step() {
+    echo "${YELLOW}▶${NC} $1"
+}
+
+log_info() {
+    echo "${DIM}  $1${NC}"
+}
+
+log_warning() {
+    echo "${YELLOW}⚠️  $1${NC}"
+}
+
+log_success() {
+    echo "${GREEN}✅ $1${NC}"
+}
+
+log_error() {
+    echo "${RED}❌ $1${NC}"
+}
+
+log_footer() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    if [ "$VERBOSE" = "true" ]; then
+        echo "${DIM}  ℹ️  Verbose mode enabled${NC}"
+        echo "${DIM}  📁 Working directory: $(pwd)${NC}"
+        echo "${DIM}  👤 User: ${USER:-unknown}${NC}"
+        echo "${DIM}  💻 Platform: ${PLATFORM_NAME}${NC}"
+    fi
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}

--- a/apps/aarch64-linux/lib/performance.sh
+++ b/apps/aarch64-linux/lib/performance.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Performance Monitoring Module for Build Scripts
+# Contains performance measurement and monitoring functions
+
+# Performance monitoring variables
+PERF_START_TIME=""
+PERF_BUILD_START_TIME=""
+PERF_SWITCH_START_TIME=""
+PERF_BUILD_DURATION=""
+PERF_SWITCH_DURATION=""
+
+# Performance monitoring functions
+perf_start_total() {
+    PERF_START_TIME=$(date +%s)
+}
+
+perf_start_phase() {
+    case "$1" in
+        "build")
+            PERF_BUILD_START_TIME=$(date +%s)
+            ;;
+        "switch")
+            PERF_SWITCH_START_TIME=$(date +%s)
+            ;;
+    esac
+}
+
+perf_end_phase() {
+    local end_time=$(date +%s)
+    case "$1" in
+        "build")
+            if [ -n "$PERF_BUILD_START_TIME" ]; then
+                PERF_BUILD_DURATION=$((end_time - PERF_BUILD_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Build phase completed in ${PERF_BUILD_DURATION}s"
+                fi
+            fi
+            ;;
+        "switch")
+            if [ -n "$PERF_SWITCH_START_TIME" ]; then
+                PERF_SWITCH_DURATION=$((end_time - PERF_SWITCH_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Switch phase completed in ${PERF_SWITCH_DURATION}s"
+                fi
+            fi
+            ;;
+    esac
+}
+
+perf_show_summary() {
+    if [ -n "$PERF_START_TIME" ]; then
+        local end_time=$(date +%s)
+        local total_duration=$((end_time - PERF_START_TIME))
+
+        echo ""
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo "${BLUE}  Performance Summary${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+        if [ -n "$PERF_BUILD_DURATION" ] && [ -n "$PERF_SWITCH_DURATION" ]; then
+            echo "${DIM}  Build phase:  ${PERF_BUILD_DURATION}s${NC}"
+            echo "${DIM}  Switch phase: ${PERF_SWITCH_DURATION}s${NC}"
+        fi
+        echo "${DIM}  Total time:   ${total_duration}s${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+    fi
+}
+
+# CPU core detection for parallel builds
+detect_optimal_jobs() {
+    local CORES
+
+    if command -v nproc >/dev/null 2>&1; then
+        # Linux
+        CORES=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        # macOS
+        CORES=$(sysctl -n hw.ncpu)
+    else
+        # Fallback
+        CORES=2
+    fi
+
+    # Check if we're in CI environment
+    if [ -n "$CI" ]; then
+        # CI: Use fewer cores to avoid overwhelming runners
+        CORES=$([ "$CORES" -gt 4 ] && echo 4 || echo "$CORES")
+    else
+        # Local development: Use more cores but cap at 8 for safety
+        CORES=$([ "$CORES" -gt 8 ] && echo 8 || echo "$CORES")
+    fi
+
+    # Return cores (minimum 1)
+    echo "$([ "$CORES" -gt 0 ] && echo "$CORES" || echo 1)"
+}

--- a/apps/aarch64-linux/lib/platform-config.sh
+++ b/apps/aarch64-linux/lib/platform-config.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Platform Configuration Module for Apply Scripts
+# Contains platform detection and configuration loading
+
+# Detect current platform
+detect_platform() {
+  local os=$(uname)
+  local arch=$(uname -m)
+
+  # Convert architecture names to Nix format
+  case "$arch" in
+    "arm64") arch="aarch64" ;;
+    "x86_64") arch="x86_64" ;;
+    *)
+      _print "${RED}Unsupported architecture: $arch${NC}"
+      exit 1
+      ;;
+  esac
+
+  # Convert OS names to Nix format
+  case "$os" in
+    "Darwin")
+      export PLATFORM_TYPE="darwin"
+      export PLATFORM_SYSTEM="$arch-darwin"
+      ;;
+    "Linux")
+      export PLATFORM_TYPE="linux"
+      export PLATFORM_SYSTEM="$arch-linux"
+      ;;
+    *)
+      _print "${RED}Unsupported operating system: $os${NC}"
+      exit 1
+      ;;
+  esac
+
+  export ARCH="$arch"
+  export OS="$os"
+
+  _print "${GREEN}Detected platform: $PLATFORM_SYSTEM${NC}"
+}
+
+# Load platform-specific configuration
+load_platform_config() {
+  detect_platform
+
+  local config_file="$(dirname "$0")/config.sh"
+
+  if [ -f "$config_file" ]; then
+    . "$config_file"
+    _print "${GREEN}Loaded platform config: $config_file${NC}"
+  else
+    _print "${YELLOW}Warning: No platform config found at $config_file${NC}"
+  fi
+}
+
+# Setup platform-specific environment
+setup_platform_environment() {
+  load_platform_config
+
+  # Linux-specific setup
+  if [ "$PLATFORM_TYPE" = "linux" ]; then
+    # Primary network interface detection
+    if command -v ip >/dev/null 2>&1; then
+      export PRIMARY_IFACE=$(ip -o -4 route show to default | awk '{print $5}')
+      _print "${GREEN}Found primary network interface: $PRIMARY_IFACE${NC}"
+    fi
+  fi
+}

--- a/apps/aarch64-linux/lib/sudo-management.sh
+++ b/apps/aarch64-linux/lib/sudo-management.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Sudo Management Module for Build Scripts
+# Contains privilege management and sudo-related functions
+
+# Sudo session management
+SUDO_REQUIRED=false
+
+# Basic sudo management functions
+check_current_privileges() {
+    [ "$(id -u)" -eq 0 ]
+}
+
+acquire_sudo_early() {
+    # Skip if already root
+    if check_current_privileges; then
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment - sudo may fail"
+        fi
+        return 0
+    fi
+
+    # Simple sudo validation
+    if ! sudo -v; then
+        if command -v log_error >/dev/null 2>&1; then
+            log_error "Failed to acquire sudo privileges"
+        fi
+        return 1
+    fi
+
+    if command -v log_success >/dev/null 2>&1; then
+        log_success "Sudo privileges acquired"
+    fi
+    return 0
+}
+
+# Register cleanup handlers
+register_cleanup() {
+    return 0
+}
+
+# Cleanup sudo session
+cleanup_sudo_session() {
+    return 0
+}
+
+# Explain why sudo is required for system changes
+explain_sudo_requirement() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  Administrator Privileges Required${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "${YELLOW}▶ Why sudo is needed:${NC}"
+    echo "${DIM}  • System configuration changes require administrator privileges${NC}"
+    echo "${DIM}  • ${PLATFORM_NAME} rebuild commands must modify system files${NC}"
+    echo "${DIM}  • This ensures your system is properly configured and secure${NC}"
+    echo ""
+    echo "${YELLOW}▶ What will happen:${NC}"
+    echo "${DIM}  • You'll be prompted for your password once${NC}"
+    echo "${DIM}  • Privileges will be used only for system configuration${NC}"
+    echo "${DIM}  • Session will be cleaned up automatically when done${NC}"
+    echo ""
+}
+
+# Determine if sudo will be needed later
+check_sudo_requirement() {
+    # Skip if already root
+    if check_current_privileges; then
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment (Claude Code)
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment detected"
+        fi
+        if command -v log_info >/dev/null 2>&1; then
+            log_info "System changes will require manual sudo execution"
+        fi
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Explain why sudo is needed
+    explain_sudo_requirement
+
+    SUDO_REQUIRED=true
+    return 0
+}
+
+get_sudo_prefix() {
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        echo "sudo"
+    else
+        echo ""
+    fi
+}

--- a/apps/aarch64-linux/lib/token-replacement.sh
+++ b/apps/aarch64-linux/lib/token-replacement.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Token Replacement Module for Apply Scripts
+# Contains logic for replacing tokens in configuration files
+
+# Replace tokens in a file
+replace_tokens_in_file() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  if [ ! -f "$file" ]; then
+    _print "${RED}Error: File not found: $file${NC}"
+    return 1
+  fi
+
+  # Replace common tokens
+  sed "s/REPLACE_USERNAME/$USERNAME/g; s/REPLACE_GIT_EMAIL/$GIT_EMAIL/g; s/REPLACE_GIT_NAME/$GIT_NAME/g" "$file" > "$temp_file"
+
+  # Move temp file back to original
+  mv "$temp_file" "$file"
+
+  _print "${GREEN}Tokens replaced in: $file${NC}"
+}
+
+# Replace tokens in multiple files
+replace_tokens() {
+  local target_dir="$1"
+
+  if [ ! -d "$target_dir" ]; then
+    _print "${RED}Error: Directory not found: $target_dir${NC}"
+    return 1
+  fi
+
+  _print "${YELLOW}Replacing tokens in configuration files...${NC}"
+
+  # Find and process configuration files
+  find "$target_dir" -type f \( -name "*.nix" -o -name "*.conf" -o -name "*.toml" \) | while read -r file; do
+    if grep -q "REPLACE_" "$file"; then
+      replace_tokens_in_file "$file"
+    fi
+  done
+
+  _print "${GREEN}Token replacement completed${NC}"
+}

--- a/apps/aarch64-linux/lib/ui-utils.sh
+++ b/apps/aarch64-linux/lib/ui-utils.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# UI Utilities Module for Apply Scripts
+# Contains color codes and UI helper functions
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Custom print function with OS-specific handling
+_print() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo -e "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Custom prompt function for user input
+_prompt() {
+  local message="$1"
+  local variable="$2"
+
+  _print "$message"
+  read -r $variable
+}
+
+# Ask for GitHub star (platform-specific)
+ask_for_star() {
+  local OS=$(uname)
+
+  _print "${YELLOW}Would you like to support my work by starring my GitHub repo? yes/no [yes]: ${NC}"
+  local response
+  read -r response
+  response=${response:-yes} # Set default response to 'yes' if input is empty
+
+  if echo "$response" | grep -qi "^y"; then
+    if [ "$OS" = "Darwin" ]; then
+      open "https://github.com/dustinlyons/nixos-config"
+    else
+      xdg-open "https://github.com/dustinlyons/nixos-config"
+    fi
+  fi
+}

--- a/apps/aarch64-linux/lib/user-input.sh
+++ b/apps/aarch64-linux/lib/user-input.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# User Input Module for Apply Scripts
+# Contains user information collection and validation
+
+# Fetch username from the system
+get_username() {
+  local username=$(whoami)
+
+  # If the username is 'nixos' or 'root', ask the user for their username
+  if [ "$username" = "nixos" ] || [ "$username" = "root" ]; then
+    _prompt "${YELLOW}You're running as $username. Please enter your desired username: ${NC}" username
+  fi
+
+  export USERNAME="$username"
+}
+
+# Get git configuration
+get_git_config() {
+  if command -v git >/dev/null 2>&1; then
+    # Fetch email and name from git config
+    export GIT_EMAIL=$(git config --get user.email)
+    export GIT_NAME=$(git config --get user.name)
+
+    # If either is empty, prompt for them
+    if [ -z "$GIT_EMAIL" ]; then
+      _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    fi
+
+    if [ -z "$GIT_NAME" ]; then
+      _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+    fi
+  else
+    # Git not available, ask for info
+    _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+  fi
+}
+
+# Collect all user information
+collect_user_info() {
+  get_username
+  get_git_config
+
+  # Display collected information
+  _print "${GREEN}Collected user information:${NC}"
+  _print "  Username: $USERNAME"
+  _print "  Email: $GIT_EMAIL"
+  _print "  Name: $GIT_NAME"
+}

--- a/apps/x86_64-darwin/lib/build-logic.sh
+++ b/apps/x86_64-darwin/lib/build-logic.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Build Logic Module for Build Scripts
+# Contains core build, switch, and orchestration functions
+
+# Execute nix build with parallelization
+run_build() {
+    perf_start_phase "build"
+
+    log_step "Building system configuration"
+    log_info "Target: ${SYSTEM_TYPE}"
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        log_info "User: ${USER}"
+    fi
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+    log_info "Using ${JOBS} parallel jobs for build"
+
+    if [ "$VERBOSE" = "true" ]; then
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" || {
+            log_error "Build failed"
+            log_footer "failed"
+            exit 1
+        }
+    else
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" 2>/dev/null || {
+            log_error "Build failed. Run with --verbose for details"
+            log_footer "failed"
+            exit 1
+        }
+    fi
+
+    perf_end_phase "build"
+    log_success "Build completed"
+}
+
+# Execute platform-specific switch
+run_switch() {
+    perf_start_phase "switch"
+
+    echo ""
+    log_step "Applying system configuration"
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        log_info "Administrator privileges will be requested for system changes"
+        if [ "$PLATFORM_TYPE" = "linux" ] && [ -n "${SSH_AUTH_SOCK:-}" ]; then
+            log_info "SSH forwarding enabled for private repositories"
+        fi
+    else
+        log_info "Running with current privileges"
+    fi
+
+    SUDO_PREFIX=$(get_sudo_prefix)
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+
+    if [ "$VERBOSE" = "true" ]; then
+        log_info "Command: ${REBUILD_COMMAND} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE}"
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                log_error "Switch failed (exit code: $?)"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    else
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                log_error "Switch failed. Run with --verbose for details"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    fi
+
+    perf_end_phase "switch"
+    log_success "Configuration applied"
+}
+
+# Cleanup function
+run_cleanup() {
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        echo ""
+        log_step "Cleaning up"
+        unlink ./result >/dev/null 2>&1
+        log_success "Cleanup completed"
+    fi
+}
+
+# Main execution function
+execute_build_switch() {
+    # Start performance monitoring
+    perf_start_total
+
+    # Check if sudo will be needed
+    if ! check_sudo_requirement; then
+        log_error "Cannot proceed without administrator privileges"
+        exit 1
+    fi
+
+    # Acquire sudo privileges EARLY if needed
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        if ! acquire_sudo_early; then
+            log_error "Failed to acquire administrator privileges"
+            exit 1
+        fi
+    fi
+
+    # Main execution
+    log_header
+
+    # Build phase (Darwin) or Build & Switch phase (Linux)
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        # Darwin: separate build and switch phases
+        run_build "$@"
+        run_switch "$@"
+    else
+        # Linux: combined build & switch phase
+        perf_start_phase "build"
+        log_step "Building and switching system configuration"
+        log_info "Target: ${SYSTEM_TYPE}"
+        if [ "$SUDO_REQUIRED" = "true" ]; then
+            log_info "Administrator privileges will be requested for system changes"
+            if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+                log_info "SSH forwarding enabled for private repositories"
+            fi
+        else
+            log_info "Running with current privileges"
+        fi
+
+        SUDO_PREFIX=$(get_sudo_prefix)
+        JOBS=$(detect_optimal_jobs)
+        log_info "Using ${JOBS} parallel jobs for build and switch"
+
+        if [ "$VERBOSE" = "true" ]; then
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        else
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+
+        perf_end_phase "build"
+        log_success "Build and switch completed"
+    fi
+
+    # Cleanup
+    run_cleanup
+
+    # Show performance summary
+    perf_show_summary
+
+    # Footer
+    log_footer "success"
+
+    # Cleanup handlers
+    register_cleanup
+    cleanup_sudo_session
+}

--- a/apps/x86_64-darwin/lib/logging.sh
+++ b/apps/x86_64-darwin/lib/logging.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Logging Module for Build Scripts
+# Contains all logging functions and color constants
+
+# Color constants
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+BLUE='\033[1;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Logging functions
+log_header() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  ${PLATFORM_NAME} Build & Switch${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+log_step() {
+    echo "${YELLOW}▶${NC} $1"
+}
+
+log_info() {
+    echo "${DIM}  $1${NC}"
+}
+
+log_warning() {
+    echo "${YELLOW}⚠️  $1${NC}"
+}
+
+log_success() {
+    echo "${GREEN}✅ $1${NC}"
+}
+
+log_error() {
+    echo "${RED}❌ $1${NC}"
+}
+
+log_footer() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    if [ "$VERBOSE" = "true" ]; then
+        echo "${DIM}  ℹ️  Verbose mode enabled${NC}"
+        echo "${DIM}  📁 Working directory: $(pwd)${NC}"
+        echo "${DIM}  👤 User: ${USER:-unknown}${NC}"
+        echo "${DIM}  💻 Platform: ${PLATFORM_NAME}${NC}"
+    fi
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}

--- a/apps/x86_64-darwin/lib/performance.sh
+++ b/apps/x86_64-darwin/lib/performance.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Performance Monitoring Module for Build Scripts
+# Contains performance measurement and monitoring functions
+
+# Performance monitoring variables
+PERF_START_TIME=""
+PERF_BUILD_START_TIME=""
+PERF_SWITCH_START_TIME=""
+PERF_BUILD_DURATION=""
+PERF_SWITCH_DURATION=""
+
+# Performance monitoring functions
+perf_start_total() {
+    PERF_START_TIME=$(date +%s)
+}
+
+perf_start_phase() {
+    case "$1" in
+        "build")
+            PERF_BUILD_START_TIME=$(date +%s)
+            ;;
+        "switch")
+            PERF_SWITCH_START_TIME=$(date +%s)
+            ;;
+    esac
+}
+
+perf_end_phase() {
+    local end_time=$(date +%s)
+    case "$1" in
+        "build")
+            if [ -n "$PERF_BUILD_START_TIME" ]; then
+                PERF_BUILD_DURATION=$((end_time - PERF_BUILD_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Build phase completed in ${PERF_BUILD_DURATION}s"
+                fi
+            fi
+            ;;
+        "switch")
+            if [ -n "$PERF_SWITCH_START_TIME" ]; then
+                PERF_SWITCH_DURATION=$((end_time - PERF_SWITCH_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Switch phase completed in ${PERF_SWITCH_DURATION}s"
+                fi
+            fi
+            ;;
+    esac
+}
+
+perf_show_summary() {
+    if [ -n "$PERF_START_TIME" ]; then
+        local end_time=$(date +%s)
+        local total_duration=$((end_time - PERF_START_TIME))
+
+        echo ""
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo "${BLUE}  Performance Summary${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+        if [ -n "$PERF_BUILD_DURATION" ] && [ -n "$PERF_SWITCH_DURATION" ]; then
+            echo "${DIM}  Build phase:  ${PERF_BUILD_DURATION}s${NC}"
+            echo "${DIM}  Switch phase: ${PERF_SWITCH_DURATION}s${NC}"
+        fi
+        echo "${DIM}  Total time:   ${total_duration}s${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+    fi
+}
+
+# CPU core detection for parallel builds
+detect_optimal_jobs() {
+    local CORES
+
+    if command -v nproc >/dev/null 2>&1; then
+        # Linux
+        CORES=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        # macOS
+        CORES=$(sysctl -n hw.ncpu)
+    else
+        # Fallback
+        CORES=2
+    fi
+
+    # Check if we're in CI environment
+    if [ -n "$CI" ]; then
+        # CI: Use fewer cores to avoid overwhelming runners
+        CORES=$([ "$CORES" -gt 4 ] && echo 4 || echo "$CORES")
+    else
+        # Local development: Use more cores but cap at 8 for safety
+        CORES=$([ "$CORES" -gt 8 ] && echo 8 || echo "$CORES")
+    fi
+
+    # Return cores (minimum 1)
+    echo "$([ "$CORES" -gt 0 ] && echo "$CORES" || echo 1)"
+}

--- a/apps/x86_64-darwin/lib/platform-config.sh
+++ b/apps/x86_64-darwin/lib/platform-config.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Platform Configuration Module for Apply Scripts
+# Contains platform detection and configuration loading
+
+# Detect current platform
+detect_platform() {
+  local os=$(uname)
+  local arch=$(uname -m)
+
+  # Convert architecture names to Nix format
+  case "$arch" in
+    "arm64") arch="aarch64" ;;
+    "x86_64") arch="x86_64" ;;
+    *)
+      _print "${RED}Unsupported architecture: $arch${NC}"
+      exit 1
+      ;;
+  esac
+
+  # Convert OS names to Nix format
+  case "$os" in
+    "Darwin")
+      export PLATFORM_TYPE="darwin"
+      export PLATFORM_SYSTEM="$arch-darwin"
+      ;;
+    "Linux")
+      export PLATFORM_TYPE="linux"
+      export PLATFORM_SYSTEM="$arch-linux"
+      ;;
+    *)
+      _print "${RED}Unsupported operating system: $os${NC}"
+      exit 1
+      ;;
+  esac
+
+  export ARCH="$arch"
+  export OS="$os"
+
+  _print "${GREEN}Detected platform: $PLATFORM_SYSTEM${NC}"
+}
+
+# Load platform-specific configuration
+load_platform_config() {
+  detect_platform
+
+  local config_file="$(dirname "$0")/config.sh"
+
+  if [ -f "$config_file" ]; then
+    . "$config_file"
+    _print "${GREEN}Loaded platform config: $config_file${NC}"
+  else
+    _print "${YELLOW}Warning: No platform config found at $config_file${NC}"
+  fi
+}
+
+# Setup platform-specific environment
+setup_platform_environment() {
+  load_platform_config
+
+  # Linux-specific setup
+  if [ "$PLATFORM_TYPE" = "linux" ]; then
+    # Primary network interface detection
+    if command -v ip >/dev/null 2>&1; then
+      export PRIMARY_IFACE=$(ip -o -4 route show to default | awk '{print $5}')
+      _print "${GREEN}Found primary network interface: $PRIMARY_IFACE${NC}"
+    fi
+  fi
+}

--- a/apps/x86_64-darwin/lib/sudo-management.sh
+++ b/apps/x86_64-darwin/lib/sudo-management.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Sudo Management Module for Build Scripts
+# Contains privilege management and sudo-related functions
+
+# Sudo session management
+SUDO_REQUIRED=false
+
+# Basic sudo management functions
+check_current_privileges() {
+    [ "$(id -u)" -eq 0 ]
+}
+
+acquire_sudo_early() {
+    # Skip if already root
+    if check_current_privileges; then
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment - sudo may fail"
+        fi
+        return 0
+    fi
+
+    # Simple sudo validation
+    if ! sudo -v; then
+        if command -v log_error >/dev/null 2>&1; then
+            log_error "Failed to acquire sudo privileges"
+        fi
+        return 1
+    fi
+
+    if command -v log_success >/dev/null 2>&1; then
+        log_success "Sudo privileges acquired"
+    fi
+    return 0
+}
+
+# Register cleanup handlers
+register_cleanup() {
+    return 0
+}
+
+# Cleanup sudo session
+cleanup_sudo_session() {
+    return 0
+}
+
+# Explain why sudo is required for system changes
+explain_sudo_requirement() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  Administrator Privileges Required${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "${YELLOW}▶ Why sudo is needed:${NC}"
+    echo "${DIM}  • System configuration changes require administrator privileges${NC}"
+    echo "${DIM}  • ${PLATFORM_NAME} rebuild commands must modify system files${NC}"
+    echo "${DIM}  • This ensures your system is properly configured and secure${NC}"
+    echo ""
+    echo "${YELLOW}▶ What will happen:${NC}"
+    echo "${DIM}  • You'll be prompted for your password once${NC}"
+    echo "${DIM}  • Privileges will be used only for system configuration${NC}"
+    echo "${DIM}  • Session will be cleaned up automatically when done${NC}"
+    echo ""
+}
+
+# Determine if sudo will be needed later
+check_sudo_requirement() {
+    # Skip if already root
+    if check_current_privileges; then
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment (Claude Code)
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment detected"
+        fi
+        if command -v log_info >/dev/null 2>&1; then
+            log_info "System changes will require manual sudo execution"
+        fi
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Explain why sudo is needed
+    explain_sudo_requirement
+
+    SUDO_REQUIRED=true
+    return 0
+}
+
+get_sudo_prefix() {
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        echo "sudo"
+    else
+        echo ""
+    fi
+}

--- a/apps/x86_64-darwin/lib/token-replacement.sh
+++ b/apps/x86_64-darwin/lib/token-replacement.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Token Replacement Module for Apply Scripts
+# Contains logic for replacing tokens in configuration files
+
+# Replace tokens in a file
+replace_tokens_in_file() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  if [ ! -f "$file" ]; then
+    _print "${RED}Error: File not found: $file${NC}"
+    return 1
+  fi
+
+  # Replace common tokens
+  sed "s/REPLACE_USERNAME/$USERNAME/g; s/REPLACE_GIT_EMAIL/$GIT_EMAIL/g; s/REPLACE_GIT_NAME/$GIT_NAME/g" "$file" > "$temp_file"
+
+  # Move temp file back to original
+  mv "$temp_file" "$file"
+
+  _print "${GREEN}Tokens replaced in: $file${NC}"
+}
+
+# Replace tokens in multiple files
+replace_tokens() {
+  local target_dir="$1"
+
+  if [ ! -d "$target_dir" ]; then
+    _print "${RED}Error: Directory not found: $target_dir${NC}"
+    return 1
+  fi
+
+  _print "${YELLOW}Replacing tokens in configuration files...${NC}"
+
+  # Find and process configuration files
+  find "$target_dir" -type f \( -name "*.nix" -o -name "*.conf" -o -name "*.toml" \) | while read -r file; do
+    if grep -q "REPLACE_" "$file"; then
+      replace_tokens_in_file "$file"
+    fi
+  done
+
+  _print "${GREEN}Token replacement completed${NC}"
+}

--- a/apps/x86_64-darwin/lib/ui-utils.sh
+++ b/apps/x86_64-darwin/lib/ui-utils.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# UI Utilities Module for Apply Scripts
+# Contains color codes and UI helper functions
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Custom print function with OS-specific handling
+_print() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo -e "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Custom prompt function for user input
+_prompt() {
+  local message="$1"
+  local variable="$2"
+
+  _print "$message"
+  read -r $variable
+}
+
+# Ask for GitHub star (platform-specific)
+ask_for_star() {
+  local OS=$(uname)
+
+  _print "${YELLOW}Would you like to support my work by starring my GitHub repo? yes/no [yes]: ${NC}"
+  local response
+  read -r response
+  response=${response:-yes} # Set default response to 'yes' if input is empty
+
+  if echo "$response" | grep -qi "^y"; then
+    if [ "$OS" = "Darwin" ]; then
+      open "https://github.com/dustinlyons/nixos-config"
+    else
+      xdg-open "https://github.com/dustinlyons/nixos-config"
+    fi
+  fi
+}

--- a/apps/x86_64-darwin/lib/user-input.sh
+++ b/apps/x86_64-darwin/lib/user-input.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# User Input Module for Apply Scripts
+# Contains user information collection and validation
+
+# Fetch username from the system
+get_username() {
+  local username=$(whoami)
+
+  # If the username is 'nixos' or 'root', ask the user for their username
+  if [ "$username" = "nixos" ] || [ "$username" = "root" ]; then
+    _prompt "${YELLOW}You're running as $username. Please enter your desired username: ${NC}" username
+  fi
+
+  export USERNAME="$username"
+}
+
+# Get git configuration
+get_git_config() {
+  if command -v git >/dev/null 2>&1; then
+    # Fetch email and name from git config
+    export GIT_EMAIL=$(git config --get user.email)
+    export GIT_NAME=$(git config --get user.name)
+
+    # If either is empty, prompt for them
+    if [ -z "$GIT_EMAIL" ]; then
+      _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    fi
+
+    if [ -z "$GIT_NAME" ]; then
+      _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+    fi
+  else
+    # Git not available, ask for info
+    _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+  fi
+}
+
+# Collect all user information
+collect_user_info() {
+  get_username
+  get_git_config
+
+  # Display collected information
+  _print "${GREEN}Collected user information:${NC}"
+  _print "  Username: $USERNAME"
+  _print "  Email: $GIT_EMAIL"
+  _print "  Name: $GIT_NAME"
+}

--- a/apps/x86_64-linux/lib/build-logic.sh
+++ b/apps/x86_64-linux/lib/build-logic.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+# Build Logic Module for Build Scripts
+# Contains core build, switch, and orchestration functions
+
+# Execute nix build with parallelization
+run_build() {
+    perf_start_phase "build"
+
+    log_step "Building system configuration"
+    log_info "Target: ${SYSTEM_TYPE}"
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        log_info "User: ${USER}"
+    fi
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+    log_info "Using ${JOBS} parallel jobs for build"
+
+    if [ "$VERBOSE" = "true" ]; then
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" || {
+            log_error "Build failed"
+            log_footer "failed"
+            exit 1
+        }
+    else
+        nix --extra-experimental-features 'nix-command flakes' build --impure --max-jobs "$JOBS" --cores 0 .#$FLAKE_SYSTEM "$@" 2>/dev/null || {
+            log_error "Build failed. Run with --verbose for details"
+            log_footer "failed"
+            exit 1
+        }
+    fi
+
+    perf_end_phase "build"
+    log_success "Build completed"
+}
+
+# Execute platform-specific switch
+run_switch() {
+    perf_start_phase "switch"
+
+    echo ""
+    log_step "Applying system configuration"
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        log_info "Administrator privileges will be requested for system changes"
+        if [ "$PLATFORM_TYPE" = "linux" ] && [ -n "${SSH_AUTH_SOCK:-}" ]; then
+            log_info "SSH forwarding enabled for private repositories"
+        fi
+    else
+        log_info "Running with current privileges"
+    fi
+
+    SUDO_PREFIX=$(get_sudo_prefix)
+
+    # Get optimal job count for parallelization
+    JOBS=$(detect_optimal_jobs)
+
+    if [ "$VERBOSE" = "true" ]; then
+        log_info "Command: ${REBUILD_COMMAND} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE}"
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                log_error "Switch failed (exit code: $?)"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" 2>&1 || {
+                    log_error "Switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    else
+        if [ -n "${SUDO_PREFIX}" ]; then
+            eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                log_error "Switch failed. Run with --verbose for details"
+                log_footer "failed"
+                exit 1
+            }
+        else
+            if [ "$PLATFORM_TYPE" = "darwin" ]; then
+                USER="$USER" ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+    fi
+
+    perf_end_phase "switch"
+    log_success "Configuration applied"
+}
+
+# Cleanup function
+run_cleanup() {
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        echo ""
+        log_step "Cleaning up"
+        unlink ./result >/dev/null 2>&1
+        log_success "Cleanup completed"
+    fi
+}
+
+# Main execution function
+execute_build_switch() {
+    # Start performance monitoring
+    perf_start_total
+
+    # Check if sudo will be needed
+    if ! check_sudo_requirement; then
+        log_error "Cannot proceed without administrator privileges"
+        exit 1
+    fi
+
+    # Acquire sudo privileges EARLY if needed
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        if ! acquire_sudo_early; then
+            log_error "Failed to acquire administrator privileges"
+            exit 1
+        fi
+    fi
+
+    # Main execution
+    log_header
+
+    # Build phase (Darwin) or Build & Switch phase (Linux)
+    if [ "$PLATFORM_TYPE" = "darwin" ]; then
+        # Darwin: separate build and switch phases
+        run_build "$@"
+        run_switch "$@"
+    else
+        # Linux: combined build & switch phase
+        perf_start_phase "build"
+        log_step "Building and switching system configuration"
+        log_info "Target: ${SYSTEM_TYPE}"
+        if [ "$SUDO_REQUIRED" = "true" ]; then
+            log_info "Administrator privileges will be requested for system changes"
+            if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+                log_info "SSH forwarding enabled for private repositories"
+            fi
+        else
+            log_info "Running with current privileges"
+        fi
+
+        SUDO_PREFIX=$(get_sudo_prefix)
+        JOBS=$(detect_optimal_jobs)
+        log_info "Using ${JOBS} parallel jobs for build and switch"
+
+        if [ "$VERBOSE" = "true" ]; then
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" || {
+                    log_error "Build and switch failed (exit code: $?)"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        else
+            if [ -n "${SUDO_PREFIX}" ]; then
+                eval "${SUDO_PREFIX} ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} \"\$@\"" >/dev/null || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            else
+                ${REBUILD_COMMAND_PATH} switch --impure --max-jobs ${JOBS} --cores 0 --flake .#${SYSTEM_TYPE} "$@" >/dev/null 2>&1 || {
+                    log_error "Build and switch failed. Run with --verbose for details"
+                    log_footer "failed"
+                    exit 1
+                }
+            fi
+        fi
+
+        perf_end_phase "build"
+        log_success "Build and switch completed"
+    fi
+
+    # Cleanup
+    run_cleanup
+
+    # Show performance summary
+    perf_show_summary
+
+    # Footer
+    log_footer "success"
+
+    # Cleanup handlers
+    register_cleanup
+    cleanup_sudo_session
+}

--- a/apps/x86_64-linux/lib/logging.sh
+++ b/apps/x86_64-linux/lib/logging.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Logging Module for Build Scripts
+# Contains all logging functions and color constants
+
+# Color constants
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+BLUE='\033[1;34m'
+DIM='\033[2m'
+NC='\033[0m'
+
+# Logging functions
+log_header() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  ${PLATFORM_NAME} Build & Switch${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+log_step() {
+    echo "${YELLOW}▶${NC} $1"
+}
+
+log_info() {
+    echo "${DIM}  $1${NC}"
+}
+
+log_warning() {
+    echo "${YELLOW}⚠️  $1${NC}"
+}
+
+log_success() {
+    echo "${GREEN}✅ $1${NC}"
+}
+
+log_error() {
+    echo "${RED}❌ $1${NC}"
+}
+
+log_footer() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    if [ "$VERBOSE" = "true" ]; then
+        echo "${DIM}  ℹ️  Verbose mode enabled${NC}"
+        echo "${DIM}  📁 Working directory: $(pwd)${NC}"
+        echo "${DIM}  👤 User: ${USER:-unknown}${NC}"
+        echo "${DIM}  💻 Platform: ${PLATFORM_NAME}${NC}"
+    fi
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}

--- a/apps/x86_64-linux/lib/performance.sh
+++ b/apps/x86_64-linux/lib/performance.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Performance Monitoring Module for Build Scripts
+# Contains performance measurement and monitoring functions
+
+# Performance monitoring variables
+PERF_START_TIME=""
+PERF_BUILD_START_TIME=""
+PERF_SWITCH_START_TIME=""
+PERF_BUILD_DURATION=""
+PERF_SWITCH_DURATION=""
+
+# Performance monitoring functions
+perf_start_total() {
+    PERF_START_TIME=$(date +%s)
+}
+
+perf_start_phase() {
+    case "$1" in
+        "build")
+            PERF_BUILD_START_TIME=$(date +%s)
+            ;;
+        "switch")
+            PERF_SWITCH_START_TIME=$(date +%s)
+            ;;
+    esac
+}
+
+perf_end_phase() {
+    local end_time=$(date +%s)
+    case "$1" in
+        "build")
+            if [ -n "$PERF_BUILD_START_TIME" ]; then
+                PERF_BUILD_DURATION=$((end_time - PERF_BUILD_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Build phase completed in ${PERF_BUILD_DURATION}s"
+                fi
+            fi
+            ;;
+        "switch")
+            if [ -n "$PERF_SWITCH_START_TIME" ]; then
+                PERF_SWITCH_DURATION=$((end_time - PERF_SWITCH_START_TIME))
+                if command -v log_info >/dev/null 2>&1; then
+                    log_info "Switch phase completed in ${PERF_SWITCH_DURATION}s"
+                fi
+            fi
+            ;;
+    esac
+}
+
+perf_show_summary() {
+    if [ -n "$PERF_START_TIME" ]; then
+        local end_time=$(date +%s)
+        local total_duration=$((end_time - PERF_START_TIME))
+
+        echo ""
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo "${BLUE}  Performance Summary${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+        if [ -n "$PERF_BUILD_DURATION" ] && [ -n "$PERF_SWITCH_DURATION" ]; then
+            echo "${DIM}  Build phase:  ${PERF_BUILD_DURATION}s${NC}"
+            echo "${DIM}  Switch phase: ${PERF_SWITCH_DURATION}s${NC}"
+        fi
+        echo "${DIM}  Total time:   ${total_duration}s${NC}"
+        echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+    fi
+}
+
+# CPU core detection for parallel builds
+detect_optimal_jobs() {
+    local CORES
+
+    if command -v nproc >/dev/null 2>&1; then
+        # Linux
+        CORES=$(nproc)
+    elif command -v sysctl >/dev/null 2>&1; then
+        # macOS
+        CORES=$(sysctl -n hw.ncpu)
+    else
+        # Fallback
+        CORES=2
+    fi
+
+    # Check if we're in CI environment
+    if [ -n "$CI" ]; then
+        # CI: Use fewer cores to avoid overwhelming runners
+        CORES=$([ "$CORES" -gt 4 ] && echo 4 || echo "$CORES")
+    else
+        # Local development: Use more cores but cap at 8 for safety
+        CORES=$([ "$CORES" -gt 8 ] && echo 8 || echo "$CORES")
+    fi
+
+    # Return cores (minimum 1)
+    echo "$([ "$CORES" -gt 0 ] && echo "$CORES" || echo 1)"
+}

--- a/apps/x86_64-linux/lib/platform-config.sh
+++ b/apps/x86_64-linux/lib/platform-config.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Platform Configuration Module for Apply Scripts
+# Contains platform detection and configuration loading
+
+# Detect current platform
+detect_platform() {
+  local os=$(uname)
+  local arch=$(uname -m)
+
+  # Convert architecture names to Nix format
+  case "$arch" in
+    "arm64") arch="aarch64" ;;
+    "x86_64") arch="x86_64" ;;
+    *)
+      _print "${RED}Unsupported architecture: $arch${NC}"
+      exit 1
+      ;;
+  esac
+
+  # Convert OS names to Nix format
+  case "$os" in
+    "Darwin")
+      export PLATFORM_TYPE="darwin"
+      export PLATFORM_SYSTEM="$arch-darwin"
+      ;;
+    "Linux")
+      export PLATFORM_TYPE="linux"
+      export PLATFORM_SYSTEM="$arch-linux"
+      ;;
+    *)
+      _print "${RED}Unsupported operating system: $os${NC}"
+      exit 1
+      ;;
+  esac
+
+  export ARCH="$arch"
+  export OS="$os"
+
+  _print "${GREEN}Detected platform: $PLATFORM_SYSTEM${NC}"
+}
+
+# Load platform-specific configuration
+load_platform_config() {
+  detect_platform
+
+  local config_file="$(dirname "$0")/config.sh"
+
+  if [ -f "$config_file" ]; then
+    . "$config_file"
+    _print "${GREEN}Loaded platform config: $config_file${NC}"
+  else
+    _print "${YELLOW}Warning: No platform config found at $config_file${NC}"
+  fi
+}
+
+# Setup platform-specific environment
+setup_platform_environment() {
+  load_platform_config
+
+  # Linux-specific setup
+  if [ "$PLATFORM_TYPE" = "linux" ]; then
+    # Primary network interface detection
+    if command -v ip >/dev/null 2>&1; then
+      export PRIMARY_IFACE=$(ip -o -4 route show to default | awk '{print $5}')
+      _print "${GREEN}Found primary network interface: $PRIMARY_IFACE${NC}"
+    fi
+  fi
+}

--- a/apps/x86_64-linux/lib/sudo-management.sh
+++ b/apps/x86_64-linux/lib/sudo-management.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Sudo Management Module for Build Scripts
+# Contains privilege management and sudo-related functions
+
+# Sudo session management
+SUDO_REQUIRED=false
+
+# Basic sudo management functions
+check_current_privileges() {
+    [ "$(id -u)" -eq 0 ]
+}
+
+acquire_sudo_early() {
+    # Skip if already root
+    if check_current_privileges; then
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment - sudo may fail"
+        fi
+        return 0
+    fi
+
+    # Simple sudo validation
+    if ! sudo -v; then
+        if command -v log_error >/dev/null 2>&1; then
+            log_error "Failed to acquire sudo privileges"
+        fi
+        return 1
+    fi
+
+    if command -v log_success >/dev/null 2>&1; then
+        log_success "Sudo privileges acquired"
+    fi
+    return 0
+}
+
+# Register cleanup handlers
+register_cleanup() {
+    return 0
+}
+
+# Cleanup sudo session
+cleanup_sudo_session() {
+    return 0
+}
+
+# Explain why sudo is required for system changes
+explain_sudo_requirement() {
+    echo ""
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo "${BLUE}  Administrator Privileges Required${NC}"
+    echo "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "${YELLOW}▶ Why sudo is needed:${NC}"
+    echo "${DIM}  • System configuration changes require administrator privileges${NC}"
+    echo "${DIM}  • ${PLATFORM_NAME} rebuild commands must modify system files${NC}"
+    echo "${DIM}  • This ensures your system is properly configured and secure${NC}"
+    echo ""
+    echo "${YELLOW}▶ What will happen:${NC}"
+    echo "${DIM}  • You'll be prompted for your password once${NC}"
+    echo "${DIM}  • Privileges will be used only for system configuration${NC}"
+    echo "${DIM}  • Session will be cleaned up automatically when done${NC}"
+    echo ""
+}
+
+# Determine if sudo will be needed later
+check_sudo_requirement() {
+    # Skip if already root
+    if check_current_privileges; then
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Check if we're in non-interactive environment (Claude Code)
+    if [ ! -t 0 ]; then
+        if command -v log_warning >/dev/null 2>&1; then
+            log_warning "Non-interactive environment detected"
+        fi
+        if command -v log_info >/dev/null 2>&1; then
+            log_info "System changes will require manual sudo execution"
+        fi
+        SUDO_REQUIRED=false
+        return 0
+    fi
+
+    # Explain why sudo is needed
+    explain_sudo_requirement
+
+    SUDO_REQUIRED=true
+    return 0
+}
+
+get_sudo_prefix() {
+    if [ "$SUDO_REQUIRED" = "true" ]; then
+        echo "sudo"
+    else
+        echo ""
+    fi
+}

--- a/apps/x86_64-linux/lib/token-replacement.sh
+++ b/apps/x86_64-linux/lib/token-replacement.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Token Replacement Module for Apply Scripts
+# Contains logic for replacing tokens in configuration files
+
+# Replace tokens in a file
+replace_tokens_in_file() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  if [ ! -f "$file" ]; then
+    _print "${RED}Error: File not found: $file${NC}"
+    return 1
+  fi
+
+  # Replace common tokens
+  sed "s/REPLACE_USERNAME/$USERNAME/g; s/REPLACE_GIT_EMAIL/$GIT_EMAIL/g; s/REPLACE_GIT_NAME/$GIT_NAME/g" "$file" > "$temp_file"
+
+  # Move temp file back to original
+  mv "$temp_file" "$file"
+
+  _print "${GREEN}Tokens replaced in: $file${NC}"
+}
+
+# Replace tokens in multiple files
+replace_tokens() {
+  local target_dir="$1"
+
+  if [ ! -d "$target_dir" ]; then
+    _print "${RED}Error: Directory not found: $target_dir${NC}"
+    return 1
+  fi
+
+  _print "${YELLOW}Replacing tokens in configuration files...${NC}"
+
+  # Find and process configuration files
+  find "$target_dir" -type f \( -name "*.nix" -o -name "*.conf" -o -name "*.toml" \) | while read -r file; do
+    if grep -q "REPLACE_" "$file"; then
+      replace_tokens_in_file "$file"
+    fi
+  done
+
+  _print "${GREEN}Token replacement completed${NC}"
+}

--- a/apps/x86_64-linux/lib/ui-utils.sh
+++ b/apps/x86_64-linux/lib/ui-utils.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# UI Utilities Module for Apply Scripts
+# Contains color codes and UI helper functions
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Custom print function with OS-specific handling
+_print() {
+  if [ "$(uname)" = "Darwin" ]; then
+    echo -e "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Custom prompt function for user input
+_prompt() {
+  local message="$1"
+  local variable="$2"
+
+  _print "$message"
+  read -r $variable
+}
+
+# Ask for GitHub star (platform-specific)
+ask_for_star() {
+  local OS=$(uname)
+
+  _print "${YELLOW}Would you like to support my work by starring my GitHub repo? yes/no [yes]: ${NC}"
+  local response
+  read -r response
+  response=${response:-yes} # Set default response to 'yes' if input is empty
+
+  if echo "$response" | grep -qi "^y"; then
+    if [ "$OS" = "Darwin" ]; then
+      open "https://github.com/dustinlyons/nixos-config"
+    else
+      xdg-open "https://github.com/dustinlyons/nixos-config"
+    fi
+  fi
+}

--- a/apps/x86_64-linux/lib/user-input.sh
+++ b/apps/x86_64-linux/lib/user-input.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# User Input Module for Apply Scripts
+# Contains user information collection and validation
+
+# Fetch username from the system
+get_username() {
+  local username=$(whoami)
+
+  # If the username is 'nixos' or 'root', ask the user for their username
+  if [ "$username" = "nixos" ] || [ "$username" = "root" ]; then
+    _prompt "${YELLOW}You're running as $username. Please enter your desired username: ${NC}" username
+  fi
+
+  export USERNAME="$username"
+}
+
+# Get git configuration
+get_git_config() {
+  if command -v git >/dev/null 2>&1; then
+    # Fetch email and name from git config
+    export GIT_EMAIL=$(git config --get user.email)
+    export GIT_NAME=$(git config --get user.name)
+
+    # If either is empty, prompt for them
+    if [ -z "$GIT_EMAIL" ]; then
+      _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    fi
+
+    if [ -z "$GIT_NAME" ]; then
+      _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+    fi
+  else
+    # Git not available, ask for info
+    _prompt "${YELLOW}Please enter your email: ${NC}" GIT_EMAIL
+    _prompt "${YELLOW}Please enter your name: ${NC}" GIT_NAME
+  fi
+}
+
+# Collect all user information
+collect_user_info() {
+  get_username
+  get_git_config
+
+  # Display collected information
+  _print "${GREEN}Collected user information:${NC}"
+  _print "  Username: $USERNAME"
+  _print "  Email: $GIT_EMAIL"
+  _print "  Name: $GIT_NAME"
+}

--- a/tests/unit/test-logging-availability.sh
+++ b/tests/unit/test-logging-availability.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Unit test for logging.sh file availability in build-switch process
+
+set -e
+
+# Test configuration
+TEST_NAME="Logging Module Availability Test"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Colors for test output
+GREEN='\033[1;32m'
+RED='\033[1;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Test counter
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Test helper functions
+test_pass() {
+    echo -e "${GREEN}✅ PASS: $1${NC}"
+    ((TESTS_PASSED++))
+}
+
+test_fail() {
+    echo -e "${RED}❌ FAIL: $1${NC}"
+    ((TESTS_FAILED++))
+}
+
+test_info() {
+    echo -e "${YELLOW}ℹ️  INFO: $1${NC}"
+}
+
+# Test 1: Check if logging.sh exists in scripts/lib
+test_logging_exists_in_scripts_lib() {
+    local logging_path="$PROJECT_ROOT/scripts/lib/logging.sh"
+
+    if [ -f "$logging_path" ]; then
+        test_pass "logging.sh exists in scripts/lib directory"
+    else
+        test_fail "logging.sh missing from scripts/lib directory"
+    fi
+}
+
+# Test 2: Check if logging.sh should exist in apps/aarch64-darwin/lib
+test_logging_should_exist_in_apps_lib() {
+    local expected_path="$PROJECT_ROOT/apps/aarch64-darwin/lib/logging.sh"
+
+    if [ -f "$expected_path" ]; then
+        test_pass "logging.sh exists in apps/aarch64-darwin/lib directory"
+    else
+        test_fail "logging.sh missing from apps/aarch64-darwin/lib directory (expected by build-switch-common.sh)"
+    fi
+}
+
+# Test 3: Check if build-switch-common.sh references correct path
+test_build_switch_common_references() {
+    local common_script="$PROJECT_ROOT/scripts/build-switch-common.sh"
+
+    if [ -f "$common_script" ]; then
+        if grep -q 'LIB_DIR/logging.sh' "$common_script"; then
+            test_pass "build-switch-common.sh references logging.sh correctly"
+        else
+            test_fail "build-switch-common.sh does not reference logging.sh"
+        fi
+    else
+        test_fail "build-switch-common.sh not found"
+    fi
+}
+
+# Test 4: Check if apps/aarch64-darwin/lib directory exists
+test_apps_lib_directory_exists() {
+    local lib_dir="$PROJECT_ROOT/apps/aarch64-darwin/lib"
+
+    if [ -d "$lib_dir" ]; then
+        test_pass "apps/aarch64-darwin/lib directory exists"
+    else
+        test_fail "apps/aarch64-darwin/lib directory does not exist"
+    fi
+}
+
+# Test 5: Simulate build-switch-common.sh execution to verify loading
+test_simulate_logging_load() {
+    local common_script="$PROJECT_ROOT/scripts/build-switch-common.sh"
+
+    # Create temporary test environment
+    local temp_dir=$(mktemp -d)
+    local temp_script="$temp_dir/test-logging-load.sh"
+
+    # Create test script that mimics build-switch-common.sh logging load
+    cat > "$temp_script" << 'EOF'
+#!/bin/sh -e
+SCRIPT_DIR="$(dirname "$0")"
+LIB_DIR="$SCRIPT_DIR/lib"
+
+# Try to load logging.sh
+if [ -f "$LIB_DIR/logging.sh" ]; then
+    . "$LIB_DIR/logging.sh"
+    echo "SUCCESS: logging.sh loaded successfully"
+    exit 0
+else
+    echo "ERROR: logging.sh not found at $LIB_DIR/logging.sh"
+    exit 1
+fi
+EOF
+
+    chmod +x "$temp_script"
+
+    # Test from apps/aarch64-darwin context
+    local test_dir="$PROJECT_ROOT/apps/aarch64-darwin"
+    cd "$test_dir"
+
+    if bash -c "SCRIPT_DIR='$test_dir' $temp_script" 2>/dev/null; then
+        test_pass "logging.sh can be loaded from apps/aarch64-darwin context"
+    else
+        test_fail "logging.sh cannot be loaded from apps/aarch64-darwin context"
+    fi
+
+    # Cleanup
+    rm -rf "$temp_dir"
+    cd "$PROJECT_ROOT"
+}
+
+# Run all tests
+echo "Running $TEST_NAME"
+echo "=================================="
+
+test_logging_exists_in_scripts_lib
+test_logging_should_exist_in_apps_lib
+test_build_switch_common_references
+test_apps_lib_directory_exists
+test_simulate_logging_load
+
+echo ""
+echo "=================================="
+echo "Test Summary:"
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo "Total:  $((TESTS_PASSED + TESTS_FAILED))"
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

build-switch 명령어에서 logging.sh 모듈을 찾지 못하는 오류를 해결했습니다. 문제는 scripts/lib/에 있는 logging.sh 파일을 apps/{platform}/lib/ 경로에서 찾으려고 했기 때문입니다.

## Changes

- **lib 디렉토리 구조 생성**: 모든 플랫폼(aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux)에 lib 디렉토리 추가
- **공유 라이브러리 복사**: scripts/lib/의 모든 모듈을 각 플랫폼 lib 디렉토리로 복사
- **TDD 테스트 추가**: logging.sh 파일 가용성을 확인하는 포괄적인 테스트 스위트 작성

## Testing

- **Unit Tests**: tests/unit/test-logging-availability.sh 추가
  - logging.sh 파일 존재 여부 확인
  - build-switch-common.sh 참조 경로 검증  
  - 시뮬레이션을 통한 모듈 로딩 테스트
- **Manual Testing**: 
  - ✅ `nix run --impure .#build-switch` 명령어 정상 실행 확인
  - ✅ logging.sh 파일 경로 오류 해결
  - ✅ 빌드 단계 성공적 완료

## Test Plan

- [ ] CI 빌드 통과 확인
- [ ] 모든 플랫폼에서 build-switch 명령어 정상 작동
- [ ] logging 모듈 정상 로딩 확인
- [ ] 기존 기능 회귀 테스트