### PR TITLE
fix: CI 상태 결정 로직 수정 - main 브랜치에서 smoke test 결과 제외

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,12 +213,24 @@ jobs:
               echo "message=Draft PR smoke test failed" >> $GITHUB_OUTPUT
             fi
           else
-            if [[ "$build_result" == "success" && "$test_result" == "success" && "$smoke_result" == "success" ]]; then
-              echo "status=success" >> $GITHUB_OUTPUT
-              echo "message=Full CI pipeline completed successfully" >> $GITHUB_OUTPUT
+            # For main branch (push events), smoke test is skipped
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              if [[ "$build_result" == "success" && "$test_result" == "success" ]]; then
+                echo "status=success" >> $GITHUB_OUTPUT
+                echo "message=Full CI pipeline completed successfully" >> $GITHUB_OUTPUT
+              else
+                echo "status=failed" >> $GITHUB_OUTPUT
+                echo "message=Build or test stage failed" >> $GITHUB_OUTPUT
+              fi
             else
-              echo "status=failed" >> $GITHUB_OUTPUT
-              echo "message=Build, test, or smoke test stage failed" >> $GITHUB_OUTPUT
+              # For PR events, include smoke test
+              if [[ "$build_result" == "success" && "$test_result" == "success" && "$smoke_result" == "success" ]]; then
+                echo "status=success" >> $GITHUB_OUTPUT
+                echo "message=Full CI pipeline completed successfully" >> $GITHUB_OUTPUT
+              else
+                echo "status=failed" >> $GITHUB_OUTPUT
+                echo "message=Build, test, or smoke test stage failed" >> $GITHUB_OUTPUT
+              fi
             fi
           fi
 


### PR DESCRIPTION
## Summary
- main 브랜치에서 smoke test가 실행되지 않는데 상태 결정 로직에서 smoke test 결과를 체크하여 항상 실패하는 문제 수정
- push 이벤트와 PR 이벤트를 구분하여 상태 결정 로직 분리

## 문제 상황
- `smoke-test` 작업은 `if: github.event_name == 'pull_request'` 조건으로 PR에서만 실행
- 하지만 `ci-complete` 작업의 상태 결정 로직에서는 `smoke_result`를 항상 체크
- main 브랜치 push 시 smoke test가 실행되지 않아 결과가 빈 값이 되어 실패 처리됨

## 수정 내용
- push 이벤트에서는 build와 test 결과만 확인
- PR 이벤트에서는 기존처럼 smoke test 포함하여 확인

## Test plan
- [x] CI 워크플로우 로직 검증
- [ ] main 브랜치 push 시 CI 성공 확인
- [ ] PR 생성 시 기존 로직 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.ai/code)