### PR TITLE
feat: kakaotalk 패키지 추가

### DIFF
--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -8,6 +8,7 @@ _:
 
   # Communication Tools
   "discord"
+  "kakaotalk"
   "notion"
   "slack"
   "telegram"


### PR DESCRIPTION
## Summary
- macOS 환경에서 kakaotalk을 homebrew cask로 설치할 수 있도록 설정 추가
- casks.nix에 kakaotalk 패키지 추가

## Test plan
- [x] nix 빌드 테스트 완료
- [x] pre-commit 훅 검증 완료
- [ ] 사용자가 `nix run #build-switch` 실행하여 실제 설치 확인

🤖 Generated with [Claude Code](https://claude.ai/code)