### PR TITLE
fix: remove deprecated tmux modify-keys option

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -488,7 +488,6 @@ in
 
       # 키보드 설정
       set-window-option -g xterm-keys on
-      set-window-option -g modify-keys on
       set-option -g extended-keys on
       set -as terminal-features 'xterm*:extkeys'
 


### PR DESCRIPTION
## Summary
Fixes tmux configuration error by removing the deprecated `modify-keys` option that is no longer valid in tmux 3.5a.

## Problem
The tmux configuration was using `set-window-option -g modify-keys on` which causes the error:
```
/nix/store/gr9kgmzyj915c62g47m25a6xfqc7h01v-hm_tmuxtmux.conf:78: invalid option: modify-keys
```

## Solution
- Removed the deprecated `modify-keys` option from tmux configuration
- The functionality is already provided by the existing `extended-keys` option which is the modern replacement

## Changes
- **modules/shared/home-manager.nix**: Removed `set-window-option -g modify-keys on` line

## Testing
- ✅ All pre-commit hooks pass
- ✅ Nix flake check passes  
- ✅ Build validation passes
- ✅ tmux starts without configuration errors
- ✅ Extended keys functionality preserved through `extended-keys` option

## Test Plan
1. Apply configuration changes with `make switch`
2. Start tmux session to verify no configuration errors
3. Test extended key functionality in terminal

🤖 Generated with [Claude Code](https://claude.ai/code)