### PR TITLE
feat(nix): unfree 패키지 claude-code 허용

### DIFF
--- a/lib/system-configs.nix
+++ b/lib/system-configs.nix
@@ -23,6 +23,7 @@ in
         inherit system;
         specialArgs = inputs;
         modules = [
+          ../modules/shared/config/nixpkgs.nix
           home-manager.darwinModules.home-manager
           nix-homebrew.darwinModules.nix-homebrew
           {
@@ -50,6 +51,7 @@ in
         inherit system;
         specialArgs = inputs;
         modules = [
+          ../modules/shared/config/nixpkgs.nix
           disko.nixosModules.disko
           home-manager.nixosModules.home-manager
           {

--- a/modules/shared/config/nixpkgs.nix
+++ b/modules/shared/config/nixpkgs.nix
@@ -1,0 +1,5 @@
+{
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (pkg.pname or (builtins.parseDrvName pkg.name).name) [
+    "claude-code"
+  ];
+}

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -29,6 +29,7 @@ with pkgs; let
     direnv        # Environment variable management per directory
     pre-commit    # Pre-commit hooks framework
     gemini-cli    # Command-line interface for Gemini
+    claude-code  # AI code generation tool
     gnumake       # GNU make build automation tool
     cmake         # Cross-platform build system generator
     home-manager  # Nix-based user environment management


### PR DESCRIPTION
## 요약
Nix 시스템에 claude-code 패키지를 추가하고 unfree 라이선스 패키지를 허용하는 설정을 구성했습니다.

## 변경사항
- [x] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경

### 구체적 변경사항:
1. **modules/shared/config/nixpkgs.nix** (신규): unfree 패키지 허용 설정 추가
   - claude-code 패키지에 대한 allowUnfreePredicate 설정
2. **lib/system-configs.nix**: nixpkgs 설정 모듈을 Darwin/NixOS 설정에 통합
3. **modules/shared/packages.nix**: claude-code 패키지를 개발 도구 목록에 추가

## 테스트 계획
- [x] `make lint` 통과
- [x] `make smoke` 통과  
- [x] `nix run .#build-switch` 성공적으로 실행
- [x] claude-code 패키지 설치 확인 (v1.0.60)
- [x] 관련 플랫폼에서 테스트 완료

## 추가 정보
- claude-code는 unfree 라이선스를 사용하는 패키지입니다
- 새로운 nixpkgs.nix 모듈은 확장 가능한 구조로 설계되어 향후 다른 unfree 패키지 추가시에도 쉽게 관리할 수 있습니다
- 시스템 재빌드 후 터미널 재시작이 필요합니다

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함