### PR TITLE
fix(docs): resolve markdownlint MD040 error in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,11 @@ YAGNI above all. Simplicity over sophistication. When in doubt, ask jito.
 ```bash
 # Claude Code friendly (no export required)
 ./apps/aarch64-darwin/build-switch      # TDD: Simplified Home Manager only
+```
 
 ## Traditional commands
 
+```bash
 make help                    # Show all available targets
 make build-current          # Build current platform only (faster)
 make build-fast             # Build with optimizations


### PR DESCRIPTION
## Summary

Fix CI failing due to markdownlint MD040 error in CLAUDE.md where a markdown header was incorrectly placed inside a bash code block.

## Changes

- **CLAUDE.md**: Restructured code blocks in `<development-commands>` section
  - Separated bash code block that contained markdown header
  - Moved `## Traditional commands` header outside of code block
  - Created proper fenced code blocks with correct structure

## Root Cause Analysis

The CI was failing because:
1. Line 148 had `## Traditional commands` markdown header inside a bash code block
2. markdownlint rule MD040 requires proper fenced code block structure
3. Markdown headers should not be inside code blocks

## Test Plan

- [x] `make lint` passes locally
- [x] All pre-commit hooks pass
- [x] markdownlint specifically passes
- [x] No other linting errors introduced

## Verification

```bash
make lint  # All checks pass including markdownlint
```

🤖 Generated with [Claude Code](https://claude.ai/code)