### PR TITLE
fix: change tmux prefix key from C-a to C-b

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -576,7 +576,7 @@ in
         continuum
       ];
       terminal = "screen-256color";
-      prefix = "C-a";
+      prefix = "C-b";
       escapeTime = 0;
       historyLimit = 50000;
       extraConfig = ''


### PR DESCRIPTION
## Summary
Restore default tmux prefix key behavior from C-a back to C-b for better compatibility and user experience.

## Changes
- Modified `modules/shared/home-manager.nix` line 579: `prefix = "C-a";` → `prefix = "C-b";`
- Enables standard Ctrl+B key combinations that users expect from tmux

## Test plan
- [x] Build and apply configuration using `./apps/aarch64-darwin/build-switch`
- [x] Run smoke tests with `make smoke` - all passed
- [x] Run core tests with `make test-core` - all 4 tests passed
- [x] Run quick parallel tests with `make test-quick` - completed in 16 seconds
- [x] Verify tmux prefix key change is applied in new sessions

🤖 Generated with [Claude Code](https://claude.ai/code)