### PR TITLE
feat(claude): integrate claude-monitor tool via Nix wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,50 +1,113 @@
-# CLAUDE.md - Dotfiles Project
+# CLAUDE.md
 
-## jito's Dotfiles Development Assistant
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-@.claude/commands/*@.claude/agents/* @modules/shared/config/claude/MCP/*
+## Dotfiles Repository Context
 
-<dotfiles-expertise>
-**Nix/NixOS**: Flakes, Home Manager, nix-darwin, package management
-**Multi-platform**: macOS (Intel/ARM), NixOS (x86_64/ARM64)
-**Build System**: Makefile, scripts, performance optimization
-</dotfiles-expertise>
+This is a Nix-based dotfiles repository for macOS and NixOS systems, using Nix flakes, Home Manager, and nix-darwin.
 
-<architecture>
-- `flake.nix` - Main entry using lib/flake-config.nix
-- `lib/` - System utilities and platform detection
-- `modules/` - Configuration (shared/darwin/nixos)
-- `scripts/` - Automation tools, global `bl` command system
-</architecture>
+## Essential Commands
 
-<essential-commands>
+### Building and Applying Configurations
+
 ```bash
-./apps/aarch64-darwin/build-switch  # Claude Code compatible
-make test                           # Full test suite  
-make smoke                          # Quick validation
+# Always set USER first
+export USER=$(whoami)
+
+# Build and apply in one step (recommended)
+./apps/x86_64-linux/build-switch   # For NixOS
+./apps/aarch64-darwin/build-switch # For macOS ARM
+./apps/x86_64-darwin/build-switch  # For macOS Intel
+
+# Alternative: Use make commands
+make build          # Build all configurations
+make switch         # Build and apply current platform
+make build-switch   # One-step build and apply
 ```
-</essential-commands>
 
-<nix-best-practices>
-**Home Manager Architecture**:
-- `modules/shared/home-manager.nix`: Cross-platform only
-- `modules/darwin/home-manager.nix`: Darwin-specific + imports shared
-- **NEVER** import shared directly at system level
-- Use `lib.optionalString isDarwin/isLinux`
-</nix-best-practices>
+### Testing
 
-<claude-integration>
-**MCP**: Context7, Sequential, Playwright
-**Agents**: performance-optimizer, root-cause-analyzer, nix-system-expert
-**Commands**: `modules/shared/config/claude/` → `~/.claude`
-**연관 명령어**: /fix-pr, /update-pr, /create-pr, /save, /restore
-</claude-integration>
+```bash
+make test           # Run all tests
+make test-core      # Fast essential tests
+make test-workflow  # End-to-end workflow tests  
+make smoke          # Quick validation check
+```
 
-<testing-standards>
-**Commands**: `make test`, `make test-core`, `./scripts/test-all-local`
-**Required**: Unit + integration + e2e unless exempted
-</testing-standards>
+### Platform-Specific Operations
 
-<machine-setup-policies>
-All installations must be managed via Nix code. No ad-hoc installations.
-</machine-setup-policies>
+```bash
+# Direct Nix operations
+nix run --impure .#build         # Build current platform
+nix run --impure .#build-switch  # Build and apply with sudo handling
+nix run --impure .#test-core     # Run core tests directly
+```
+
+## Architecture
+
+### Core Structure
+- **`flake.nix`**: Main entry point using `lib/flake-config.nix`
+- **`lib/`**: System utilities, platform detection (`platform-system.nix`, `user-resolution.nix`)
+- **`modules/`**: Modular configurations
+  - `shared/`: Cross-platform configurations
+  - `darwin/`: macOS-specific settings
+  - `nixos/`: NixOS-specific settings
+- **`hosts/`**: System configurations (`darwin/default.nix`, `nixos/default.nix`)
+- **`scripts/`**: Build automation and utilities
+
+### Home Manager Architecture Rules
+- **`modules/shared/home-manager.nix`**: Contains ONLY cross-platform configurations
+- **`modules/darwin/home-manager.nix`**: Darwin-specific, imports shared
+- **`modules/nixos/home-manager.nix`**: NixOS-specific, imports shared
+- **NEVER import shared directly at system level** - always through platform modules
+- Use `lib.optionalString isDarwin/isLinux` for conditional configurations
+
+### Package Management
+- **`modules/shared/packages.nix`**: Core packages installed via Nix
+- **`modules/darwin/casks.nix`**: macOS GUI applications via Homebrew
+- **Python tools**: Managed via `uv` (fast Python package installer)
+- **All installations must be managed via Nix** - no ad-hoc installations
+
+### Build System
+- **Platform detection**: Automatic via `lib/platform-system.nix`
+- **User resolution**: Dynamic via `lib/user-resolution.nix`
+- **Build scripts**: Located in `apps/[platform]/build-switch`
+- **Common logic**: `scripts/build-switch-common.sh`
+
+## Claude Code Integration
+
+### MCP Servers
+- Context7, Sequential, Playwright configured
+- Setup: `make setup-mcp`
+
+### Custom Commands
+Located in `modules/shared/config/claude/commands/`:
+- `/analyze`, `/build`, `/commit`, `/create-pr`, `/debug`, `/implement`, `/spawn`, `/task`, `/test`
+- PR workflow: `/fix-pr`, `/update-pr`  
+- State management: `/save`, `/restore`
+
+### Specialized Agents
+Located in `modules/shared/config/claude/agents/`:
+- `backend-engineer`, `frontend-specialist`, `system-architect`, `test-automator`
+- `python-ultimate-expert`, `typescript-pro`, `golang-pro`
+- `debugger`, `code-reviewer`, `devops-engineer`
+
+### Configuration Activation
+Claude configurations are automatically deployed to `~/.claude/` during system build.
+
+## Testing Standards
+- **Required**: Unit + integration + E2E tests for all changes
+- **Test categories**: core, workflow, performance
+- **Quick validation**: `make smoke` before commits
+- **Full suite**: `make test` before PRs
+
+## Development Policies
+- **All installations via Nix** - maintain declarative configuration
+- **Platform-specific code** goes in respective modules (darwin/nixos)
+- **Cross-platform code** in shared modules with proper conditionals
+- **Test before commit** - use `make test-core` at minimum
+
+## Global Commands
+- **`bl`**: Custom command dispatcher system
+- Commands stored in `~/.bl/commands/`
+- Extensible through Nix configuration

--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -192,13 +192,7 @@ in
           (nohup "$HOME/dotfiles/scripts/auto-update-dotfiles" --silent &>/dev/null &)
         fi
 
-        # Auto-install claude-monitor via uv if not already installed
-        if command -v uv >/dev/null 2>&1; then
-          if ! uv tool list | grep -q "claude-monitor"; then
-            echo "Installing claude-monitor via uv..."
-            uv tool install claude-monitor
-          fi
-        fi
+        # Claude-monitor is now managed via Nix packages
 
         # IntelliJ IDEA 백그라운드 실행 함수 (platform-aware)
         idea() {

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -26,6 +26,9 @@ with pkgs; let
     python3Packages.pipx # Install Python applications in isolated environments
     virtualenv # Python virtual environment tool
     uv # Fast Python package installer
+    (pkgs.writeShellScriptBin "claude-monitor" ''
+      ${uv}/bin/uv tool run claude-monitor "$@"
+    '') # Claude monitor tool wrapper
     direnv # Environment variable management per directory
     pre-commit # Pre-commit hooks framework
     gemini-cli # Command-line interface for Gemini


### PR DESCRIPTION
## 요약
claude-monitor 도구를 Nix 래퍼를 통해 통합하여 선언적 패키지 관리를 구현합니다.

## 변경사항
- [x] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경

### 구체적인 변경내용
- `modules/shared/packages.nix`: claude-monitor를 uv tool로 실행하는 Nix 래퍼 스크립트 추가
- `modules/shared/home-manager.nix`: 자동 설치 로직 제거 (Nix로 관리)
- `CLAUDE.md`: Claude Code 설정 문서 업데이트

## 테스트 계획
- [x] `make lint` 통과
- [x] `make smoke` 통과
- [x] `make build` 통과
- [ ] 로컬에서 수동 테스트 완료
- [ ] 관련 플랫폼에서 테스트 완료

## 추가 정보
- claude-monitor는 이제 Nix 패키지로 관리되어 일관된 실행 환경을 보장합니다
- uv tool run을 통해 실행되므로 별도 설치 과정이 필요 없습니다
- 기존 자동 설치 로직을 제거하여 선언적 구성 원칙을 준수합니다

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함