### PR TITLE
수정: Claude 훅을 전역 설정으로 변경

### DIFF
--- a/modules/shared/config/claude/hooks/append_ultrathink.py
+++ b/modules/shared/config/claude/hooks/append_ultrathink.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+ULTRATHINK_MESSAGE = (
+    "Use the maximum amount of ultrathink. Take all the time you need. "
+    "It's much better if you do too much research and thinking than not enough."
+)
+
+def main():
+    try:
+        # Read input from stdin
+        input_data = json.loads(sys.stdin.read())
+
+        # Get the prompt
+        prompt = input_data.get("prompt", "")
+
+        # Check if prompt ends with -u flag (as a separate word)
+        stripped_prompt = prompt.strip()
+        if stripped_prompt.endswith(" -u"):
+            # Remove the -u flag
+            clean_prompt = stripped_prompt[:-3].rstrip()
+
+            # Append ultrathink message
+            prompt = f"{clean_prompt}\n\n{ULTRATHINK_MESSAGE}"
+
+            # Update the input data
+            input_data["prompt"] = prompt
+        elif stripped_prompt == "-u":
+            # Handle case where prompt is just "-u"
+            prompt = f"\n\n{ULTRATHINK_MESSAGE}"
+
+            # Update the input data
+            input_data["prompt"] = prompt
+
+        # Output the modified (or original) data
+        print(json.dumps(input_data))
+
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+    except KeyError as e:
+        print(f"Missing required key in input: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약
다른 프로젝트에서 Claude Code 사용 시 훅 경로 오류를 해결하기 위해 전역 설정으로 변경했습니다.

## 변경사항
- [x] 설정 변경

### 주요 수정사항
1. **훅 경로 전역화**: `~/.claude/settings.json`에서 프로젝트별 경로(`$CLAUDE_PROJECT_DIR`)를 전역 경로(`~/.claude/hooks/`)로 변경
2. **git-commit-validator.py**: 전역 경로 사용으로 모든 프로젝트에서 작동
3. **append_ultrathink.py**: 전역 경로 사용으로 일관성 보장

## 문제 해결
- `bamiro-server` 프로젝트에서 발생한 `not found` 오류 해결
- 다른 프로젝트에서도 Claude Code 훅이 정상 작동

## 테스트 계획
- [x] dotfiles 프로젝트에서 훅 정상 작동 확인
- [x] 다른 프로젝트에서 훅 경로 오류 해결 확인
- [x] pre-commit 훅 통과 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 모든 프로젝트에서 호환성 확보