### PR TITLE
refactor(darwin): migrate karabiner-elements from Nix to Homebrew

### DIFF
--- a/modules/darwin/casks.nix
+++ b/modules/darwin/casks.nix
@@ -17,6 +17,7 @@ _:
   # Utility Tools
   "alt-tab"
   "claude"
+  "karabiner-elements" # Key remapping and modification tool
   "tailscale-app" # VPN mesh network with GUI
 
   # Entertainment Tools

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -9,14 +9,6 @@ let
   user = getUserInfo.user;
   additionalFiles = import ./files.nix { inherit user config pkgs; };
 
-  # Karabiner-Elements v14.13.0 (v15.0+ has nix-darwin compatibility issues)
-  karabiner-elements-v14 = pkgs.karabiner-elements.overrideAttrs (old: {
-    version = "14.13.0";
-    src = pkgs.fetchurl {
-      url = "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v14.13.0/Karabiner-Elements-14.13.0.dmg";
-      hash = "sha256-gmJwoht/Tfm5qMecmq1N6PSAIfWOqsvuHU8VDJY8bLw="; # pragma: allowlist secret
-    };
-  });
 in
 {
   imports = [
@@ -60,7 +52,7 @@ in
 
       home = {
         enableNixpkgsReleaseCheck = false;
-        packages = (pkgs.callPackage ./packages.nix { }) ++ [ karabiner-elements-v14 ];
+        packages = pkgs.callPackage ./packages.nix { };
         file = lib.mkMerge [
           (import ../shared/files.nix { inherit config pkgs user self lib; })
           additionalFiles
@@ -80,18 +72,5 @@ in
   # Dock configuration moved to hosts/darwin/default.nix
   # See hosts/darwin/default.nix for dock settings
 
-  # Karabiner-Elements Nix Apps 연동
-  system.activationScripts.karabinerNixApps = {
-    text = ''
-      # Nix Apps 디렉토리에 Karabiner-Elements 심볼릭 링크 생성
-      mkdir -p "/Applications/Nix Apps"
-      rm -f "/Applications/Nix Apps/Karabiner-Elements.app"
-      ln -sf "${karabiner-elements-v14}/Applications/Karabiner-Elements.app" "/Applications/Nix Apps/Karabiner-Elements.app"
-
-      # Launch Services 호환성을 위한 메인 Applications 링크
-      rm -f "/Applications/Karabiner-Elements.app"
-      ln -sf "/Applications/Nix Apps/Karabiner-Elements.app" "/Applications/Karabiner-Elements.app"
-    '';
-  };
 
 }

--- a/modules/darwin/packages.nix
+++ b/modules/darwin/packages.nix
@@ -5,19 +5,10 @@ let
   # Import shared packages directly
   shared-packages = import ../shared/packages.nix { inherit pkgs; };
 
-  # Karabiner-Elements v14.13.0 (v15.0+ has nix-darwin compatibility issues)
-  karabiner-elements-v14 = karabiner-elements.overrideAttrs (old: {
-    version = "14.13.0";
-    src = fetchurl {
-      url = "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v14.13.0/Karabiner-Elements-14.13.0.dmg";
-      hash = "sha256-gmJwoht/Tfm5qMecmq1N6PSAIfWOqsvuHU8VDJY8bLw="; # pragma: allowlist secret
-    };
-  });
 
   # Platform-specific packages
   platform-packages = [
     dockutil
-    # karabiner-elements-v14 is handled in home-manager.nix
   ];
 in
 # Use the standardized merging pattern


### PR DESCRIPTION
## Summary

Simplifies Karabiner-Elements installation by migrating from a custom Nix derivation with version pinning to standard Homebrew Cask installation. This eliminates complex workarounds for nix-darwin v15+ compatibility issues while providing a more maintainable solution.

## Changes

### Files Modified
- **modules/darwin/casks.nix** ➕ Added `karabiner-elements` to Homebrew Cask list
- **modules/darwin/home-manager.nix** ➖ Removed custom `karabiner-elements-v14` override and system activation scripts  
- **modules/darwin/packages.nix** ➖ Removed version-pinned Karabiner-Elements derivation

### Code Changes
- ✅ **+1 insertion**: Added Karabiner-Elements to Homebrew Cask with descriptive comment
- ✅ **-31 deletions**: Removed complex Nix overrides, version pinning, and app linking scripts
- ✅ **Net reduction**: 30 lines of configuration code eliminated

## Benefits

### Maintenance
- **Simpler Configuration**: Eliminates custom Nix derivation overrides
- **Automatic Updates**: Leverages Homebrew's built-in update mechanism  
- **Reduced Complexity**: Removes system activation scripts and app linking logic

### Compatibility  
- **macOS Integration**: Better integration with macOS Launch Services
- **Version Management**: No more manual version pinning to work around nix-darwin issues
- **Future-Proof**: Avoids nix-darwin compatibility problems with Karabiner-Elements v15+

## Test Plan

- [ ] Verify Homebrew Cask installation: `brew list --cask | grep karabiner`
- [ ] Test application launch from Spotlight and Applications folder
- [ ] Confirm key remapping functionality works as expected
- [ ] Validate no broken symlinks remain in `/Applications/`

## Breaking Changes

⚠️ **Installation Method Change**: Users will need to:
1. Uninstall existing Nix-managed Karabiner-Elements: `nix-env --uninstall karabiner-elements`
2. Apply new configuration to install via Homebrew: `make build-switch`
3. Reconfigure any existing Karabiner-Elements settings

## Related Issues

Addresses potential compatibility issues with nix-darwin v15+ and simplifies the overall Darwin package management strategy.

🤖 Generated with [Claude Code](https://claude.ai/code)