### PR TITLE
refactor(claude): remove duplicate logic in ultrathink hook

### DIFF
--- a/modules/shared/config/claude/hooks/append_ultrathink.py
+++ b/modules/shared/config/claude/hooks/append_ultrathink.py
@@ -16,26 +16,8 @@ def main():
         # Get the prompt
         prompt = input_data.get("prompt", "")
 
-        # Check if prompt ends with -u flag (as a separate word)
+        # Check if -u flag is present
         stripped_prompt = prompt.strip()
-        if stripped_prompt.endswith(" -u"):
-            # Remove the -u flag
-            clean_prompt = stripped_prompt[:-3].rstrip()
-
-            # Append ultrathink message
-            prompt = f"{clean_prompt}\n\n{ULTRATHINK_MESSAGE}"
-
-            # Update the input data
-            input_data["prompt"] = prompt
-        elif stripped_prompt == "-u":
-            # Handle case where prompt is just "-u"
-            prompt = f"\n\n{ULTRATHINK_MESSAGE}"
-
-            # Update the input data
-            input_data["prompt"] = prompt
-
-        # For UserPromptSubmit, we can only add context, not modify the prompt
-        # Check if -u flag was used and add ultrathink context
         if stripped_prompt.endswith(" -u") or stripped_prompt == "-u":
             # Remove -u flag from original prompt and add ultrathink context
             if stripped_prompt == "-u":
@@ -46,7 +28,7 @@ def main():
             # Output the clean prompt and ultrathink message as context
             print(f"{clean_prompt}\n\n{ULTRATHINK_MESSAGE}")
         else:
-            # No modification needed, just pass through
+            # No -u flag, just pass through
             print(json.dumps(input_data))
 
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## 요약
Claude Code ultrathink hook에서 중복된 `-u` 플래그 처리 로직을 제거하여 코드를 단순화했습니다.

## 변경사항
- [x] 리팩토링
- [x] 코드 정리

### 세부 변경사항
- 중복된 `-u` 플래그 감지 및 처리 로직 제거
- 단일 조건문으로 간소화
- 20줄 코드 감소, 동일한 기능 유지

## 테스트 계획
- [x] `-u` 플래그가 있는 경우: 플래그 제거 후 ultrathink 컨텍스트 추가
- [x] `-u` 플래그만 있는 경우: 빈 프롬프트와 ultrathink 컨텍스트 생성  
- [x] 일반 프롬프트: JSON 그대로 전달
- [x] 동작 검증 완료

## 추가 정보
기존에 동일한 `-u` 플래그 처리가 두 번 구현되어 있었으나, 실제로는 두 번째 구현만 사용되고 있었습니다. 첫 번째 구현(라인 21-35)을 제거하여 코드 가독성과 유지보수성을 향상시켰습니다.

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함  
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 동작 테스트 완료