### PR TITLE
feat(ssh): improve connection stability with KeepAlive settings

### DIFF
--- a/modules/shared/home-manager.nix
+++ b/modules/shared/home-manager.nix
@@ -529,6 +529,9 @@ in
         Host *
           IdentitiesOnly yes
           AddKeysToAgent yes
+          ServerAliveInterval 60
+          ServerAliveCountMax 3
+          TCPKeepAlive yes
       '' + lib.optionalString isDarwin ''
         UseKeychain yes
       '';


### PR DESCRIPTION
## Summary

SSH 연결 안정성을 개선하기 위한 KeepAlive 설정을 추가했습니다. 네트워크 연결 불안정이나 강제 종료 시 발생하는 키 입력 문제를 해결합니다.

## Changes

- **SSH KeepAlive 설정 추가**:
  - `ServerAliveInterval 60`: 60초마다 연결 상태 확인
  - `ServerAliveCountMax 3`: 3번 실패 후 연결 종료  
  - `TCPKeepAlive yes`: TCP 레벨 연결 유지

## Problem Solved

SSH + tmux 사용 중 네트워크 연결이 불안정하거나 강제 종료될 때 발생하는 문제들:
- 키 입력이 정상적으로 처리되지 않음
- 터미널 상태와 원격 서버 간 동기화 실패
- tmux 세션 복구 후에도 키 매핑 문제 지속

## Test Plan

- [x] Nix 빌드 테스트 통과
- [x] Pre-commit hooks 모두 통과
- [ ] SSH 연결 테스트 (연결 후 네트워크 중단 시뮬레이션)
- [ ] tmux 세션 안정성 확인

## Technical Details

이 설정들은 모든 SSH 호스트에 적용되며:
- 정기적인 연결 상태 확인으로 좀비 연결 방지
- 네트워크 불안정 시 빠른 연결 재설정
- TCP 레벨에서의 연결 유지로 하위 레벨 안정성 확보

🤖 Generated with [Claude Code](https://claude.ai/code)