### PR TITLE
feat(claude): enhance command documentation and MCP guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ nix run --impure .#test-core     # Run core tests directly
 
 **Best Practices**: Refer to Context7 documentation for comprehensive Claude Code best practices, patterns, and implementation examples
 
+**Prompt Philosophy**:
+
+- **Token Efficiency**: 토큰 낭비 방지를 위해 간결하고 집중된 프롬프트 작성
+- **Duplication Prevention**: 기존 명령어와 중복 기능 체크 필수
+- **Convention Consistency**: 기존 프로젝트 컨벤션 및 패턴 준수 확인
+- **Permission Protocol**: 명령어/지시문 변경은 위험한 작업이므로 사용자 명시적 허락 필수
+- **Validation Requirements**: 새로운 명령어 생성 전 반드시 기존 구조 분석 및 검증
+
 ### Custom Commands
 
 Located in `modules/shared/config/claude/commands/`:

--- a/modules/shared/config/claude/commands/brainstorm.md
+++ b/modules/shared/config/claude/commands/brainstorm.md
@@ -1,64 +1,58 @@
 ---
 name: brainstorm
-description: "Transform vague ideas into concrete requirements through codebase analysis"
-agents: [system-architect, frontend-developer, backend-engineer]
+description: "Transform ideas into detailed specifications through systematic questioning"
+tools: [Write]
 ---
 
-# /brainstorm - Interactive Specification Development
+# /brainstorm - Iterative Specification Development
 
 **Purpose**: Ask me one question at a time so we can develop a thorough, step-by-step spec for this idea. Each question builds on my previous answers, and our end goal is to have a detailed specification I can hand off to a developer.
-
-## Usage
-
-```bash
-/brainstorm <idea>    # Interactive Q&A to develop detailed specification
-```
 
 ## How It Works
 
 1. You give me an idea
-2. I ask **one question at a time in Korean**
-3. Each question includes **numbered options** for easy selection
-4. Each question builds on your previous answers
-5. We continue until we have a complete spec
-6. I ask if you want me to save everything as `spec.md`
+2. I ask **one question at a time**
+3. Each question builds on your previous answers
+4. We continue until we have a complete spec
+5. I save the spec as `spec.md`
+6. Optionally, I can create a GitHub repository
 
-## Question Format
-
-Questions will be asked in Korean with numbered options:
-
-```
-질문: 이 앱을 주로 사용할 대상은 누구인가요?
-
-1. 일반 소비자
-2. 기업 직원
-3. 개발자/기술자
-4. 학생
-5. 기타 (직접 입력)
-
-번호를 선택하거나 직접 답변해주세요.
-```
-
-## Examples
+## Question Flow Example
 
 ```bash
-/brainstorm "team task tracker"
-# → "팀 업무 추적 시스템을 사용할 팀 규모는 어느 정도인가요?
-#    1. 소규모 팀 (3-10명)
-#    2. 중간 규모 팀 (10-50명)
-#    3. 대규모 팀 (50명 이상)"
+/brainstorm "team collaboration app"
+```
 
-/brainstorm "user login system"  
-# → "로그인 시스템이 필요한 애플리케이션 유형은 무엇인가요?
-#    1. 웹 애플리케이션
-#    2. 모바일 앱
-#    3. 데스크톱 애플리케이션
-#    4. API 서비스"
+```
+Q1: What's the main problem this app solves for teams?
+A1: Teams struggle to track who's working on what
 
-/brainstorm "mobile shopping app"
-# → "모바일 쇼핑 앱의 주요 목표는 무엇인가요?
-#    1. B2C 일반 소매
-#    2. B2B 기업간 거래
-#    3. C2C 중고거래
-#    4. 특정 카테고리 전문"
+Q2: What size teams are you targeting?
+A2: Small teams, 5-15 people
+
+Q3: Do they need real-time updates or is periodic sync enough?
+A3: Real-time is important for coordination
+
+Q4: What platforms do they need - web, mobile, desktop?
+A4: Web-first, mobile nice to have
+```
+
+## Final Output
+
+After our conversation, I will:
+
+1. **Summarize** everything we've discussed
+2. **Create `spec.md`** with:
+   - Project overview and objectives
+   - User requirements and workflows
+   - Technical requirements
+   - Success criteria
+3. **Ask if you want** a GitHub repository created
+
+## Next Step
+
+The `spec.md` becomes input for `/plan` to create implementation blueprint.
+
+```bash
+/brainstorm "idea" → spec.md → /plan → plan.md
 ```

--- a/modules/shared/config/claude/commands/do-plan.md
+++ b/modules/shared/config/claude/commands/do-plan.md
@@ -1,130 +1,77 @@
 ---
 name: do-plan
-description: "Execute plans step-by-step with progress tracking and smart assistance"
-agents: [project-manager, implementation-specialist]
-tools: [TodoWrite, Task]
+description: "Project manager approach: specification → technology selection → detailed planning"
+tools: [TodoWrite, Task, Write]
 ---
 
-# /do-plan - Sequential Plan Execution
+# /do-plan - Project Manager Blueprint
 
-**Purpose**: Execute planned tasks one by one in order, with progress tracking
+**Purpose**: You are an experienced, pragmatic software project manager who previously worked as an engineer. Your job is to craft a clear, detailed project plan, which will be passed to the engineering lead to turn into a set of work tickets to assign to engineers.
 
-## How It Works
+## Process
 
-### 1. Load Existing Plan
-- Takes the plan created by `/plan` command
-- Reads the checklist of tasks in order
-- Identifies the next uncompleted task
+### 1. Specification Gathering
+If the user hasn't provided a specification yet, ask them for one.
 
-### 2. Sequential Processing
-- **Execute one task at a time** in the planned order
-- Complete the current task fully before moving to next
-- Update task status (pending → in progress → completed)
-- Ask for confirmation before proceeding to next task
+### 2. Technology Selection & Approval
+Read through the spec, think about it, and propose a set of technology choices for the project to the user.
+**Stop and get feedback** from the user on those choices.
+**Iterate until the user approves.**
 
-### 3. Progress Tracking
-- Show which tasks are done, current, and remaining
-- Display overall progress percentage
-- Estimate time remaining based on completed tasks
+### 3. Detailed Blueprint Creation
+Draft a detailed, step-by-step blueprint for building this project.
 
-## Basic Usage
+### 4. Phase Breakdown
+Once you have a solid plan, break it down into small, iterative phases that build on each other.
+**Look at these phases and then go another round** to break them into small steps.
+Review the results and make sure that the steps are small enough to be implemented safely, but big enough to move the project forward.
+**Iterate until you feel that the steps are right sized** for this project.
 
-```bash
-/do-plan
+### 5. Plan Integration
+Integrate the whole plan into one list, organized by phase.
+Store the final iteration in `plan.md`.
+
+### 6. Final Handoff
+**STOP. ASK THE USER WHAT TO DO NEXT. DO NOT IMPLEMENT ANYTHING.**
+
+## Technology Selection Example
+
+```markdown
+## Technology Recommendations
+
+### Frontend
+**Recommendation: React with TypeScript**
+- Pros: Strong typing, large ecosystem, team familiarity
+- Cons: Learning curve, build complexity
+- Alternative: Vue.js (simpler, smaller learning curve)
+
+### Backend  
+**Recommendation: Node.js with Express**
+- Pros: JavaScript consistency, rapid development
+- Cons: Single-threaded limitations
+- Alternative: Python with FastAPI (better for data processing)
+
+Do you approve these technology choices?
 ```
 
-Example sequential execution:
-```
-📋 Login System Implementation - Task 3 of 8
+## Deliverables
 
-✅ COMPLETED TASKS:
-  ✅ Analyze current authentication system
-  ✅ Define security requirements
+- **Approved technology stack** with rationale
+- **`plan.md`** with detailed implementation phases
+- **Ready-to-assign work tickets** for engineering team
 
-🔄 CURRENT TASK:
-  🔄 Design database schema
-     Status: In progress - working on user table structure
-     Started: 15 minutes ago
+## Key Principles
 
-⏳ REMAINING TASKS:
-  ⏳ Develop authentication API
-  ⏳ Implement password hashing
-  ⏳ JWT token management
-  ⏳ Implement login form
-  ⏳ Error handling and validation
+- **Pragmatic approach**: Focus on implementable solutions
+- **Engineering background**: Realistic complexity assessment  
+- **Iterative delivery**: Break work into safe, meaningful phases
+- **Clear communication**: Plans readable by both managers and engineers
 
-Progress: 2/8 tasks complete (25%) | Current task ETA: 30 minutes
-```
+## Planning vs Implementation
 
-## Sequential Execution Features
+**This command is for PLANNING ONLY.**
+- Planning: technology selection, phase breakdown, work tickets
+- Implementation: handled by `/plan` or engineering teams
+- **Never cross into actual coding or implementation**
 
-### Task Focus
-- **One task at a time**: Complete current task before starting next
-- **Context switching prevention**: Stay focused on single objective
-- **Clear completion criteria**: Know exactly when task is done
-
-### Progress Management
-- **Linear progression**: Follow the planned sequence strictly
-- **Checkpoint confirmations**: Verify completion before advancing
-- **Rollback capability**: Return to previous task if needed
-
-### Smart Assistance & Automation
-- **Task-specific help**: Provide relevant guidance for current task
-- **Context retention**: Remember what was done in previous tasks
-- **Dependency validation**: Ensure prerequisites are met before proceeding
-
-### Automatic Task Tool Integration
-- **Complexity Detection**: Auto-detect tasks requiring 3+ implementation steps
-- **Immediate Task Usage**: Use Task tool automatically for complex tasks, no manual approach
-- **Smart Agent Selection**: Follows global agent auto-mapping rules from CLAUDE.md
-
-### Pre-Implementation Analysis
-- **Pattern Analysis**: Analyze existing codebase patterns before implementation
-- **Style Consistency**: Read similar files to understand conventions
-- **Architecture Alignment**: Verify new implementation fits existing patterns
-
-## Control Options
-
-During execution, you can:
-- Pause current task if needed
-- Resume paused work
-- Skip to next task if current one is complete
-- Go back to previous task if needed
-
-You can also request:
-- Current progress status
-- Overview of all tasks
-- Preview of upcoming tasks
-
-## Completion & Cleanup
-
-Upon completion, automatically:
-- Provide comprehensive results summary
-- Suggest running tests
-- Verify deployment readiness
-- Recommend follow-up tasks
-
-## Plan Integration
-
-Works directly with `/plan` output:
-- **Direct execution**: Start processing plan immediately after creation
-- **Sequential order**: Follow exact task sequence from plan
-- **Status updates**: Mark tasks complete in original plan structure
-- **Plan continuity**: Maintain connection to original planning context
-
-## Example Workflow
-
-```bash
-# 1. Create a plan
-/plan "Implement user authentication"
-
-# 2. Execute the plan sequentially  
-/do-plan
-```
-
-The system will:
-- Load the generated task list
-- Start with task #1
-- Complete it fully before moving to task #2
-- Continue until all tasks are done
-- Maintain focus on one task at a time
+**STOP. ASK THE USER WHAT TO DO NEXT. DO NOT IMPLEMENT ANYTHING.**

--- a/modules/shared/config/claude/commands/do-todo.md
+++ b/modules/shared/config/claude/commands/do-todo.md
@@ -1,0 +1,93 @@
+---
+name: do-todo
+description: "Execute todos systematically with proper planning, implementation, and tracking"
+tools: [TodoWrite, Task, Read, Write, Bash, Edit]
+---
+
+# /do-todo - Systematic Todo Execution
+
+**Purpose**: Open todo.md and methodically work through unchecked tasks with proper planning, implementation, testing, and documentation.
+
+## Process
+
+### 1. Task Selection
+- Open `todo.md` and find the first unchecked task
+- Select one task to focus on completely
+
+### 2. Planning Phase
+- Carefully plan how to implement the selected task
+- Document the plan as a detailed comment (like a GitHub issue)
+- Break down complex tasks into smaller steps if needed
+
+### 3. Implementation Phase
+- Create a new branch for the work
+- Write robust, well-documented code
+- Include comprehensive tests and debug logging
+- Verify all tests pass before proceeding
+
+### 4. Completion Phase
+- Commit changes with clear, descriptive messages
+- Open pull request referencing the planning documentation
+- Mark the completed item as checked in `todo.md`
+
+### 5. Move to Next Task
+- Return to step 1 and select the next unchecked task
+- Repeat the cycle systematically
+
+## Implementation Standards
+
+### Code Quality
+- **Robust implementation**: Handle edge cases and error conditions
+- **Clear documentation**: Code comments and README updates
+- **Consistent style**: Follow project conventions and patterns
+
+### Testing Requirements
+- **Comprehensive tests**: Unit tests for all new functionality
+- **Debug logging**: Proper logging for troubleshooting
+- **Test verification**: Ensure all tests pass before committing
+
+### Documentation
+- **Planning documentation**: Clear task breakdown and approach
+- **Commit messages**: Descriptive and linked to planning docs
+- **Progress tracking**: Keep `todo.md` updated with completion status
+
+## Example Workflow
+
+```bash
+/do-todo
+```
+
+**Process Example**:
+1. Opens `todo.md`, finds: "- [ ] Add user authentication system"
+2. Plans: "Implement JWT-based auth with login/logout endpoints"
+3. Creates branch: `feature/user-authentication`
+4. Implements: User model, auth middleware, login routes, tests
+5. Commits: "Add JWT authentication system - refs #planning-doc"
+6. Updates: `todo.md` marks "- [x] Add user authentication system"
+7. Moves to next unchecked item
+
+## Key Principles
+
+### Systematic Progression
+- One task at a time, completed fully before moving on
+- Proper planning prevents rushed implementations
+- Each task gets appropriate attention and quality
+
+### Quality Assurance
+- Tests must pass before marking tasks complete
+- Code review standards applied to all implementations
+- Documentation maintained throughout the process
+
+### Progress Tracking
+- `todo.md` serves as single source of truth for project status
+- Clear completion markers show what's done vs remaining
+- Planning documentation provides context for future reference
+
+## Integration with Other Commands
+
+```bash
+/plan → plan.md → extract todos → todo.md
+/do-todo → systematic execution of todo items
+```
+
+The command works best when `todo.md` contains well-defined, actionable tasks from the planning phase.

--- a/modules/shared/config/claude/commands/plan.md
+++ b/modules/shared/config/claude/commands/plan.md
@@ -1,91 +1,77 @@
 ---
 name: plan
-description: "Smart task planning with structured breakdown and execution preparation"
-agents: [system-architect, project-manager]
-tools: [TodoWrite, Task, ExitPlanMode]
+description: "Create implementation blueprints with LLM-ready code generation prompts"
+tools: [TodoWrite, Task, Write]
 ---
 
-# /plan - Smart Task Planning
+# /plan - Code Generation Blueprint
 
-**Purpose**: Analyze requirements and create actionable step-by-step plans
+**Purpose**: Draft a detailed, step-by-step blueprint for building this project. Break the plan into small, iterative chunks that build on each other, with specific prompts for code generation.
 
-## Planning Process
+## Methodology
 
-### 1. Requirements Analysis
-- Understand current situation and goals
-- Identify technical constraints
-- Assess required resources
+1. **Draft** detailed project blueprint
+2. **Break down** into small, iterative chunks
+3. **Review and refine** steps:
+   - Small enough to implement safely
+   - Big enough to move project forward
+4. **Create prompts** for LLM to implement each step
+5. **Prioritize** best practices and incremental progress
+6. **Integrate** code without orphaned segments
 
-### 2. Task Breakdown
-- Break large tasks into smaller units
-- Define dependencies for each step
-- Estimate time requirements
+## Output
 
-### 3. Execution Sequencing
-- Order tasks considering dependencies
-- Identify tasks that can run in parallel
-- Risk assessment and contingency planning
+Creates `plan.md` with implementation blueprint:
 
-## Usage Examples
+```markdown
+# Project Implementation Plan
 
-### Basic Usage
-```bash
-/plan "Implement new login system"
+## Phase 1: Foundation
+### Step 1.1: Project Setup
+```code
+Create basic project structure with package.json, .gitignore, and README.md
+Initialize with essential dependencies for React and Node.js
 ```
 
-**Example Output**:
-```
-## Login System Implementation Plan
-
-### Phase 1: Analysis & Design (2-3 hours)
-- [ ] Analyze current authentication system
-- [ ] Define security requirements
-- [ ] Design database schema
-
-### Phase 2: Backend Implementation (1-2 days)
-- [ ] Develop authentication API
-- [ ] Implement password hashing
-- [ ] JWT token management
-
-### Phase 3: Frontend Integration (1 day)
-- [ ] Implement login form
-- [ ] Token storage and management
-- [ ] Error handling and validation
-
-### Phase 4: Testing & Deployment (half day)
-- [ ] Write unit tests
-- [ ] Run integration tests
-- [ ] Deploy and monitor
+### Step 1.2: Database Schema  
+```code
+Design and implement user table schema in PostgreSQL
+Include fields: id, email, password_hash, created_at, updated_at
+Create migration file and run initial setup
 ```
 
-### API Development Planning
-```bash
-/plan "Build RESTful API server"
+## Phase 2: Authentication
+### Step 2.1: User Model
+```code
+Create User model with password hashing using bcrypt
+Implement validation for email format and password strength
+Add methods for password comparison and JWT token generation
+```
 ```
 
-### Refactoring Planning
-```bash
-/plan "Migrate existing codebase to TypeScript"
-```
+## Key Requirements
 
-## Useful Features
+### Code Generation Focus
+- Each step includes specific prompts for LLM implementation
+- Use ```code``` tags to mark prompt sections
+- Include context about what's been built so far
+- Ensure each prompt builds on previous work
 
-### Risk Identification
-Includes potential issues and solutions for each phase
+### Integration Continuity  
+- No orphaned code segments
+- Clear interfaces between components
+- Build each step on previous foundations
+- Test integration at each step
 
-### Dependency Management
-Clearly shows task order and bottlenecks
+### Step Sizing
+- Small enough: implement safely without breaking things
+- Big enough: meaningful progress toward project goals
+- Review and iterate until steps feel right-sized
 
-### Time Estimation
-Realistic work time predictions for schedule management
-
-## do-plan Integration
-
-Generated plans can be executed directly with `/do-plan`:
+## Usage
 
 ```bash
-# After plan generation
-/do-plan
+/plan "Build a task management API with authentication"
 ```
 
-Each phase is executed as a checklist with real-time progress tracking.
+The plan creates ready-to-use prompts that an LLM can implement step-by-step, with each phase building systematically on the previous work.


### PR DESCRIPTION
## 요약
Claude Code 명령어 문서화를 개선하고 MCP 도구 사용 가이드라인을 명확히 했습니다. 새로운 `/do-todo` 명령어를 추가하고 기존 명령어들의 설명을 보완했습니다.

## 변경사항
- [x] 기능 추가/수정 - `/do-todo` 명령어 추가
- [x] 문서 업데이트 - 명령어 문서 및 가이드라인 개선
- [x] 설정 변경 - CLAUDE.md MCP 도구 사용 지침 정리

### 구체적인 변경사항:
- **CLAUDE.md**: MCP 도구 사용 가이드라인 명확화 (Context7, Sequential Thinking, Serena, Playwright)
- **`/brainstorm`**: 반복적 명세 개발 프로세스 설명 개선
- **`/do-plan`**: 계획 vs 구현 구분 명확화, 계획 전용 명령어임을 강조
- **`/plan`**: 코드 생성 청사진 방법론 보완
- **`/do-todo`**: 새로운 작업 실행 워크플로우 명령어 추가

## 테스트 계획
- [x] `make lint` 통과
- [ ] `make smoke` 통과  
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [ ] 관련 플랫폼에서 테스트 완료

## 추가 정보
이 PR은 Claude Code 워크플로우를 더욱 명확하고 효율적으로 만들기 위한 문서화 개선에 집중했습니다:

1. **토큰 최적화**: MCP 도구 사용 시 배치 호출 권장사항 추가
2. **명령어 역할 명확화**: 각 명령어의 고유 목적과 사용 시점 구분
3. **워크플로우 연결성**: 명령어 간 연결고리 강화 (`/brainstorm` → `spec.md` → `/plan` → `plan.md`)

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함  
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함