### PR TITLE
feat(claude): disable Serena MCP server in rejected list

### DIFF
--- a/modules/shared/config/claude/settings.json
+++ b/modules/shared/config/claude/settings.json
@@ -420,7 +420,8 @@
   "enableAllProjectMcpServers": false,
   "rejectedMcpServers": [
     "playwright",
-    "magic"
+    "magic",
+    "serena"
   ],
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Summary
- Add Serena MCP server to rejectedMcpServers list in Claude settings
- Prevents automatic activation of Serena MCP for optimized configuration
- Maintains consistency with other disabled MCP servers (playwright, magic)

## Test plan
- [ ] Verify settings.json syntax is valid
- [ ] Confirm Serena MCP is properly disabled in Claude Code
- [ ] Test that existing MCP functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)