### PR TITLE
feat: improve build-switch support for non-NixOS Linux systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,9 +310,14 @@ build-switch: check-user
 		echo "🔄 Switching to new configuration..."; \
 		sudo -E env USER=$(USER) ./result/sw/bin/darwin-rebuild switch --impure --flake .#$${TARGET} $(ARGS) || { echo "❌ Switch failed!"; exit 1; }; \
 		unlink ./result; \
-	else \
+	elif [ -f /etc/NIXOS ]; then \
 		echo "🔨 Building and switching NixOS configuration..."; \
 		sudo -E USER=$(USER) SSH_AUTH_SOCK=$$SSH_AUTH_SOCK /run/current-system/sw/bin/nixos-rebuild switch --impure --flake .#$${TARGET} $(ARGS); \
+	else \
+		echo "ℹ️  Detected non-NixOS Linux system (Ubuntu, etc.)"; \
+		echo "🏠 Using Home Manager for user configuration instead"; \
+		echo "🚀 Running: nix run .#build-switch"; \
+		$(NIX) run --impure .#build-switch $(ARGS); \
 	fi; \
 	end_time=$$(date +%s); \
 	duration=$$((end_time - start_time)); \


### PR DESCRIPTION
## Summary

Enhanced the `build-switch` Makefile target to properly support non-NixOS Linux distributions (Ubuntu, Debian, etc.) by adding intelligent system detection and fallback logic.

## Changes

- **Enhanced Linux System Detection**: Added proper detection for NixOS vs non-NixOS Linux systems using `/etc/NIXOS` check
- **Home Manager Fallback**: Implemented fallback to `nix run .#build-switch` for non-NixOS systems like Ubuntu
- **Improved User Experience**: Added informative messages to clarify which build path is being used
- **Cross-Platform Compatibility**: Maintains existing Darwin and NixOS functionality while extending Linux support

## Technical Details

The change replaces a simple `else` clause with proper conditional logic:
- **Darwin**: Uses `darwin-rebuild switch` (unchanged)  
- **NixOS**: Uses `nixos-rebuild switch` when `/etc/NIXOS` exists (unchanged)
- **Non-NixOS Linux**: Falls back to Home Manager via `nix run .#build-switch` (new)

## Test Plan

- [ ] Test `make build-switch` on macOS (Darwin)
- [ ] Test `make build-switch` on NixOS systems  
- [ ] Test `make build-switch` on Ubuntu/Debian systems
- [ ] Verify user feedback messages are clear and helpful
- [ ] Ensure no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)