### PR TITLE
feat: add Git worktree management commands

### DIFF
--- a/modules/shared/config/claude/commands/create-worktrees.md
+++ b/modules/shared/config/claude/commands/create-worktrees.md
@@ -1,0 +1,87 @@
+---
+name: create-worktrees
+description: "Git worktree 관리를 위한 고급 기법 및 명령어 생성"
+---
+
+Git worktree를 효율적으로 관리하고 생성하는 고급 기법.
+
+**Usage**: `/create-worktrees [options]`
+
+## Git Worktree 관리 전략
+
+### 벌크 워크트리 생성
+
+여러 브랜치에 대해 동시에 워크트리를 생성합니다.
+
+```bash
+#!/bin/bash
+
+# GitHub CLI 인증 확인
+gh auth status || { echo "GitHub CLI 인증이 필요합니다"; exit 1; }
+
+# 워크트리 기본 디렉토리 생성
+mkdir -p ./worktrees
+
+# 모든 브랜치 조회 후 처리
+gh api repos/:owner/:repo/branches --jq '.[].name' | while read -r branch; do
+    worktree_path="./worktrees/${branch}"
+
+    # 기존 워크트리 건너뛰기
+    if [ ! -d "$worktree_path" ]; then
+        git worktree add "$worktree_path" "origin/$branch"
+        echo "워크트리 생성: $branch"
+    else
+        echo "기존 워크트리 건너뛰기: $branch"
+    fi
+done
+```
+
+### 개별 워크트리 생성
+
+특정 브랜치에 대한 대화식 워크트리 생성.
+
+```bash
+#!/bin/bash
+
+# 브랜치 정보 입력 요청
+read -p "브랜치 이름: " branch_name
+read -p "기본 브랜치 (선택사항): " base_branch
+
+# 워크트리 생성 (기본 브랜치 옵션 포함)
+git worktree add -b "$branch_name" "./worktrees/$branch_name" "${base_branch:-HEAD}"
+echo "워크트리 생성 완료: $branch_name"
+```
+
+## 고급 워크트리 패턴
+
+### 네스티드 브랜치 구조 지원
+
+```bash
+# feature/ui/button → worktrees/feature-ui-button
+sanitized_name=$(echo "$branch_name" | sed 's/\//-/g')
+git worktree add "./worktrees/$sanitized_name" "$branch_name"
+```
+
+### 워크트리 정리 및 관리
+
+```bash
+# 삭제된 브랜치의 워크트리 정리
+git worktree prune
+
+# 모든 워크트리 상태 확인
+git worktree list
+```
+
+## 프로젝트별 설정
+
+- **큰 리포지터리**: 선택적 브랜치 워크트리 생성
+- **팀 협업**: 공통 워크트리 네이밍 규칙 적용
+- **CI/CD 통합**: 자동화된 워크트리 관리
+
+## 보안 고려사항
+
+- 민감한 브랜치 제외 로직
+- 워크트리별 환경 변수 격리
+- 임시 워크트리 자동 정리
+
+What would you like me to help you create worktrees for?

--- a/modules/shared/config/claude/commands/delete-worktrees.md
+++ b/modules/shared/config/claude/commands/delete-worktrees.md
@@ -1,0 +1,121 @@
+---
+name: delete-worktrees
+description: "Git worktree 삭제 및 정리를 위한 안전한 관리 도구"
+---
+
+Git worktree를 안전하게 삭제하고 정리하는 도구.
+
+**Usage**: `/delete-worktrees [options]`
+
+## Git Worktree 삭제 전략
+
+### 벌크 워크트리 정리
+
+병합된 브랜치의 워크트리를 일괄 정리합니다.
+
+```bash
+#!/bin/bash
+
+# 병합된 브랜치 확인 후 워크트리 삭제
+git branch --merged main | grep -v main | while read -r branch; do
+    worktree_path="./worktrees/${branch// /}"
+
+    if [ -d "$worktree_path" ]; then
+        echo "병합된 브랜치 워크트리 삭제: $branch"
+        git worktree remove "$worktree_path" --force
+    fi
+done
+
+# 고아 워크트리 정리
+git worktree prune
+echo "워크트리 정리 완료"
+```
+
+### 선택적 워크트리 삭제
+
+대화식으로 특정 워크트리를 선택하여 삭제합니다.
+
+```bash
+#!/bin/bash
+
+echo "현재 워크트리 목록:"
+git worktree list
+
+echo ""
+read -p "삭제할 워크트리 경로: " worktree_path
+
+# 안전성 확인
+if [ -d "$worktree_path" ]; then
+    read -p "정말로 '$worktree_path'를 삭제하시겠습니까? (y/N): " confirm
+
+    if [[ $confirm == [yY] ]]; then
+        git worktree remove "$worktree_path"
+        echo "워크트리 삭제 완료: $worktree_path"
+    else
+        echo "삭제 취소됨"
+    fi
+else
+    echo "워크트리를 찾을 수 없습니다: $worktree_path"
+fi
+```
+
+## 고급 정리 패턴
+
+### 오래된 워크트리 자동 정리
+
+```bash
+# 30일 이상 미사용 워크트리 찾기
+find ./worktrees -type d -atime +30 -name "*.git" | while read -r git_dir; do
+    worktree_path=$(dirname "$git_dir")
+    echo "오래된 워크트리 발견: $worktree_path"
+    # 추가 확인 로직 필요
+done
+```
+
+### 브랜치 상태별 정리
+
+```bash
+# 원격에서 삭제된 브랜치의 워크트리 정리
+git remote prune origin
+git worktree list | grep -v "bare\|main" | while read -r worktree_info; do
+    worktree_path=$(echo "$worktree_info" | awk '{print $1}')
+    branch_name=$(echo "$worktree_info" | awk '{print $3}' | sed 's/\[//;s/\]//')
+
+    if ! git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+        echo "원격에서 삭제된 브랜치 워크트리: $worktree_path"
+        git worktree remove "$worktree_path" --force
+    fi
+done
+```
+
+## 안전장치
+
+### 변경사항 확인
+
+```bash
+# 삭제 전 미커밋 변경사항 확인
+if [ -n "$(git -C "$worktree_path" status --porcelain)" ]; then
+    echo "경고: 커밋되지 않은 변경사항이 있습니다"
+    git -C "$worktree_path" status --short
+    read -p "그래도 삭제하시겠습니까? (y/N): " force_confirm
+    [[ $force_confirm != [yY] ]] && exit 1
+fi
+```
+
+### 백업 생성
+
+```bash
+# 중요한 워크트리 삭제 전 백업
+backup_path="./backups/$(basename "$worktree_path")-$(date +%Y%m%d)"
+cp -r "$worktree_path" "$backup_path"
+echo "백업 생성: $backup_path"
+```
+
+## 정리 규칙
+
+- **병합된 브랜치**: 자동 정리 대상
+- **스태시 있는 워크트리**: 수동 확인 필요
+- **미커밋 변경사항**: 경고 후 사용자 확인
+- **메인 브랜치**: 삭제 금지
+
+What worktrees would you like me to help you clean up?

--- a/modules/shared/config/claude/settings.json
+++ b/modules/shared/config/claude/settings.json
@@ -30,9 +30,8 @@
     ],
     "deny": []
   },
-  "model": "sonnet",
+  "model": "opusplan",
   "enableAllProjectMcpServers": true,
-  "rejectedMcpServers": [],
   "hooks": {
     "PreToolUse": [
       {
@@ -67,11 +66,12 @@
       }
     ]
   },
-  "feedbackSurveyState": {
-    "lastShownTime": 1755225425616
-  },
   "statusLine": {
     "type": "command",
     "command": "input=$(cat); current_dir=\"$(echo \"$input\" | jq -r '.workspace.current_dir')\"; model_name=\"$(echo \"$input\" | jq -r '.model.display_name')\"; printf '\\033[2m'; if git rev-parse --git-dir >/dev/null 2>&1; then branch=$(git branch --show-current 2>/dev/null || echo 'detached'); status=''; if [ -n \"$(git status --porcelain 2>/dev/null)\" ]; then status='*'; fi; printf '\\033[34m%s \\033[32m%s%s\\033[0m' \"$(basename \"$current_dir\")\" \"$branch\" \"$status\"; else printf '\\033[34m%s\\033[0m' \"$(basename \"$current_dir\")\"; fi; if [ -n \"${IN_NIX_SHELL:-}\" ] && [ \"${name:-}\" != \"nix-shell\" ] && [ \"${name:-}\" != \"shell\" ]; then printf ' \\033[44m\\033[37m %s \\033[0m' \"$name\"; elif [ -n \"${IN_NIX_SHELL:-}\" ]; then printf ' \\033[44m\\033[37m nix \\033[0m'; fi; printf ' \\033[90m%s\\033[0m\\033[0m' \"$model_name\""
+  },
+  "rejectedMcpServers": [],
+  "feedbackSurveyState": {
+    "lastShownTime": 1755225425616
   }
 }


### PR DESCRIPTION
## 요약

Git worktree를 효율적으로 관리할 수 있는 두 가지 새로운 Claude 명령어를 추가했습니다:

- `/create-worktrees`: 워크트리 생성 및 벌크 관리
- `/delete-worktrees`: 안전한 워크트리 삭제 및 정리

## 변경사항

- ✅ **create-worktrees 명령어**: GitHub CLI 통합, 벌크 생성, 대화식 개별 생성
- ✅ **delete-worktrees 명령어**: 병합된 브랜치 자동 정리, 안전장치, 백업 기능
- ✅ **고급 패턴 지원**: 네스티드 브랜치, 오래된 워크트리 감지, 상태별 정리
- ✅ **안전성 강화**: 미커밋 변경사항 보호, 변경사항 확인, 백업 생성

## 주요 기능

### create-worktrees
- GitHub CLI를 활용한 모든 브랜치 워크트리 일괄 생성
- 대화식 개별 워크트리 생성
- 네스티드 브랜치 구조 지원 (feature/ui/button → worktrees/feature-ui-button)
- 기존 워크트리 중복 생성 방지

### delete-worktrees
- 병합된 브랜치의 워크트리 자동 정리
- 원격에서 삭제된 브랜치 워크트리 감지 및 정리
- 30일 이상 미사용 워크트리 찾기
- 삭제 전 미커밋 변경사항 확인 및 백업 생성

## 테스트 계획

- [ ] `/create-worktrees` 명령어 기본 동작 확인
- [ ] `/delete-worktrees` 명령어 안전장치 테스트
- [ ] GitHub CLI 연동 기능 검증
- [ ] 네스티드 브랜치 이름 sanitization 확인
- [ ] 백업 및 복구 기능 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)