### PR TITLE
Update Nix flake dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755825449,
-        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
+        "lastModified": 1757015938,
+        "narHash": "sha256-1qBXNK/QxEjCqIoA2DxWn5gqM8rVxt+OxKodXu1GLTY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
+        "rev": "eaacfa1101b84225491d2ceae9549366d74dc214",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756734952,
-        "narHash": "sha256-H6jmduj4QIncLPAPODPSG/8ry9lpr1kRq6fYytU52qU=",
+        "lastModified": 1756991914,
+        "narHash": "sha256-4ve/3ah5H/SpL2m3qmZ9GU+VinQYp2MN1G7GamimTds=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29ab63bbb3d9eee4a491f7ce701b189becd34068",
+        "rev": "b08f8737776f10920c330657bee8b95834b7a70f",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1756767428,
-        "narHash": "sha256-JViyn7YdCzA5NdSrtNV7eXuLsQ4oTWcpaa35iDv9HSM=",
+        "lastModified": 1757045758,
+        "narHash": "sha256-SIGi6BtwGwkV6/dm3KedVrGZbqpPk47LCVTFu3cEBRA=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "f99be8a6db7139afad94955c68765123dad2e006",
+        "rev": "17142088a4568f8c71723b6018e1a9790715a828",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1756770126,
-        "narHash": "sha256-M9SVavjRviIJzlLirT3qy9CgndZq375rMukzGnz3y2k=",
+        "lastModified": 1757042462,
+        "narHash": "sha256-5kcQCwC7i7nKHzFKHoPju3iy5va0ghq3C8OHk6Z+1s4=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "713de0aa9c75a9a646f5c664f8a7c0a20178c503",
+        "rev": "24f97a7220a3f1c442165812f2b090f3299c5709",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates all Nix flake dependencies to their latest versions
- Includes updates to nix-darwin, home-manager, homebrew repositories, and nixpkgs
- Maintains compatibility with existing dotfiles configuration

## Changes
- **nix-darwin**: Updated from 8df64f8 to eaacfa1
- **home-manager**: Updated from 29ab63b to b08f873  
- **homebrew-cask**: Updated from f99be8a to 1714208
- **homebrew-core**: Updated from 713de0a to 24f97a7
- **nixpkgs**: Updated from d7600c7 to d0fc308

## Test plan
- [ ] Build succeeds on macOS (`make build-switch`)
- [ ] Build succeeds on NixOS (`make build-switch`) 
- [ ] Smoke tests pass (`make smoke`)
- [ ] No breaking changes to existing configuration

🤖 Generated with [Claude Code](https://claude.ai/code)