### PR TITLE
refactor(claude): remove WorktreeCreate hook from settings.json

### DIFF
--- a/users/shared/.config/claude/settings.json
+++ b/users/shared/.config/claude/settings.json
@@ -50,18 +50,7 @@
   "skipDangerousModePermissionPrompt": true,
   "installMethod": "native",
   "rejectedMcpServers": [],
-  "hooks": {
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'INPUT=$(cat); NAME=$(echo \"$INPUT\" | jq -r .name); CWD=$(echo \"$INPUT\" | jq -r .cwd); DIR=\"$CWD/.worktrees/$NAME\"; git -C \"$CWD\" worktree add -b \"worktree/$NAME\" \"$DIR\" >&2 && echo \"$DIR\"'"
-          }
-        ]
-      }
-    ]
-  },
+  "hooks": {},
   "feedbackSurveyState": {
     "lastShownTime": 1755225425616
   }


### PR DESCRIPTION
## Summary
- settings.json에서 WorktreeCreate 훅을 제거하여 플러그인으로 이전 준비

## Changes
- `users/shared/.config/claude/settings.json`에서 WorktreeCreate 훅 블록 제거
- `hooks` 필드를 빈 객체로 변경

## Test plan
- [ ] `make test` 통과 확인
- [ ] 새 worktree 생성 시 플러그인으로 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated git worktree branch creation functionality from configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->