### PR TITLE
fix(home-manager): replace removed mysql80 package

### DIFF
--- a/tests/unit/database-packages-test.nix
+++ b/tests/unit/database-packages-test.nix
@@ -1,0 +1,24 @@
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  homeManagerSource = builtins.readFile ../../users/shared/home-manager.nix;
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "database-packages" [
+    (helpers.assertTest "mysql80-removed-from-home-manager" (
+      !(lib.hasInfix "mysql80" homeManagerSource)
+    ) "home-manager.nix should not reference removed mysql80 package")
+
+    (helpers.assertTest "mariadb-client-added-to-home-manager" (
+      lib.hasInfix "mariadb.client" homeManagerSource
+    ) "home-manager.nix should use mariadb.client instead of mysql80")
+  ];
+}

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -24,7 +24,7 @@
 #   - Terminal: ghostty, htop, starship
 #   - Fonts: noto-fonts-cjk-sans, cascadia-code, d2coding
 #   - Media: ffmpeg
-#   - Databases: postgresql, sqlite, redis, mysql80
+#   - Databases: postgresql, sqlite, redis, mariadb.client
 #
 
 {
@@ -138,7 +138,7 @@
       postgresql
       sqlite
       redis
-      mysql80
+      mariadb.client
 
       # Productivity tools
       bc


### PR DESCRIPTION
## Summary
- replace removed `mysql80` package reference with `mariadb.client` in Home Manager packages
- update the database package comment to match the new package
- add a regression test that prevents reintroducing `mysql80`

## Tests
- [x] `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test suite to validate database package configurations.

* **Bug Fixes**
  * Updated database tools configuration to use MariaDB client instead of MySQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->