### PR TITLE
feat(zsh): refresh Claude wrapper model defaults

### DIFF
--- a/tests/unit/zsh-claude-wrappers-test.nix
+++ b/tests/unit/zsh-claude-wrappers-test.nix
@@ -71,11 +71,11 @@ in
       (assertInitHas "cc-parse-set-positional" "set --")
     ]
 
-    # 4. cco requires CCO_ env vars (no silent fallback)
+    # 4. cco allows env overrides with built-in fallback values
     ++ [
-      (assertInitHas "cco-requires-sonnet-env" "CCO_SONNET_MODEL:?Set")
-      (assertInitHas "cco-high-requires-env"   "CCO_OPUS_MODEL:?Set")
-      (assertInitHas "cco-low-requires-env"    "CCO_HAIKU_MODEL:?Set")
+      (assertInitHas "cco-sonnet-env-override" "CCO_SONNET_MODEL:-")
+      (assertInitHas "cco-high-env-override"   "CCO_OPUS_MODEL:-")
+      (assertInitHas "cco-low-env-override"    "CCO_HAIKU_MODEL:-")
     ]
 
     # 5. ccz requires CCZ_ env vars (no silent fallback)

--- a/users/shared/zsh/claude-wrappers.nix
+++ b/users/shared/zsh/claude-wrappers.nix
@@ -1,7 +1,7 @@
 # Claude Code wrapper functions for Zsh
 #
 # Returns a pure string of shell code defining:
-#   cc/cc-h/cc-l:    Anthropic API (sonnet/opus/haiku)
+#   cc/cc-h/cc-l:    Anthropic API (Sonnet 4.6 / Opus 4.6 / Haiku 4.5)
 #   cco/cco-h/cco-l: OpenAI-compatible proxy
 #   ccz/ccz-h/ccz-l: Z.ai GLM API
 #   cck:             Kimi API via OpenAI-compatible proxy
@@ -63,7 +63,7 @@
   }
 
   cc() {
-    eval "$(_cc_parse_model_flags "" "opus" "haiku" model "$@")"
+    eval "$(_cc_parse_model_flags "claude-sonnet-4-6" "opus[1m]" "claude-haiku-4-5" model "$@")"
     ENABLE_TOOL_SEARCH=true _cc_run "$model" "$@"
   }
 
@@ -82,7 +82,7 @@
   }
 
   cco() {
-    eval "$(_cc_parse_model_flags "''${CCO_SONNET_MODEL:?Set CCO_SONNET_MODEL in ~/.zshrc.local}" "''${CCO_OPUS_MODEL:?Set CCO_OPUS_MODEL in ~/.zshrc.local}" "''${CCO_HAIKU_MODEL:?Set CCO_HAIKU_MODEL in ~/.zshrc.local}" model "$@")"
+    eval "$(_cc_parse_model_flags "''${CCO_SONNET_MODEL:-claude-sonnet-4-6}" "''${CCO_OPUS_MODEL:-claude-opus-4-6}" "''${CCO_HAIKU_MODEL:-claude-haiku-4-5}" model "$@")"
     _cco_run "$model" "$@"
   }
 


### PR DESCRIPTION
## Summary
- refresh `cc` defaults to the latest official Claude model aliases
- set `cc -h` to use the 1M context Opus selector
- allow `cco` to fall back to latest Claude model aliases when local overrides are unset

## Changes
- update `cc` model defaults to `claude-sonnet-4-6`, `opus[1m]`, and `claude-haiku-4-5`
- update `cco` fallback defaults to latest official aliases
- relax the zsh wrapper unit test to verify env-override fallback behavior instead of exact version strings

## Tests
- [x] `export USER=$(whoami) && nix build --impure '.#checks.aarch64-darwin.unit-zsh-claude-wrappers'`