### PR TITLE
feat(claude): show login email in statusline

### DIFF
--- a/users/shared/.config/claude/statusline.sh
+++ b/users/shared/.config/claude/statusline.sh
@@ -39,6 +39,17 @@ readonly BOLD=$'\033[1m'       # Bold text
 # Read JSON input from stdin
 input=$(cat)
 
+# Login indicator: show email local part (before @) in green
+login_indicator=""
+whoami_json=$(timeout 0.5 claude auth status 2>/dev/null || echo "")
+if [[ -n "$whoami_json" ]]; then
+    email=$(echo "$whoami_json" | jq -r '.email // empty')
+    if [[ -n "$email" ]]; then
+        email_local="${email%%@*}"
+        login_indicator="${GREEN}${email_local}${RESET} ${GRAY}│${RESET} "
+    fi
+fi
+
 # Extract data from JSON input using single jq call for performance
 # Use tab as IFS to handle spaces in model names correctly
 IFS=$'\t' read -r model_name current_dir <<< "$(echo "$input" | jq -r '[
@@ -184,9 +195,9 @@ fi
 
 # Build output string
 if [[ -n "$ctx_display" ]]; then
-    output_string="${BOLD}${BLUE}${model_name}${RESET} ${GRAY}│${RESET} ${CYAN}${ctx_display}${RESET} ${GRAY}│${RESET} ${PURPLE}${dir_display}${RESET}"
+    output_string="${login_indicator}${BOLD}${BLUE}${model_name}${RESET} ${GRAY}│${RESET} ${CYAN}${ctx_display}${RESET} ${GRAY}│${RESET} ${PURPLE}${dir_display}${RESET}"
 else
-    output_string="${BOLD}${BLUE}${model_name}${RESET} ${GRAY}│${RESET} ${PURPLE}${dir_display}${RESET}"
+    output_string="${login_indicator}${BOLD}${BLUE}${model_name}${RESET} ${GRAY}│${RESET} ${PURPLE}${dir_display}${RESET}"
 fi
 
 if [[ -n "$git_info" ]]; then


### PR DESCRIPTION
## Summary
- statusline 맨 좌측에 `claude auth status`로 로그인된 이메일의 local part를 초록색으로 표시
- 예: `claude.ai.2025 │ Opus 4.6 │ 50k │ ~/dotfiles │ main`

## Changes
- `claude auth status`에서 이메일 추출, `@` 앞부분만 표시
- 로그인 안 된 경우 인디케이터 생략

## Test plan
- [ ] `make switch` 후 statusline에 이메일 표시 확인
- [ ] 로그아웃 상태에서 인디케이터 미표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authenticated user indicator to the statusline, displaying your email prefix in green
  * Gracefully handles cases where authentication status is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->