### PR TITLE
fix(homebrew): use full tap path for im-select formula

### DIFF
--- a/users/shared/darwin-homebrew.nix
+++ b/users/shared/darwin-homebrew.nix
@@ -63,7 +63,7 @@ in
 
     # Development Services Configuration
     brews = [
-      "im-select" # Switch input method from terminal (for Obsidian Vim IME control)
+      "daipeihust/tap/im-select" # Switch input method from terminal (for Obsidian Vim IME control)
     ];
 
     # Performance Optimization: Selective Cleanup Strategy


### PR DESCRIPTION
## 요약

`im-select` Homebrew formula를 올바른 tap 경로(`daipeihust/tap/im-select`)로 수정합니다.

## 변경사항

- [ ] 기능 추가/수정
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 설정 변경

`users/shared/darwin-homebrew.nix`: `im-select` → `daipeihust/tap/im-select` (공식 tap 경로 사용)

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [ ] 로컬에서 수동 테스트 완료
- [ ] 관련 플랫폼에서 테스트 완료

## 추가 정보

`im-select`는 Homebrew core에 포함되지 않고 `daipeihust/tap`에서만 제공되므로 전체 tap 경로가 필요합니다.

## 체크리스트

- [ ] 코드가 프로젝트의 코딩 스타일을 따름
- [ ] 자체 검토를 완료함
- [ ] 필요한 경우 문서를 업데이트함
- [ ] 변경사항이 기존 기능을 손상시키지 않음
- [ ] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source for the input method selector package to use an alternative tap version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->