### PR TITLE
fix(statusline): add timeout fallback for environments without coreutils

### DIFF
--- a/users/shared/.config/claude/statusline.sh
+++ b/users/shared/.config/claude/statusline.sh
@@ -36,6 +36,12 @@ readonly GRAY=$'\033[37m'      # Gray for separators
 readonly RESET=$'\033[0m'      # Reset colors
 readonly BOLD=$'\033[1m'       # Bold text
 
+# Fallback for `timeout`: macOS has no built-in timeout and Claude Code's
+# shell snapshot PATH may omit coreutils on some accounts.
+if ! command -v timeout >/dev/null 2>&1; then
+    timeout() { shift; "$@"; }
+fi
+
 # Read JSON input from stdin
 input=$(cat)
 


### PR DESCRIPTION
## Summary
- macOS에는 `timeout`이 기본 설치돼 있지 않고, Claude Code default account의 shell snapshot PATH는 Nix coreutils 경로를 포함하지 않아 `timeout`이 resolve되지 않음
- 결과적으로 `statusline.sh`의 세 호출 지점(email/ahead-behind/PR)이 모두 조용히 실패해 상태줄 정보가 누락됨
- `timeout`이 없을 때 duration 인자를 버리고 명령만 실행하는 shim 함수를 상단에 정의

## Changes
- `users/shared/.config/claude/statusline.sh`: `timeout` 폴백 함수 추가

## Test plan
- [x] default account snapshot 환경에서 email/git 정보 표시 재현 (수정 전: 누락, 수정 후: 표시)
- [x] pre-commit hook 통과 (shellcheck/shfmt/bashate)
- [ ] `make switch` 후 실제 bstack 디렉토리의 Claude Code 세션에서 email HUD 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility by implementing a fallback mechanism that allows the script to execute on systems without the standard timeout utility, expanding support across more environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->