### PR TITLE
fix(hammerspoon): warn when Secure Input blocks Hyper key

### DIFF
--- a/users/shared/.config/hammerspoon/init.lua
+++ b/users/shared/.config/hammerspoon/init.lua
@@ -1,3 +1,5 @@
+require('hs.ipc')
+hs.allowAppleScript(true)
 hs.loadSpoon('Hyper')
 hs.loadSpoon('HyperModal')
 hs.loadSpoon('Pomodoro')
@@ -60,3 +62,18 @@ Pomodoro:init({
 
 -- Bind Hyper+P to toggle Pomodoro session
 Hyper:bind({}, 'p', function() Pomodoro:toggleSession() end)
+
+-- Warn when Secure Input gets enabled (1Password is the usual culprit).
+-- Why: Secure Input blocks Hammerspoon/Karabiner from receiving key events,
+-- silently breaking the Hyper key. Surface it instead of debugging blind.
+local secureInputTimer = hs.timer.new(2, function()
+  if hs.eventtap.isSecureInputEnabled() then
+    if not _G._secureInputWarned then
+      hs.alert.show("⚠️ Secure Input ON — close 1Password window", 3)
+      _G._secureInputWarned = true
+    end
+  else
+    _G._secureInputWarned = false
+  end
+end)
+secureInputTimer:start()


### PR DESCRIPTION
## 요약

1Password 메인 창이 떠 있으면 macOS Secure Input이 활성화되어 Hammerspoon이 키 이벤트를 전혀 받지 못하고, Hyper key가 조용히 동작을 멈추는 문제가 있었습니다. 원인을 즉시 알 수 있도록 알림을 추가합니다.

## 변경사항

- [x] 버그 수정
- [x] 설정 변경

- `users/shared/.config/hammerspoon/init.lua`
  - `hs.eventtap.isSecureInputEnabled()`을 2초마다 폴링해 활성화되면 화면에 경고 alert 표시
  - `hs.ipc` / `hs.allowAppleScript(true)` 추가 — `hs` CLI로 디버깅 가능

## 테스트 계획

- [x] 로컬에서 수동 테스트 완료 (1Password 창 열면 경고 뜨고, 닫으면 경고 사라짐)
- [x] Hyper+I → Ghostty 정상 동작 확인 (1Password 닫은 상태)

## 추가 정보

근본 원인은 1Password가 의도적으로 Secure Input을 켜는 정책 때문이며, defaults로는 끌 수 없습니다. 본 PR은 진단성 개선만 다룹니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring for Secure Input mode that displays an alert with instructions to resolve keyboard input conflicts when Secure Input is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->