### PR TITLE
chore(claude-code): remove CLAUDE.md, settings.json, statusline.sh deployment

### DIFF
--- a/tests/integration/claude-plugin-test.nix
+++ b/tests/integration/claude-plugin-test.nix
@@ -45,19 +45,6 @@ let
     echo "Claude Code plugin installation completed"
   '';
 
-  # Validate the Claude configuration structure
-  validateClaudeConfig =
-    let
-      configExists = builtins.pathExists claudeCodeNix;
-      scriptContent = if configExists then builtins.readFile claudeCodeNix else "";
-      hasHomeFile = builtins.match ".*home\\.file.*" scriptContent != null;
-      hasClaudeDir = builtins.match ".*\\.claude.*" scriptContent != null;
-      hasSettings =
-        builtins.match ".*settings\\.json.*" scriptContent != null
-        || builtins.match ".*statusline\\.sh.*" scriptContent != null;
-    in
-    configExists && hasHomeFile && hasClaudeDir && hasSettings;
-
 in
 # Convert tests to executable derivation
 pkgs.runCommand "claude-plugin-test-results"
@@ -125,29 +112,7 @@ pkgs.runCommand "claude-plugin-test-results"
     if [ -f "${claudeCodeNix}" ]; then
       echo "✅ PASS: claude-code.nix exists"
 
-      # Check for home.file configuration
-      if grep -q "home\\.file" "${claudeCodeNix}" || grep -q "home.file" "${claudeCodeNix}"; then
-        echo "✅ PASS: home.file configuration found"
-      else
-        echo "❌ FAIL: home.file configuration not found"
-        exit 1
-      fi
-
-      # Check for .claude directory reference
-      if grep -q "\\.claude" "${claudeCodeNix}"; then
-        echo "✅ PASS: .claude directory reference found"
-      else
-        echo "❌ FAIL: .claude directory reference not found"
-        exit 1
-      fi
-
-      # Check for Claude settings or statusline
-      if grep -q "settings\\.json" "${claudeCodeNix}" || grep -q "statusline\\.sh" "${claudeCodeNix}"; then
-        echo "✅ PASS: Claude configuration files found"
-      else
-        echo "❌ FAIL: Claude configuration files not found"
-        exit 1
-      fi
+      echo "✅ PASS: claude-code.nix structure is valid (file deployment managed externally)"
 
     else
       echo "❌ FAIL: claude-code.nix not found"
@@ -243,8 +208,6 @@ pkgs.runCommand "claude-plugin-test-results"
     echo "  ✅ Claude Code CLI availability verified"
     echo "  ✅ Installation prerequisites validated"
     echo "  ✅ Configuration file structure validated"
-    echo "  ✅ home.file directives confirmed"
-    echo "  ✅ .claude directory references found"
     echo "  ✅ Real configuration functionality tested (not mocked)"
     echo ""
     echo "Claude Code configuration is properly structured and ready!"

--- a/users/shared/claude-code.nix
+++ b/users/shared/claude-code.nix
@@ -11,27 +11,4 @@
   ...
 }:
 
-{
-
-  # Configuration files: read-only symlinks to /nix/store (version controlled)
-  home.file.".claude/statusline.sh" = {
-    source = ./.config/claude/statusline.sh;
-    executable = true;
-    force = true;
-  };
-
-  home.file.".claude/CLAUDE.md" = {
-    source = ./.config/claude/CLAUDE.md;
-    force = true;
-  };
-
-  # settings.json: initial copy only (writable after first setup)
-  home.activation.claudeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -f ~/.claude/settings.json ]; then
-      run mkdir -p ~/.claude
-      run cp ${./.config/claude/settings.json} ~/.claude/settings.json
-      run chmod 644 ~/.claude/settings.json
-    fi
-  '';
-
-}
+{ }


### PR DESCRIPTION
## Summary

- `CLAUDE.md`, `settings.json`, `statusline.sh` 파일을 Claude 세팅 시 자동 배포하는 코드 제거

## Changes

- `users/shared/claude-code.nix`에서 `home.file.".claude/statusline.sh"`, `home.file.".claude/CLAUDE.md"`, `home.activation.claudeSettings` 설정 모두 제거
- 모듈은 빈 어트리뷰트셋 `{ }`으로만 유지

## Tests

- Pre-commit hooks 통과
- Fast Tests 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic configuration file setup and symlink management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->