### PR TITLE
feat(zsh): remove hardcoded default model from cc wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ nix build '.#checks.aarch64-darwin.basic' --impure  # Specific check
 make test-integration                                # Integration tests only
 ```
 
+### First-Time Bootstrap (macOS)
+
+`make switch` invokes `darwin-rebuild`, which only exists after nix-darwin has been installed. For a brand-new machine, bootstrap once with:
+
+```bash
+sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake ".#$(hostname -s)"
+```
+
+After that succeeds, use `make switch` for all subsequent rebuilds.
+
 ### Platform-Specific Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-switch: switch
 
 switch:
 ifeq ($(UNAME), Darwin)
-	$(NIX_ENV) $(SUDO_NIX) run nix-darwin -- switch --flake ".#$(NIXNAME)"
+	$(NIX_ENV) sudo -H env PATH=$$PATH darwin-rebuild switch --flake ".#$(NIXNAME)"
 else ifeq ($(IS_NIXOS), true)
 	$(NIX_ENV_FULL) $(SUDO_NIX) run "nixpkgs#nixos-rebuild" -- switch --flake ".#${NIXNAME}"
 else

--- a/tests/unit/makefile-switch-commands-test.nix
+++ b/tests/unit/makefile-switch-commands-test.nix
@@ -34,21 +34,21 @@ pkgs.runCommand "makefile-switch-commands-test"
   ''
     echo "Testing Makefile switch commands (Option 3)"
 
-    # Test 1: build-switch should use nix-darwin on Darwin (via dependency on switch)
-    # build-switch depends on switch, and switch contains nix-darwin command
+    # Test 1: build-switch should use darwin-rebuild on Darwin (via dependency on switch)
+    # build-switch depends on switch, and switch contains darwin-rebuild command
     if (grep -A 5 "^build-switch:" "$makefileSource" | grep -q "switch") &&
-       (grep -A 20 "^switch:" "$makefileSource" | grep -q "nix-darwin"); then
-      echo "✅ Test 1 PASS: build-switch uses nix-darwin via dependency on switch"
+       (grep -A 20 "^switch:" "$makefileSource" | grep -q "darwin-rebuild"); then
+      echo "✅ Test 1 PASS: build-switch uses darwin-rebuild via dependency on switch"
     else
-      echo "❌ Test 1 FAIL: build-switch should depend on switch which uses nix-darwin"
+      echo "❌ Test 1 FAIL: build-switch should depend on switch which uses darwin-rebuild"
       exit 1
     fi
 
-    # Test 2: switch should use nix-darwin on Darwin
-    if grep -A 20 "^switch:" "$makefileSource" | grep -q "nix-darwin"; then
-      echo "✅ Test 2 PASS: switch uses nix-darwin"
+    # Test 2: switch should use darwin-rebuild on Darwin
+    if grep -A 20 "^switch:" "$makefileSource" | grep -q "darwin-rebuild"; then
+      echo "✅ Test 2 PASS: switch uses darwin-rebuild"
     else
-      echo "❌ Test 2 FAIL: switch should use nix-darwin"
+      echo "❌ Test 2 FAIL: switch should use darwin-rebuild"
       exit 1
     fi
 

--- a/users/shared/zsh/claude-wrappers.nix
+++ b/users/shared/zsh/claude-wrappers.nix
@@ -63,8 +63,7 @@
   }
 
   cc() {
-    eval "$(_cc_parse_model_flags "claude-sonnet-4-6" "opus[1m]" "claude-haiku-4-5" model "$@")"
-    ENABLE_TOOL_SEARCH=true _cc_run "$model" "$@"
+    ENABLE_TOOL_SEARCH=true command claude --dangerously-skip-permissions "$@"
   }
 
   # cco: Configure in ~/.zshrc.local:

--- a/users/shared/zsh/default.nix
+++ b/users/shared/zsh/default.nix
@@ -87,6 +87,7 @@
 
     shellAliases = {
       # Multi-level directory navigation
+      ".." = "cd ..";
       "..." = "cd ../..";
       "...." = "cd ../../..";
       "....." = "cd ../../../..";


### PR DESCRIPTION
## Summary
- `cc` wrapper에서 하드코딩된 `claude-sonnet-4-6` 기본 모델 제거
- 모델 선택을 `settings.json`의 `model` 필드에 위임
- `settings.json`에 `claude-opus-4-7` 설정 시 `cc`가 그대로 따름

## Changes
- `users/shared/zsh/claude-wrappers.nix`: `cc()`에서 `_cc_parse_model_flags` 제거, 직접 `command claude --dangerously-skip-permissions` 호출
- `CLAUDE.md`: First-Time Bootstrap 섹션 추가
- `Makefile`: `make switch` darwin 커맨드 수정