### PR TITLE
feat(zsh): expand cd ... with ZLE widget for tab completion

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -94,11 +94,16 @@ in
   (helpers.assertTest "alias-gt-exists" (hasAlias "gt") "alias 'gt' (git tag) should exist")
   (helpers.assertTest "alias-gl-exists" (hasAlias "gl") "alias 'gl' (git prettylog) should exist")
 
-  # Multi-level directory navigation aliases
-  (helpers.assertTest "alias-dot-dot-dot-exists" (hasAlias "...") "alias '...' (cd ../..) should exist")
-  (helpers.assertTest "alias-four-dots-exists" (hasAlias "....") "alias '....' (cd ../../..) should exist")
-  (helpers.assertTest "alias-five-dots-exists" (hasAlias ".....") "alias '.....' (cd ../../../..) should exist")
-  (helpers.assertTest "alias-six-dots-exists" (hasAlias "......") "alias '......' (cd ../../../../..) should exist")
+  # Multi-level directory navigation: "..." and longer are expanded by the
+  # rationalise-dot ZLE widget (see users/shared/zsh/functions.nix) so that
+  # tab completion works on `cd .../<TAB>`. Only ".." remains as a plain alias.
+  (helpers.assertTest "alias-dot-dot-exists" (hasAlias "..") "alias '..' (cd ..) should exist")
+  (helpers.assertTest "rationalise-dot-widget"
+    (initContentHas "rationalise-dot()")
+    "rationalise-dot ZLE widget should be defined in initContent")
+  (helpers.assertTest "rationalise-dot-bindkey"
+    (initContentHas "bindkey . rationalise-dot")
+    "rationalise-dot widget should be bound to '.'")
 
   # ls color alias
   (helpers.assertTest "alias-ls-color" (hasAlias "ls")

--- a/tests/unit/zsh-rationalise-dot-test.nix
+++ b/tests/unit/zsh-rationalise-dot-test.nix
@@ -1,0 +1,126 @@
+# Zsh rationalise-dot ZLE widget tests
+#
+# Verifies that the dot-expansion widget is wired into zsh initContent
+# so that typing "..." becomes "../..", "...." becomes "../../..", etc.
+# The widget mutates $LBUFFER inline, which is what enables tab completion
+# on paths like `cd .../<TAB>`.
+#
+# Also runs the widget logic under a real zsh to confirm expansion output.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  nixtest ? { },
+  self ? ./.,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  mockConfig = import ../lib/mock-config.nix { inherit pkgs lib; };
+
+  zshConfig = import ../../users/shared/zsh {
+    inherit pkgs lib;
+    isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+    config = mockConfig.mkEmptyConfig;
+  };
+
+  initContent = zshConfig.programs.zsh.initContent.content or "";
+  aliases = zshConfig.programs.zsh.shellAliases or { };
+
+  assertInitHas =
+    name: needle:
+    helpers.assertTest "zsh-rat-dot-${name}" (lib.hasInfix needle initContent)
+      "Expected '${needle}' in zsh initContent";
+
+  # Runtime check: source the widget definition under zsh and simulate the
+  # keypresses that produce "..." / "....", asserting $LBUFFER is rewritten.
+  # We don't need ZLE active — the function body only touches $LBUFFER, so
+  # we can invoke it as a regular function in a non-interactive shell.
+  runtimeTest =
+    pkgs.runCommand "zsh-rationalise-dot-runtime"
+      {
+        nativeBuildInputs = [ pkgs.zsh ];
+      }
+      ''
+        cat > widget.zsh <<'EOF'
+        rationalise-dot() {
+          if [[ $LBUFFER = *.. ]]; then
+            LBUFFER+=/..
+          else
+            LBUFFER+=.
+          fi
+        }
+        EOF
+
+        expand() {
+          zsh -c "
+            source ./widget.zsh
+            LBUFFER='$1'
+            for _ in {1..$2}; do rationalise-dot; done
+            print -r -- \"\$LBUFFER\"
+          "
+        }
+
+        # Typing "..." from empty buffer -> "../.."
+        got=$(expand "" 3)
+        [[ "$got" = "../.." ]] || { echo "FAIL 3 dots: got '$got'"; exit 1; }
+
+        # Typing "...." -> "../../.."
+        got=$(expand "" 4)
+        [[ "$got" = "../../.." ]] || { echo "FAIL 4 dots: got '$got'"; exit 1; }
+
+        # Typing "....." -> "../../../.."
+        got=$(expand "" 5)
+        [[ "$got" = "../../../.." ]] || { echo "FAIL 5 dots: got '$got'"; exit 1; }
+
+        # After "cd " prefix, "..." still expands (LBUFFER includes prefix)
+        got=$(expand "cd " 3)
+        [[ "$got" = "cd ../.." ]] || { echo "FAIL cd prefix: got '$got'"; exit 1; }
+
+        # Two dots alone stay literal (widget only rewrites from the 3rd dot)
+        got=$(expand "" 2)
+        [[ "$got" = ".." ]] || { echo "FAIL 2 dots literal: got '$got'"; exit 1; }
+
+        # A single dot after a non-dot char stays literal (e.g. filenames)
+        got=$(expand "foo" 1)
+        [[ "$got" = "foo." ]] || { echo "FAIL foo.: got '$got'"; exit 1; }
+
+        echo "runtime widget behavior OK"
+        touch $out
+      '';
+
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "zsh-rationalise-dot" [
+    # 1. Widget function body is present
+    (assertInitHas "fn-defined" "rationalise-dot()")
+    (assertInitHas "lbuffer-check" "[[ $LBUFFER = *.. ]]")
+    (assertInitHas "lbuffer-append-slash" "LBUFFER+=/..")
+    (assertInitHas "lbuffer-append-dot" "LBUFFER+=.")
+
+    # 2. Widget is registered with ZLE and bound to "."
+    (assertInitHas "zle-register" "zle -N rationalise-dot")
+    (assertInitHas "bindkey" "bindkey . rationalise-dot")
+    (assertInitHas "isearch-literal" "bindkey -M isearch . self-insert")
+
+    # 3. Old multi-dot shell aliases were removed so they no longer shadow
+    #    the widget (only ".." alias remains for convenience).
+    (helpers.assertTest "zsh-rat-dot-no-triple-alias"
+      (!(builtins.hasAttr "..." aliases))
+      "shellAliases should not define '...' — the ZLE widget handles it"
+    )
+    (helpers.assertTest "zsh-rat-dot-no-quad-alias"
+      (!(builtins.hasAttr "...." aliases))
+      "shellAliases should not define '....' — the ZLE widget handles it"
+    )
+
+    # 4. Runtime behavior under real zsh
+    (helpers.assertTest "zsh-rat-dot-runtime"
+      (builtins.pathExists runtimeTest)
+      "rationalise-dot widget runtime simulation failed"
+    )
+  ];
+}

--- a/users/shared/zsh/default.nix
+++ b/users/shared/zsh/default.nix
@@ -86,12 +86,10 @@
     completionInit = "autoload -Uz compinit && compinit -C";
 
     shellAliases = {
-      # Multi-level directory navigation
+      # Multi-level directory navigation: "..." -> "../.." expansion is
+      # handled by the rationalise-dot ZLE widget in functions.nix so that
+      # tab completion (e.g. `cd .../<tab>`) works naturally.
       ".." = "cd ..";
-      "..." = "cd ../..";
-      "...." = "cd ../../..";
-      "....." = "cd ../../../..";
-      "......" = "cd ../../../../..";
 
       # Claude CLI shortcuts are now functions in initContent (cc, cco, ccz)
 

--- a/users/shared/zsh/functions.nix
+++ b/users/shared/zsh/functions.nix
@@ -11,6 +11,22 @@ shell() {
     nix-shell '<nixpkgs>' -A "$1"
 }
 
+# rationalise-dot: when the user types a third (or later) consecutive "."
+# at the end of the buffer, expand it to "/..". This makes "..." expand to
+# "../..", "...." to "../../..", etc. — and because the expansion happens
+# inline in the buffer, tab-completion (e.g. `cd .../<TAB>`) works naturally.
+rationalise-dot() {
+  if [[ $LBUFFER = *.. ]]; then
+    LBUFFER+=/..
+  else
+    LBUFFER+=.
+  fi
+}
+zle -N rationalise-dot
+bindkey . rationalise-dot
+# Keep "." literal inside incremental search
+bindkey -M isearch . self-insert
+
 # Enhanced SSH wrapper with intelligent reconnection
 ssh() {
   # Optimized connection wrapper with autossh fallback


### PR DESCRIPTION
## Summary
- Replace multi-dot shell aliases (\`...\`, \`....\`, ...) with a zsh \`rationalise-dot\` ZLE widget that rewrites the buffer inline.
- Because the expansion hits \`\$LBUFFER\` as you type, \`cd .../<TAB>\` now tab-completes naturally.
- Keeps \`..\` alias for convenience; isearch preserves literal \`.\`.

## Changes
- \`users/shared/zsh/default.nix\`: drop \`...\`/\`....\`/... aliases.
- \`users/shared/zsh/functions.nix\`: add \`rationalise-dot\` widget, \`zle -N\`, \`bindkey .\`, and isearch passthrough.
- \`tests/unit/zsh-rationalise-dot-test.nix\`: new unit test — checks the widget/bindings are wired into \`initContent\`, asserts the old aliases are gone, and runs the widget under a real zsh to verify \`...\`→\`../..\`, \`....\`→\`../../..\`, \`cd \`+\`...\`→\`cd ../..\`, \`..\` literal, and \`foo.\` literal.

## Test plan
- [x] \`nix build --impure .#checks.aarch64-darwin.unit-zsh-rationalise-dot\` passes locally
- [ ] CI green
- [ ] Manual: after \`make switch\`, type \`cd ...\` and confirm buffer becomes \`cd ../..\`; tab-complete \`cd .../\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced zsh dot-rationalization: multiple consecutive dots automatically expand to parent directory navigation patterns (e.g., `...` → `../..`), improving tab-completion behavior for directory navigation.
  * Migrated multi-dot navigation from shell aliases to ZLE widget implementation.

* **Tests**
  * Added comprehensive unit tests for dot-rationalization behavior and widget integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->