### PR TITLE
feat(zsh): cd into existing worktree when gw branch already checked out

### DIFF
--- a/tests/unit/gw-existing-worktree-test.nix
+++ b/tests/unit/gw-existing-worktree-test.nix
@@ -1,0 +1,38 @@
+# tests/unit/gw-existing-worktree-test.nix
+# Verify gw handles the "branch already used by another worktree" case by
+# parsing the existing path out of git's error message and cd-ing there.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  nixtest ? { },
+  self ? ./.,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  gwScript = import ../../users/shared/zsh/gw.nix;
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "gw-existing-worktree" [
+    (helpers.assertTest "gw-defines-existing-worktree-handler"
+      (lib.hasInfix "_handle_existing_worktree" gwScript)
+      "gw should define _handle_existing_worktree helper")
+
+    (helpers.assertTest "gw-parses-existing-worktree-path"
+      (lib.hasInfix "already used by worktree at" gwScript)
+      "gw should parse 'already used by worktree at <path>' from git error output")
+
+    (helpers.assertTest "gw-warns-on-existing-worktree"
+      (lib.hasInfix "is already checked out at" gwScript)
+      "gw should print a warning when the branch is already checked out elsewhere")
+
+    (helpers.assertTest "gw-cds-into-existing-worktree"
+      (lib.hasInfix ''cd "$existing_worktree"'' gwScript)
+      "gw should cd into the existing worktree instead of failing")
+  ];
+}

--- a/users/shared/zsh/gw.nix
+++ b/users/shared/zsh/gw.nix
@@ -114,6 +114,14 @@
       return $result
     }
 
+    # Helper: Handle "branch already used by another worktree" case
+    # Parses the path out of git's error and echoes it, so caller can cd there.
+    local _handle_existing_worktree() {
+      local error_output="$1"
+      local existing_path=$(echo "$error_output" | sed -n "s/.*already used by worktree at '\(.*\)'.*/\1/p" | head -1)
+      [[ -n "$existing_path" ]] && echo "$existing_path"
+    }
+
     # Helper: Handle hierarchical branch conflicts
     local _handle_ref_conflict() {
       local branch="$1"
@@ -152,6 +160,15 @@
 
     local create_error
     if ! create_error=$(_create_worktree "$branch_name" "$worktree_dir" "$base_branch"); then
+      # If branch is already checked out in another worktree, jump there.
+      local existing_worktree=$(_handle_existing_worktree "$create_error")
+      if [[ -n "$existing_worktree" ]]; then
+        _msg "$YELLOW" "Warning: branch '$branch_name' is already checked out at $existing_worktree"
+        _msg "$BLUE" "Switching to existing worktree instead."
+        cd "$existing_worktree"
+        return 0
+      fi
+
       # Try to handle hierarchical ref conflict
       local resolved_branch=$(_handle_ref_conflict "$branch_name" "$create_error")
       if [[ -n "$resolved_branch" ]]; then


### PR DESCRIPTION
## 요약

`gw <branch>`를 호출했을 때 해당 브랜치가 이미 다른 worktree에 체크아웃되어 있으면 raw git 에러로 실패하던 문제를 개선. 이제 경고를 표시하고 기존 worktree 경로로 자동 이동한다.

## 변경사항

- [x] 기능 추가/수정
- [x] 테스트 추가/수정

- `users/shared/zsh/gw.nix`: `_handle_existing_worktree` 헬퍼 추가. `git worktree add` 실패 시 `"already used by worktree at '<path>'"` 메시지를 파싱해, 노란색 warning을 띄우고 기존 경로로 `cd`.
- `tests/unit/gw-existing-worktree-test.nix`: 핸들러 정의, 에러 파싱, warning, `cd` 동작을 각각 검증하는 4개 assertion 추가.

## 테스트 계획

- [x] 새 테스트 `test-suite-gw-existing-worktree` 빌드 성공 (4/4 pass)
- [x] `gw` pre-commit hook (Fast Tests) 통과
- [ ] 수동 검증: 이미 존재하는 브랜치 이름으로 `gw` 실행 시 기존 worktree로 이동 확인

## 추가 정보

기존 에러 메시지는 이런 형태였음:
```
fatal: 'feat/foo' is already used by worktree at '/path/to/.worktrees/feat-foo'
```
이제는 warning + 자동 cd 로 처리된다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `gw` script now intelligently handles cases where a branch is already checked out in another worktree. When detected, it warns the user and automatically navigates to the existing location.

* **Tests**
  * Added test suite to verify correct detection and handling of existing worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->