### PR TITLE
fix(direnv): avoid duplicate check override

### DIFF
--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -19,7 +19,6 @@
       env = oldAttrs.env // {
         CGO_ENABLED = "1";
       };
-      doCheck = !prev.stdenv.hostPlatform.isDarwin;
       preBuild = ''
         # Remove -linkmode=external from the build flags
         substituteInPlace GNUmakefile \

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -13,7 +13,10 @@
 
     # direnv - fix cgo build issue by removing linkmode=external
     direnv = prev.direnv.overrideAttrs (oldAttrs: {
-      env = oldAttrs.env // { CGO_ENABLED = "1"; };
+      env = oldAttrs.env // {
+        CGO_ENABLED = "1";
+      };
+      doCheck = !prev.stdenv.hostPlatform.isDarwin;
       preBuild = ''
         # Remove -linkmode=external from the build flags
         substituteInPlace GNUmakefile \

--- a/tests/unit/direnv-overlay-test.nix
+++ b/tests/unit/direnv-overlay-test.nix
@@ -1,0 +1,19 @@
+{
+  inputs,
+  system,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  overlays = import ../../lib/overlays.nix { inherit inputs; };
+  overlaidPkgs = import inputs.nixpkgs {
+    inherit system overlays;
+    config.allowUnfree = true;
+  };
+in
+helpers.assertTest "direnv-checks-disabled-on-darwin"
+  (if overlaidPkgs.stdenv.isDarwin then overlaidPkgs.direnv.drvAttrs.doCheck == false else true)
+  "direnv checks should be disabled on Darwin because upstream shell tests hang during system builds"


### PR DESCRIPTION
## 요약

- direnv 2.37.1의 Darwin 빌드 중 zsh checkPhase가 멈추는 문제를 피하도록 upstream/base의 check 비활성화와 충돌하지 않게 정리했습니다.
- Darwin에서 direnv checks가 비활성화되는지 확인하는 회귀 테스트를 추가했습니다.

## 변경사항

- [ ] 기능 추가/수정
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [x] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

추가 검증:
- [x] `nix build --impure '.#checks.aarch64-darwin.unit-direnv-overlay'`
- [x] `nix build --impure --expr 'let flake = builtins.getFlake (toString ./.); overlays = import ./lib/overlays.nix { inputs = flake.inputs; }; pkgs = import flake.inputs.nixpkgs { system = "aarch64-darwin"; inherit overlays; config.allowUnfree = true; }; in pkgs.direnv'`
- [x] `nix build --impure --show-trace '.#darwinConfigurations.kakaostyle-jito.system'`
- [x] `nix fmt -- --check lib/overlays.nix tests/unit/direnv-overlay-test.nix`

## 추가 정보

- preflight 중 base가 먼저 같은 direnv check 비활성화를 추가해 중복 `doCheck` 정의가 발생했으며, 해당 중복을 제거했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함