### PR TITLE
fix(gw): retry random name on collision and capture git errors via stdout

### DIFF
--- a/tests/unit/gw-random-collision-test.nix
+++ b/tests/unit/gw-random-collision-test.nix
@@ -1,0 +1,36 @@
+# tests/unit/gw-random-collision-test.nix
+# Verify gw retries random branch name generation when the generated name
+# collides with an existing branch, and that _create_worktree returns git's
+# combined output on stdout (so $(...) capture works for error parsing).
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  nixtest ? { },
+  self ? ./.,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  gwScript = import ../../users/shared/zsh/gw.nix;
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "gw-random-collision" [
+    (helpers.assertTest "gw-retries-on-random-collision"
+      (lib.hasInfix ''for _attempt in'' gwScript
+        && lib.hasInfix ''git rev-parse --verify "$branch_name"'' gwScript)
+      "gw should retry random branch name generation if it collides with an existing branch")
+
+    (helpers.assertTest "gw-create-worktree-emits-on-stdout"
+      (!(lib.hasInfix ''echo "$error_output" >&2'' gwScript))
+      "gw _create_worktree should not redirect git output to stderr; caller captures via \$(...)")
+
+    (helpers.assertTest "gw-create-worktree-uses-2to1-redirect"
+      (lib.hasInfix ''git worktree add "$worktree_dir" "$branch" 2>&1'' gwScript)
+      "gw _create_worktree should merge stderr into stdout so error output is capturable")
+  ];
+}

--- a/users/shared/zsh/gw.nix
+++ b/users/shared/zsh/gw.nix
@@ -36,9 +36,15 @@
 
     local branch_name="$1"
 
-    # If no branch name provided, generate a random one
+    # If no branch name provided, generate a random one.
+    # Retry a few times if the random name collides with an existing branch,
+    # since reusing an existing branch may also be checked out in another worktree.
     if [[ $# -eq 0 ]]; then
-      branch_name=$(_random_branch_name)
+      local _attempt
+      for _attempt in 1 2 3 4 5; do
+        branch_name=$(_random_branch_name)
+        git rev-parse --verify "$branch_name" >/dev/null 2>&1 || break
+      done
     fi
 
     # ANSI color codes
@@ -91,27 +97,21 @@
       return 0
     }
 
-    # Helper: Create worktree with existing or new branch
-    # Outputs error messages to stderr on failure, returns exit code
+    # Helper: Create worktree with existing or new branch.
+    # Echoes git's combined stdout+stderr so the caller can capture and parse it
+    # via $(...). Returns git's exit code.
     local _create_worktree() {
       local branch="$1"
       local worktree_dir="$2"
       local base_branch="$3"
-      local error_output
 
       if git rev-parse --verify "$branch" >/dev/null 2>&1; then
         _msg "$BLUE" "Branch '$branch' already exists. Using existing branch."
-        error_output=$(git worktree add "$worktree_dir" "$branch" 2>&1)
+        git worktree add "$worktree_dir" "$branch" 2>&1
       else
         _msg "$GREEN" "Creating new branch '$branch' (base: $base_branch)"
-        error_output=$(git worktree add -b "$branch" "$worktree_dir" "$base_branch" 2>&1)
+        git worktree add -b "$branch" "$worktree_dir" "$base_branch" 2>&1
       fi
-
-      local result=$?
-      if [[ $result -ne 0 ]]; then
-        echo "$error_output" >&2
-      fi
-      return $result
     }
 
     # Helper: Handle "branch already used by another worktree" case


### PR DESCRIPTION
## 요약

`gw`(인자 없이 호출)가 가끔 `fatal: '...' is already used by worktree at '...'`로 실패하던 문제를 수정합니다. 직접 원인은 랜덤 브랜치 이름이 기존 브랜치와 충돌하는 것이었고, 잠복 원인은 충돌 처리 로직이 git 에러를 stderr로만 출력해 호출자의 \`\$(...)\` 캡처가 빈 문자열을 받던 버그였습니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정

`users/shared/zsh/gw.nix`:
- `_create_worktree`: git 출력을 `2>&1`로 stdout에 내보내고 함수 내부의 `>&2` 리다이렉트 제거 — 이제 호출자가 에러 메시지를 캡처해 `_handle_existing_worktree`가 경로를 파싱하고 기존 worktree로 cd 가능
- 인자 없이 호출 시 랜덤 이름이 기존 브랜치와 충돌하면 최대 5회까지 재시도

`tests/unit/gw-random-collision-test.nix` 추가:
- 재시도 루프 존재 확인
- `_create_worktree`가 stderr 리다이렉트를 쓰지 않는지 확인
- `2>&1` 머지 사용 확인

## 테스트 계획

- [x] `nix build .#checks.aarch64-darwin.unit-gw-random-collision` 통과
- [x] `nix build .#checks.aarch64-darwin.unit-gw-existing-worktree` 통과 (회귀 없음)
- [x] `nix build .#checks.aarch64-darwin.unit-gw-sanitization` 통과 (회귀 없음)
- [x] pre-commit hooks 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved random branch name generation with automatic retry logic (up to 5 attempts) to avoid collisions with existing branches.
  * Enhanced error output handling in worktree creation for better error diagnostics.

* **Tests**
  * Added comprehensive test suite validating collision handling, output management, and error handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baleen37/dotfiles/pull/1252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->