### PR TITLE
fix(zsh): anchor multi-dot cd regex so arbitrary paths pass through

### DIFF
--- a/tests/unit/zsh-multidot-cd-test.nix
+++ b/tests/unit/zsh-multidot-cd-test.nix
@@ -48,7 +48,7 @@ let
 
         cat > fn.zsh <<'EOF'
         cd() {
-          if [[ $# -eq 1 && "$1" =~ ^\.\.\.+$ ]]; then
+          if [[ $# -eq 1 && "$1" =~ "^\.{3,}$" ]]; then
             local dots="$1"
             local target=""
             local i
@@ -87,6 +87,20 @@ let
         got=$(run "a/b" "c")
         [[ "$got" = "$root/a/b/c" ]] || { echo "FAIL cd c: got '$got'"; exit 1; }
 
+        # Regression: arbitrary paths must NOT be treated as multi-dot.
+        # Previously, an unquoted `=~ ^\.\.\.+$` regex mis-matched paths
+        # like "/tmp" or "abc", causing them to be rewritten as `../../../`.
+        mkdir -p tmp_target abc_target
+        got=$(run "a/b/c/d/e" "$root/tmp_target")
+        [[ "$got" = "$root/tmp_target" ]] || { echo "FAIL cd /abs path: got '$got'"; exit 1; }
+
+        got=$(run "a/b/c" "../d_sibling" 2>/dev/null || true)
+        # Just ensure that a non-dot relative arg is passed through as-is
+        # (mkdir the target first so cd succeeds).
+        mkdir -p a/b/d_sibling
+        got=$(run "a/b/c" "../d_sibling")
+        [[ "$got" = "$root/a/b/d_sibling" ]] || { echo "FAIL cd ../sibling: got '$got'"; exit 1; }
+
         echo "runtime cd override behavior OK"
         touch $out
       '';
@@ -96,7 +110,7 @@ in
   platforms = [ "any" ];
   value = helpers.testSuite "zsh-multidot-cd" [
     (assertInitHas "fn-defined" "cd() {")
-    (assertInitHas "regex-check" ''"$1" =~ ^\.\.\.+$'')
+    (assertInitHas "regex-check" ''"$1" =~ "^\.{3,}$"'')
     (assertInitHas "builtin-cd" "builtin cd")
 
     (helpers.assertTest "zsh-multidot-no-triple-alias"

--- a/users/shared/zsh/functions.nix
+++ b/users/shared/zsh/functions.nix
@@ -15,7 +15,7 @@ shell() {
 # Implemented as a function override (not a ZLE widget) so the typed form
 # (`cd ...`) is preserved in shell history instead of being rewritten.
 cd() {
-  if [[ $# -eq 1 && "$1" =~ ^\.\.\.+$ ]]; then
+  if [[ $# -eq 1 && "$1" =~ "^\.{3,}$" ]]; then
     local dots="$1"
     local target=""
     local i


### PR DESCRIPTION
## 요약

`cd()` 오버라이드의 multi-dot regex(`^\.\.\.+$`)가 따옴표 없이 사용되면서 zsh `[[ =~ ]]`에서 anchor가 풀려 `/tmp`, `abc`, `.../foo` 같은 임의 경로까지 매칭됐습니다. 결과적으로 `cd /tmp`가 `cd ../../../`로 재작성되어 엉뚱한 디렉터리(보통 `/`)로 이동했습니다.

regex를 따옴표로 감싸 (`"^\.{3,}$"`) zsh가 anchored literal pattern으로 해석하도록 수정합니다.

## 변경사항

- [x] 버그 수정 — `users/shared/zsh/functions.nix`
- [x] 테스트 추가 — `tests/unit/zsh-multidot-cd-test.nix`
  - regex assertion 갱신
  - 절대 경로(`\$root/tmp_target`), 상대 비-점 인자(`../d_sibling`) 회귀 케이스 추가

## 테스트 계획

- [x] `pre-commit` (fast tests 포함) 통과
- [x] clean zsh에서 회귀 재현 → 수정 후 정상 동작 수동 확인
  - `cd ...` / `cd ....` / `cd .....` → N단계 위로 ✅
  - `cd /tmp/...` → 절대 경로 그대로 ✅ (예전엔 `/`로 갔음)
  - `cd ..` / `cd c` → builtin 그대로 ✅
- [ ] `make switch` 후 새 세션에서 동작 확인

## 추가 정보

원인 분석:

    zsh -f -c '[[ "/tmp" =~ ^\.\.\.+$ ]] && echo MATCH'   # → MATCH (버그)
    zsh -f -c '[[ "/tmp" =~ "^\.{3,}$" ]] && echo MATCH'  # → (no match, 정상)

zsh는 unquoted regex의 backslash 처리를 다르게 하며 anchor가 의도대로 작동하지 않습니다. 따옴표로 감싸는 게 안전합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-dot argument detection in the `cd` command override for more accurate path handling.
  * Fixed potential issue where non-dot paths could be incorrectly rewritten.

* **Tests**
  * Added regression test coverage to prevent non-dot paths from being mishandled in future updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baleen37/dotfiles/pull/1253)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->