### PR TITLE
fix(ci): enable aarch64-linux emulation on Linux x86_64 runners

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -16,6 +16,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Register cross-arch binfmt handlers (Linux only)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        # Linux ARM64 matrix entries run on x86_64 GitHub-hosted runners but build
+        # aarch64-linux derivations. Without binfmt + qemu-user, every flake.lock
+        # update that introduces an uncached aarch64-linux derivation breaks the
+        # Build closure step. tonistiigi/binfmt installs a persistent registration
+        # for all common targets and is itself ~5MB, so it's cheap on x86_64 runs.
+        docker run --privileged --rm tonistiigi/binfmt --install arm64
+
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       with:
@@ -24,6 +35,7 @@ runs:
           experimental-features = nix-command flakes
           accept-flake-config = true
           trusted-users = root *
+          extra-platforms = aarch64-linux
           substituters = https://baleen-nix.cachix.org https://nix-community.cachix.org https://cache.nixos.org/
           trusted-public-keys = baleen-nix.cachix.org-1:awgC7Sut148An/CZ6TZA+wnUtJmJnOvl5NThGio9j5k= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -16,16 +16,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Register cross-arch binfmt handlers (Linux only)
-      if: runner.os == 'Linux'
+    - name: Register cross-arch binfmt handlers (Linux x86_64 only)
+      if: runner.os == 'Linux' && runner.arch == 'X64'
       shell: bash
       run: |
         # Linux ARM64 matrix entries run on x86_64 GitHub-hosted runners but build
         # aarch64-linux derivations. Without binfmt + qemu-user, every flake.lock
         # update that introduces an uncached aarch64-linux derivation breaks the
-        # Build closure step. tonistiigi/binfmt installs a persistent registration
-        # for all common targets and is itself ~5MB, so it's cheap on x86_64 runs.
-        docker run --privileged --rm tonistiigi/binfmt --install arm64
+        # Build closure step.
+        #
+        # tonistiigi/binfmt registers with the binfmt_misc F flag, so the kernel
+        # holds an open fd to qemu-aarch64 — sandboxed Nix builds reach it without
+        # needing extra-sandbox-paths. Image is pinned to a tagged release rather
+        # than :latest to keep CI reproducible (see docker/setup-qemu-action#110).
+        # Skipped automatically on native ARM runners (runner.arch == ARM64).
+        docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install arm64
 
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21


### PR DESCRIPTION
The Linux ARM64 matrix entry runs on ubuntu-latest (x86_64 hardware)
but the Build closure step builds .#nixosConfigurations.vm-aarch64-utm,
whose toplevel derivation is aarch64-linux. With no binfmt handler and
no extra-platforms entry, Nix can only succeed via 100% substituter
cache hits — so every flake.lock update that introduces a fresh
aarch64-linux derivation breaks post-merge CI on main (e.g. runs
25770424552 and 25705651674).

Register qemu-user binfmt handlers via tonistiigi/binfmt before
installing Nix, and advertise aarch64-linux in extra-platforms so Nix
will dispatch aarch64-linux build steps through the emulated runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-architecture build support for ARM64 on x86_64 Linux runners, enabling ARM64 artifacts to be built and tested on existing Linux hosts.
  * Nix installer now recognizes and supports the aarch64-linux platform, allowing Nix to resolve and handle ARM64 derivations seamlessly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baleen37/dotfiles/pull/1255)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->