### PR TITLE
feat(hosts): enable per-host module overrides via flake.hosts.<name>.homeModules

### DIFF
--- a/flake-modules/hosts.nix
+++ b/flake-modules/hosts.nix
@@ -15,6 +15,11 @@
       system = "aarch64-darwin";
       class = "darwin";
       user = "jito.hello";
+      homeModules = {
+        # 회사 macOS는 hammerspoon / karabiner를 사용하지 않는다
+        modules.programs.hammerspoon.enable = false;
+        modules.programs.karabiner.enable = false;
+      };
     };
     vm-aarch64-utm = {
       system = "aarch64-linux";

--- a/flake-modules/systems.nix
+++ b/flake-modules/systems.nix
@@ -17,12 +17,14 @@ let
     mkSystem name {
       inherit (h) system user;
       darwin = true;
+      homeModules = h.homeModules or { };
     };
 
   mkNixos =
     name: h:
     mkSystem name {
       inherit (h) system user;
+      homeModules = h.homeModules or { };
     };
 in
 {

--- a/lib/mksystem.nix
+++ b/lib/mksystem.nix
@@ -10,6 +10,7 @@ name:
   user,
   darwin ? false,
   wsl ? false,
+  homeModules ? { },
 }:
 
 let
@@ -91,7 +92,10 @@ systemFunc {
       home-manager = {
         useGlobalPkgs = true;
         useUserPackages = true;
-        users.${user} = import userHMConfig;
+        users.${user} = lib.mkMerge [
+          (import userHMConfig)
+          homeModules
+        ];
         extraSpecialArgs = {
           inherit inputs self;
           currentSystemUser = user;

--- a/tests/unit/host-overrides-test.nix
+++ b/tests/unit/host-overrides-test.nix
@@ -1,0 +1,45 @@
+# tests/unit/host-overrides-test.nix
+#
+# Verifies that a host's `homeModules` attribute actually overrides
+# `modules.programs.*.enable` in the resulting darwin configuration.
+
+{
+  pkgs,
+  lib,
+  self,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  # The kakaostyle-jito host should have hammerspoon disabled via homeModules.
+  jitoCfg = self.darwinConfigurations.kakaostyle-jito.config;
+
+  hammerspoonEnabledOnJito =
+    jitoCfg.home-manager.users."jito.hello".modules.programs.hammerspoon.enable;
+
+  # By contrast, macbook-pro (no override) should keep the module-level default
+  # (`pkgs.stdenv.hostPlatform.isDarwin` == true on aarch64-darwin).
+  # Note: macbook-pro resolves to the current USER (jito.hello in this env).
+  proCfg = self.darwinConfigurations.macbook-pro.config;
+
+  macbookProUsers = builtins.attrNames proCfg.home-manager.users;
+  macbookProUser = builtins.head macbookProUsers;
+
+  hammerspoonEnabledOnPro =
+    proCfg.home-manager.users.${macbookProUser}.modules.programs.hammerspoon.enable;
+
+in
+{
+  platforms = [ "darwin" ];
+  value = {
+    override-disables-hammerspoon = helpers.assertTest "kakaostyle-jito disables hammerspoon" (
+      hammerspoonEnabledOnJito == false
+    ) "host.homeModules must override modules.programs.hammerspoon.enable to false on kakaostyle-jito";
+
+    default-keeps-hammerspoon = helpers.assertTest "macbook-pro keeps hammerspoon default" (
+      hammerspoonEnabledOnPro == true
+    ) "macbook-pro (no override) must keep hammerspoon default=true (Darwin)";
+  };
+}


### PR DESCRIPTION
## Summary

Plan 1 (#1269)이 만든 modules.* 옵션 시스템 위에서, 머신마다 모듈을 토글할 수 있는 데이터 주도 메커니즘을 추가한다.

## Why

직전 PR로 22개 모듈이 `modules.<programs|packages>.<name>.enable`이라는 옵션을 갖게 됐지만, 머신별로 이를 override할 방법이 없었다. 예를 들어 `kakaostyle-jito`(회사 macOS)에서는 hammerspoon/karabiner를 끄고 싶지만 모든 darwin 머신이 동일한 `users/shared/home-manager.nix`를 import하므로 분리 불가능했다.

## Design (D-lite)

업계 표준 조사(notusknot/hlissner/wimpysworld/Misterio77) 결과 5개 머신 규모에 D-lite 패턴 채택. 즉:
- `flake.hosts.<name>.homeModules` 속성에 데이터로 override 선언
- `lib/mksystem.nix`가 `lib.mkMerge`로 home-manager.users에 머지

self-gating(D-full)이나 별도 옵션 트리(B 패턴) 없이 최소 변경.

## Changes

- `lib/mksystem.nix`: `homeModules ? { }` 인자 + `users.${user}`를 `lib.mkMerge`로
- `flake-modules/systems.nix`: mkDarwin/mkNixos가 `h.homeModules or { }` 전달
- `flake-modules/hosts.nix`: kakaostyle-jito에 `homeModules = { modules.programs.hammerspoon.enable = false; modules.programs.karabiner.enable = false; }` 추가
- `tests/unit/host-overrides-test.nix` (신규): host override가 머신 derivation에 반영되는지 검증

## Test plan

- [x] 5/5 머신 평가/빌드 성공
- [x] kakaostyle-jito에서 `modules.programs.hammerspoon.enable == false`
- [x] kakaostyle-jito에서 `modules.programs.karabiner.enable == false`
- [x] macbook-pro에서 `modules.programs.hammerspoon.enable == true`
- [x] macbook-pro에서 `modules.programs.karabiner.enable == true`
- [x] make test exit 0
- [x] 새 unit test 2개 PASS (unit-host-overrides-override-disables-hammerspoon, unit-host-overrides-default-keeps-hammerspoon)
- [ ] CI 통과