### PR TITLE
fix(zsh): number gw worktrees by max existing prefix, not list count

### DIFF
--- a/tests/unit/gw-numbering-test.nix
+++ b/tests/unit/gw-numbering-test.nix
@@ -1,0 +1,34 @@
+# tests/unit/gw-numbering-test.nix
+# Verify gw _sanitize_branch numbers worktrees by scanning the max existing
+# numeric prefix in .worktrees, not by counting `git worktree list` entries.
+# Counting collides after a middle worktree is deleted.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  gwScript = import ../../users/shared/programs/zsh/gw.nix;
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "gw-numbering" [
+    (helpers.assertTest "gw-scans-worktrees-dir-for-max-num"
+      (lib.hasInfix ''ls "''${repo_root}/.worktrees"'' gwScript)
+      "gw _sanitize_branch should list .worktrees to find the max number"
+    )
+
+    (helpers.assertTest "gw-extracts-numeric-prefix" (lib.hasInfix "grep -oE '^[0-9]+'" gwScript)
+      "gw _sanitize_branch should extract the leading numeric prefix from directory names"
+    )
+
+    (helpers.assertTest "gw-does-not-count-worktree-list" (
+      !(lib.hasInfix "git worktree list | tail -n +2 | wc -l" gwScript)
+    ) "gw _sanitize_branch should not number by `git worktree list` count (collides after deletion)")
+  ];
+}

--- a/users/shared/programs/zsh/gw.nix
+++ b/users/shared/programs/zsh/gw.nix
@@ -68,12 +68,16 @@
     }
 
     # Helper: Sanitize branch name for directory (replace / with -)
-    # Prefix with zero-padded sequential number based on existing worktree count
+    # Prefix with zero-padded number = (highest existing number in .worktrees) + 1.
+    # Counting worktrees would collide after a middle entry is deleted, so we
+    # scan the actual directory names for the max numeric prefix instead.
     # Always returns an absolute path based on the main worktree root so gw works
     # correctly from inside a worktree (flat, not nested).
     local _sanitize_branch() {
       local repo_root=$(git worktree list | head -1 | awk '{print $1}')
-      local next_num=$(printf "%05d" $(( $(git worktree list | tail -n +2 | wc -l | tr -d ' ') + 1 )))
+      local max_num=$(ls "''${repo_root}/.worktrees" 2>/dev/null \
+        | grep -oE '^[0-9]+' | sort -n | tail -1)
+      local next_num=$(printf "%05d" $(( ''${max_num:-0} + 1 )))
       echo "''${repo_root}/.worktrees/''${next_num}-''${1//\//-}"
     }
 


### PR DESCRIPTION
## Summary

- `gw` 가 `.worktrees/00017-...` 형태로 새 worktree 디렉터리를 만들 때, 번호를 `git worktree list` **개수 + 1** 로 계산했음. 중간 worktree를 삭제하면 빈 번호가 생기고, 새로 만들 때 그 번호와 충돌해서 `Worktree already exists` 로 실패.
- 이제 `.worktrees/` 디렉터리에서 **최대 숫자 prefix + 1** 로 번호를 매김. 삭제와 무관하게 항상 단조 증가.

## Changes

- `users/shared/programs/zsh/gw.nix` — `_sanitize_branch` 가 `ls .worktrees | grep -oE '^[0-9]+' | sort -n | tail -1` 결과에 +1 해서 번호를 결정.
- `tests/unit/gw-numbering-test.nix` — 회귀 방지 단위 테스트 추가 (자동 발견).

## Test plan

- [x] `nix build .#checks.aarch64-darwin.unit-gw-numbering` 통과
- [x] 기존 `unit-gw-{sanitization,existing-worktree,random-collision}` 회귀 없음
- [x] `make format` 통과
- [x] pre-commit hooks (`Fast Tests`, `deadnix`, 기타) 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved worktree directory numbering to prevent collisions by scanning existing directories for the highest numeric prefix, rather than relying on total worktree count.

* **Tests**
  * Added unit tests for worktree numbering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baleen37/dotfiles/pull/1272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->