### PR TITLE
feat(karabiner): add hyper+s to toggle Slack

### DIFF
--- a/flake-modules/hosts.nix
+++ b/flake-modules/hosts.nix
@@ -15,11 +15,6 @@
       system = "aarch64-darwin";
       class = "darwin";
       user = "jito.hello";
-      homeModules = {
-        # 회사 macOS는 hammerspoon / karabiner를 사용하지 않는다
-        modules.programs.hammerspoon.enable = false;
-        modules.programs.karabiner.enable = false;
-      };
     };
     vm-aarch64-utm = {
       system = "aarch64-linux";

--- a/users/shared/programs/karabiner.nix
+++ b/users/shared/programs/karabiner.nix
@@ -53,7 +53,7 @@ let
       bundle = "md.obsidian";
       proc = "Obsidian";
     };
-    s = {
+    m = {
       bundle = "com.tinyspeck.slackmacgap";
       proc = "Slack";
     };

--- a/users/shared/programs/karabiner.nix
+++ b/users/shared/programs/karabiner.nix
@@ -53,6 +53,10 @@ let
       bundle = "md.obsidian";
       proc = "Obsidian";
     };
+    s = {
+      bundle = "com.tinyspeck.slackmacgap";
+      proc = "Slack";
+    };
     t = {
       bundle = "com.culturedcode.ThingsMac";
       proc = "Things3";


### PR DESCRIPTION
## 요약

회사 macOS(`kakaostyle-jito`)에서 hyper key가 동작하지 않던 문제를 수정합니다. hyper+s(Slack 토글)를 비롯한 모든 hyper 바인딩이 먹지 않던 원인은 호스트 설정에서 karabiner가 비활성화되어 있어 `right_command → hyper` 변환 자체가 일어나지 않았기 때문입니다.

## 변경사항

- [x] 설정 변경
- `flake-modules/hosts.nix`: `kakaostyle-jito`의 hammerspoon/karabiner 비활성화 블록 제거 → 두 모듈 모두 `default = isDarwin`이라 자동 활성화
- `users/shared/programs/karabiner.nix`: hyper+s로 Slack 토글하는 바인딩 추가

## 테스트 계획

- [x] `make build` 통과 (`nix build .#darwinConfigurations.kakaostyle-jito.system`)
- [x] 빌드된 `karabiner.json`에 Slack 토글(`slackmacgap`) 바인딩 포함 확인
- [x] hammerspoon 심링크(`~/.hammerspoon`)가 home-manager-files에 생성됨 확인
- [ ] `make switch` 후 실기기에서 hyper+s 동작 확인 (Karabiner 입력 모니터링 권한 필요)

## 추가 정보

switch 후 hyper 키가 동작하려면 Karabiner-Elements가 입력 모니터링 권한을 가지고 있어야 합니다(시스템 설정 > 개인정보 보호 > 입력 모니터링). 회사 머신에서 처음 켜는 것이라 권한 프롬프트가 뜰 수 있습니다.