### PR TITLE
fix(ghostty): disable shell-integration cursor feature

### DIFF
--- a/users/shared/programs/.config/ghostty/config
+++ b/users/shared/programs/.config/ghostty/config
@@ -15,7 +15,7 @@ window-padding-y = 10
 
 # Shell Integration
 shell-integration = true
-shell-integration-features = cursor,sudo,title
+shell-integration-features = no-cursor,sudo,title
 
 # Option key as Alt for terminal keybindings (opt+t for Claude Code think toggle)
 macos-option-as-alt=left


### PR DESCRIPTION
## 요약

Ghostty의 zsh shell-integration이 입력 모드 진입 시 `\e[5 q`(blinking beam) DECSCUSR를 보내는데, 이 beam 커서가 ZLE의 redraw 최적화와 맞물려 backspace 동작이 시각적으로 깨져 보이는 문제를 수정.

## 변경사항

- `users/shared/programs/.config/ghostty/config`: `shell-integration-features`에서 `cursor` → `no-cursor`

- [x] 버그 수정

## 동작 분석

`cd ` 입력 후 backspace 한 번 누를 때 zsh가 터미널로 내보내는 바이트:

```
c \x08 c d ' ' \x08
              └── 마지막 backspace 응답은 cursor-left 하나뿐
```

`cd abc` + backspace 한 번은 `...abc\x08 \x08`(back-space-back, 정상 erase)인데, **trailing space에 한해서만** `\x08`만 나오고 erase 시퀀스가 생략됨. ZLE 버퍼는 `cd`로 줄지만 화면의 공백 셀은 그대로 남음.

기본 block 커서면 그 셀을 커서가 덮어서 안 보이는데, shell-integration이 강제한 beam 커서로는 노출됨 → "공백이 추가됐다"로 보임.

`no-cursor`로 끄면 Ghostty 기본 block 커서가 유지되어 시각적 잔류 공백이 가려짐.

## 테스트 계획

- [x] `make switch` 통과 (로컬 적용 완료)
- [x] pre-commit 훅 통과
- [ ] 적용 후 Ghostty에서 `cd ` + backspace 시 잔류 공백 안 보임 확인