### PR TITLE
fix(ssh): let Ghostty manage ssh terminfo + move keepalive to ssh_config

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -216,8 +216,8 @@ in
     (helpers.assertTest "function-shell-exists" (initContentHas "shell()")
       "shell() function for nix-shell should exist"
     )
-    (helpers.assertTest "function-ssh-wrapper" (initContentHas "ssh()")
-      "ssh() wrapper function should exist"
+    (helpers.assertTest "alias-assh-exists" (initContentHas "alias assh=")
+      "assh alias for autossh should exist (plain ssh is delegated to Ghostty's wrapper)"
     )
 
     # Git Worktree function (gw)
@@ -281,10 +281,6 @@ in
 
     (helpers.assertTest "ssh-wrapper-first-poll" (initContentHas "AUTOSSH_FIRST_POLL")
       "ssh wrapper should set AUTOSSH_FIRST_POLL for autossh"
-    )
-
-    (helpers.assertTest "ssh-wrapper-tcp-keepalive" (initContentHas "TCPKeepAlive")
-      "ssh wrapper should enable TCP keepalive"
     )
 
     # SSH agent setup for GUI applications (macOS)

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -17,6 +17,7 @@
     ./programs/codex.nix
     ./programs/opencode.nix
     ./programs/ghostty.nix
+    ./programs/ssh.nix
     ./programs/hammerspoon.nix
     ./programs/karabiner.nix
 
@@ -48,6 +49,7 @@
     codex.enable = true;
     opencode.enable = true;
     ghostty.enable = true;
+    ssh.enable = true;
   };
 
   # All package categories are enabled for this configuration

--- a/users/shared/programs/.config/ghostty/config
+++ b/users/shared/programs/.config/ghostty/config
@@ -15,7 +15,7 @@ window-padding-y = 10
 
 # Shell Integration
 shell-integration = true
-shell-integration-features = no-cursor,sudo,title
+shell-integration-features = no-cursor,sudo,title,ssh-env,ssh-terminfo
 
 # Option key as Alt for terminal keybindings (opt+t for Claude Code think toggle)
 macos-option-as-alt=left

--- a/users/shared/programs/ssh.nix
+++ b/users/shared/programs/ssh.nix
@@ -1,0 +1,32 @@
+# SSH client configuration
+#
+# Manages ~/.ssh/config via home-manager so connection keepalive applies
+# uniformly to every host (including invocations through Ghostty's
+# ssh-terminfo wrapper). The OrbStack include is preserved at the top.
+
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.modules.programs.ssh;
+in
+{
+  options.modules.programs.ssh.enable = lib.mkEnableOption "SSH client config";
+
+  config = lib.mkIf cfg.enable {
+    programs.ssh = {
+      enable = true;
+      includes = [ "~/.orbstack/ssh/config" ];
+      matchBlocks."*" = {
+        serverAliveInterval = 60;
+        serverAliveCountMax = 3;
+        extraOptions = {
+          TCPKeepAlive = "yes";
+        };
+      };
+    };
+  };
+}

--- a/users/shared/programs/zsh/env.nix
+++ b/users/shared/programs/zsh/env.nix
@@ -39,6 +39,6 @@
   # npm configuration
   export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 
-  # GitHub CLI token
-  export GITHUB_TOKEN=$(gh auth token)
+  # GitHub CLI token (silent if not authenticated, e.g. on remote SSH hosts)
+  export GITHUB_TOKEN=$(gh auth token 2>/dev/null || true)
 ''

--- a/users/shared/programs/zsh/functions.nix
+++ b/users/shared/programs/zsh/functions.nix
@@ -2,8 +2,14 @@
 #
 # Provides:
 # - shell(): quick nix-shell access
-# - ssh(): enhanced SSH wrapper with autossh fallback
+# - cd(): multi-dot cd shortcut
+# - assh: autossh alias for long-lived connections
 # - setup_ssh_agent_for_gui(): SSH agent for GUI apps
+#
+# Note: ssh() is intentionally NOT overridden. Ghostty's shell-integration
+# installs its own ssh() to upload xterm-ghostty terminfo to remote hosts;
+# wrapping ssh here would shadow that. Keepalive options live in ~/.ssh/config
+# (programs.ssh module).
 
 ''
   # nix shortcuts
@@ -28,24 +34,10 @@
     fi
   }
 
-  # Enhanced SSH wrapper with intelligent reconnection
-  ssh() {
-    # Optimized connection wrapper with autossh fallback
-    if command -v autossh >/dev/null 2>&1; then
-      # Use autossh with optimized settings for reliability
-      AUTOSSH_POLL=60 AUTOSSH_FIRST_POLL=30 autossh -M 0 \
-        -o "ServerAliveInterval=30" \
-        -o "ServerAliveCountMax=3" \
-        "$@"
-    else
-      # Enhanced regular SSH with connection optimization
-      command ssh \
-        -o "ServerAliveInterval=60" \
-        -o "ServerAliveCountMax=3" \
-        -o "TCPKeepAlive=yes" \
-        "$@"
-    fi
-  }
+  # autossh for long-lived connections that need auto-reconnect.
+  # Plain `ssh` goes through Ghostty's shell-integration wrapper which
+  # uploads ghostty terminfo to the remote — don't shadow it.
+  alias assh='AUTOSSH_POLL=60 AUTOSSH_FIRST_POLL=30 autossh -M 0 -o ServerAliveInterval=30 -o ServerAliveCountMax=3'
 
   # SSH agent setup for GUI applications
   # Ensures GUI apps can access SSH agent for Git operations


### PR DESCRIPTION
## 요약

원격 SSH 호스트에서 매번 `can't find terminal definition for xterm-ghostty` 가 떠서 ncurses 기반 프로그램(tmux, vim 등)이 깨지는 근본 원인을 수정.

## 원인

`users/shared/programs/zsh/functions.nix` 의 `ssh()` 래퍼(autossh fallback)가 Ghostty shell-integration의 `ssh()` 래퍼를 **덮어씌우고** 있었음. Ghostty 래퍼는 `ssh-terminfo` 기능이 켜져 있을 때:

1. `command ssh -G "$@"` 로 user/hostname 파싱
2. 원격에 ghostty terminfo가 없으면 `infocmp -0 -x xterm-ghostty | ssh ... 'mkdir -p ~/.terminfo && tic -x -'` 로 자동 업로드
3. `ghostty +ssh-cache` 로 호스트별 캐싱
4. `TERM=xterm-ghostty` 와 `COLORTERM=truecolor` 환경변수 설정 후 실제 ssh 실행

사용자 wrapper가 이 모든 걸 우회해서 terminfo가 절대 업로드되지 않음.

## 변경사항

- `users/shared/programs/zsh/functions.nix`: `ssh()` 함수 제거. autossh가 정말 필요할 때를 위해 `assh` alias 추가.
- `users/shared/programs/ssh.nix` (신규): `programs.ssh` 모듈로 `~/.ssh/config` 관리.
  - `Host *` 에 `ServerAliveInterval=60`, `ServerAliveCountMax=3`, `TCPKeepAlive=yes` — 기존 wrapper가 옵션으로 주던 keepalive를 ssh_config로 이전 → 모든 ssh 호출에 동일 적용
  - 기존 OrbStack `Include ~/.orbstack/ssh/config` 보존
- `users/shared/programs/.config/ghostty/config`: `shell-integration-features` 에 `ssh-env,ssh-terminfo` 추가
- `users/shared/programs/zsh/env.nix`: `export GITHUB_TOKEN=\$(gh auth token 2>/dev/null || true)` — gh 인증 없는 원격에서 stderr spam 안 뜨도록

- [x] 버그 수정
- [x] 설정 변경

## 마이그레이션 노트

기존 `~/.ssh/config` (Orbstack include만 있던 파일)는 home-manager가 관리하려면 미리 이동되어 있어야 함. 본 PR 적용 전 `mv ~/.ssh/config ~/.ssh/config.before-home-manager` 한 뒤 `make switch`. 새 호스트에서는 첫 ssh 시 \"Setting up xterm-ghostty terminfo on <host>...\" 메시지가 한 번 뜨고 이후엔 캐시 사용.

## 테스트 계획

- [x] `make switch` 통과 (로컬 적용 완료)
- [x] pre-commit 훅 통과
- [x] `~/.ssh/config` 가 nix-managed 심볼릭으로 생성됨 확인
- [x] `ssh` 가 더 이상 zsh 함수가 아님 확인 (Ghostty 안에서만 shell-integration이 정의)
- [x] `assh` alias 동작 확인
- [ ] 새 Ghostty 창에서 SSH → terminfo 자동 업로드 + 캐시 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared SSH client configuration with built-in keepalive settings for more consistent terminal sessions.
  * Added a new `assh` shortcut for long-running, auto-reconnecting SSH connections.

* **Improvements**
  * Expanded Ghostty shell integration with additional SSH-related features.
  * Updated shell environment behavior so GitHub CLI token setup no longer errors when not authenticated.

* **Tests**
  * Updated Zsh integration coverage to reflect the new SSH shortcut behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->