### PR TITLE
Merge remote-tracking branch 'origin/main' into snappy-pebble-knuth

### DIFF
--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -80,8 +80,8 @@ in
   # OSC52 clipboard integration (cross-platform, works over SSH)
   # ============================================================================
   tmux-osc52-clipboard =
-    mkConfigTest "tmux-osc52-clipboard" (hasConfigString "set -s set-clipboard external")
-      "tmux should use OSC52 for cross-platform clipboard";
+    mkConfigTest "tmux-osc52-clipboard" (hasConfigString "set -s set-clipboard on")
+      "tmux should use OSC52 for cross-platform clipboard (on: also accepts inner-app yanks)";
 
   tmux-osc52-copy-bindings =
     mkConfigTest "tmux-osc52-copy-bindings"

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -6,7 +6,8 @@
 #   - Ctrl-a prefix (screen-style)
 #   - Intuitive split bindings: | (vertical), - (horizontal)
 #   - Vim-style pane navigation: h/j/k/l
-#   - Vi-style copy mode with OSC52 clipboard support
+#   - Vi-style copy mode with tmux-native OSC52 clipboard support
+#   - Truecolor (RGB) + undercurl inherited from xterm-ghostty terminfo
 #   - Cross-platform: Works on macOS, Linux, and remote SSH
 #   - Seamless Vim integration: vim-tmux-navigator plugin
 #
@@ -47,7 +48,7 @@ in
 
       plugins = [ ];
 
-      terminal = "screen-256color";
+      terminal = "tmux-256color";
       prefix = "C-a";
       escapeTime = 0;
       historyLimit = 50000;
@@ -57,13 +58,12 @@ in
         # ============================================================================
         # Base configuration
         # ============================================================================
-        set -g default-terminal "tmux-256color"
+        # default-terminal is emitted by programs.tmux.terminal = "tmux-256color"
         set -g default-shell ${pkgs.zsh}/bin/zsh
         set -g default-command "${pkgs.zsh}/bin/zsh -l"
         set -g focus-events on
 
         # Terminal and display settings
-        set-environment -g TERM screen-256color
         set -g mouse on
         bind-key -n MouseDown2Pane paste-buffer
         set -g base-index 1
@@ -73,7 +73,7 @@ in
         # Performance optimizations
         set -g display-time 2000
         set -g repeat-time 500
-        set -g status-interval 1
+        set -g status-interval 5
 
         # Session settings
         set -g remain-on-exit off
@@ -134,23 +134,34 @@ in
         bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
         bind-key -T copy-mode-vi Escape send-keys -X cancel
 
-        # OSC52 clipboard integration for remote SSH support
-        set -s set-clipboard external
+        # OSC52 clipboard integration. The xterm-ghostty terminfo carries the Ms
+        # capability, so tmux emits OSC52 itself on copy — no manual printf hack
+        # needed. 'on' (vs 'external') also lets apps inside tmux (Neovim/agent
+        # OSC52 yank) populate the clipboard. allow-passthrough keeps DCS-wrapped
+        # OSC52 from coding agents (Claude Code, etc.) working through tmux.
+        set -s set-clipboard on
         set -g allow-passthrough on
 
-        # OSC52 copy bindings (works over SSH)
-        bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "sh -c 'b64=\$(dd bs=1 count=100000 status=none | base64 | tr -d \"\\n\"); printf \"\\033]52;c;%s\\a\" \"\$b64\" > \"\$1\"' sh #{client_tty}"
-        bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "sh -c 'b64=\$(dd bs=1 count=100000 status=none | base64 | tr -d \"\\n\"); printf \"\\033]52;c;%s\\a\" \"\$b64\" > \"\$1\"' sh #{client_tty}"
-        bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "sh -c 'b64=\$(dd bs=1 count=100000 status=none | base64 | tr -d \"\\n\"); printf \"\\033]52;c;%s\\a\" \"\$b64\" > \"\$1\"' sh #{client_tty}"
+        # Copy to system clipboard via tmux-native OSC52 (works over SSH).
+        bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+        bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel
+        bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
 
         # ============================================================================
         # Terminal capabilities
         # ============================================================================
-        set -ga terminal-overrides ",*256col*:Tc,*:U8=0"
-        set-window-option -g xterm-keys on
+        # Truecolor (RGB). terminal-features matches the OUTER terminal's TERM,
+        # which is xterm-ghostty under Ghostty. The xterm-ghostty terminfo also
+        # already advertises Smulx/Setulc (undercurl) and Ss/Se (cursor shape),
+        # so no manual terminal-overrides are needed for those.
+        set -as terminal-features ',xterm-ghostty:RGB'
+
+        # Extended keys (CSI u). Ghostty speaks the CSI-u encoding; tmux 3.6
+        # defaults extended-keys-format to xterm form, so set csi-u explicitly
+        # for modifier combos (e.g. Shift+Enter) to reach apps inside tmux.
         set-option -g extended-keys on
-        set -as terminal-features 'xterm*:extkeys'
-        set -as terminal-overrides ',*:keys=\E[u'
+        set-option -s extended-keys-format csi-u
+        set -as terminal-features ',xterm-ghostty:extkeys'
 
         # ============================================================================
         # Status bar
@@ -161,7 +172,7 @@ in
         set -g status-left-length 20
         set -g status-right-length 50
         set -g status-left '#[fg=colour233,bg=colour241,bold] #S '
-        set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
+        set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M '
 
         # Window status display
         setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '


### PR DESCRIPTION
## 요약

Ghostty 안에서 tmux를 쓸 때의 베스트프랙티스를 적용합니다. `xterm-ghostty` terminfo가 설치되어 RGB/undercurl/OSC52(Ms)/cursor(Ss·Se) 능력을 모두 갖추고 있다는 점(실측 확인)을 전제로, ghostty 네이티브 터미널 처리에 통일하고 불필요한 수동 워크어라운드를 제거했습니다. statusline 디자인은 그대로 유지합니다.

## 변경사항

- [ ] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [x] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경

- `screen-256color` 강제 TERM 제거 → tmux 안 `tmux-256color`, 바깥 `xterm-ghostty`로 통일하여 ghostty의 truecolor/undercurl이 tmux 안에서도 살아남도록 함
- 수동 OSC52 `printf` hack → tmux 네이티브 `copy-pipe-and-cancel`로 교체 (terminfo에 `Ms` 존재). **100KB 복사 잘림 버그 제거**
- `set-clipboard external` → `on`: tmux 안 앱(Neovim/coding agent)의 OSC52 yank도 클립보드에 도달
- `extended-keys-format csi-u` 추가: Ghostty의 CSI-u 키 인코딩에 맞춰 Shift+Enter 등 modifier 조합이 tmux 안 앱까지 전달
- no-op였던 `tmux-256color:RGB`(terminal-features는 바깥 TERM만 매칭) 및 terminfo에 이미 있는 undercurl 오버라이드 제거
- 중복 `default-terminal` 제거, `status-interval 1 → 5`(초단위 시계 갱신 부하 제거)

## 테스트 계획

- [x] `make test` 통과 (preflight에서 All Tests Passed)
- [x] `make build` 통과 (darwin 시스템 빌드 성공, tmux.conf 내용 실측 검증)
- [ ] `make switch` 후 `tmux kill-server`로 재시작하여 로컬 동작 확인 (sudo 필요 — 머지 후 직접 적용)

## 추가 정보

- terminfo 능력은 `infocmp -x xterm-ghostty`로 실측: `Ms=`, `Smulx`, `Setulc`, `Ss=`, `Se=` 모두 존재 확인. 따라서 `xterm-ghostty:`로 스코프된 수동 오버라이드는 전부 재선언 중복이라 추가하지 않음.
- 적용 후 검증: `tmux info | grep -iE 'Ms:|RGB|Tc'`, copy-mode `y` 복사 → macOS 앱 붙여넣기.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 변경사항이 기존 기능을 손상시키지 않음