### PR TITLE
feat(tmux): propagate session/window to Ghostty title; drop redundant -l

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ trusted-users = root @admin yourusername
 - **users/shared/programs/git.nix**: Git configuration with centralized user info from lib/user-info.nix
 - **users/shared/programs/vim.nix**: Vim setup with airline, tmux-navigator, relative line numbers
 - **users/shared/programs/zsh.nix**: Zsh environment with fzf, direnv, Claude/OpenCode aliases
-- **users/shared/programs/tmux.nix**: Tmux config with vi-mode copy-paste, session persistence
+- **users/shared/programs/tmux.nix**: Tmux config with vi-mode copy-paste, OSC52 clipboard
 - **users/shared/programs/starship.nix**: Minimal prompt configuration
 - **users/shared/programs/claude-code.nix**: Claude Code commands/skills/hooks deployment
 
@@ -380,9 +380,8 @@ The zsh configuration provides these shortcuts (defined in `users/shared/program
 **Tmux** (users/shared/programs/tmux.nix):
 
 - Prefix: Ctrl+a
-- Vi-style copy mode with clipboard integration
-- Cross-platform: pbcopy (macOS), xclip (Linux)
-- Session persistence via resurrect/continuum plugins
+- Vi-style copy mode with tmux-native OSC52 clipboard (works over SSH)
+- Cross-platform: OSC52 (no pbcopy/xclip dependency)
 
 **Fzf** (in zsh.nix):
 

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -76,6 +76,10 @@ in
     mkConfigTest "tmux-vim-pane-navigation" (hasConfigString "bind h select-pane -L")
       "tmux should use vim-style pane navigation (hjkl)";
 
+  tmux-set-titles =
+    mkConfigTest "tmux-set-titles" (hasConfigString "set -g set-titles on")
+      "tmux should propagate session/window to the terminal title (Ghostty tab identification)";
+
   # ============================================================================
   # OSC52 clipboard integration (cross-platform, works over SSH)
   # ============================================================================

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -60,7 +60,7 @@ in
         # ============================================================================
         # default-terminal is emitted by programs.tmux.terminal = "tmux-256color"
         set -g default-shell ${pkgs.zsh}/bin/zsh
-        set -g default-command "${pkgs.zsh}/bin/zsh -l"
+        # default-command left unset: tmux runs default-shell as a login shell
         set -g focus-events on
 
         # Terminal and display settings
@@ -79,6 +79,12 @@ in
         set -g remain-on-exit off
         set -g allow-rename off
         set -g destroy-unattached off
+
+        # Propagate session/window to the Ghostty tab/window title so multiple
+        # tabs are distinguishable. Complements allow-rename off: apps can't
+        # hijack the name via OSC, but tmux itself sets the outer title.
+        set -g set-titles on
+        set -g set-titles-string "#S  #I:#W"
 
         # ============================================================================
         # Prefix key bindings (Ctrl-a style)


### PR DESCRIPTION
## 요약

직전 PR(#1278)에 이어, Ghostty+tmux의 다음 티어 베스트프랙티스를 적용합니다. competitive-agents로 두 관점(간결성/완전성)을 리서치하고, **양쪽이 교차 검증한 high-confidence 항목만** 채택했습니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] 문서 업데이트
- [x] 리팩토링
- [x] 설정 변경

- **`set-titles on` 추가**: tmux 세션/윈도우를 Ghostty 탭·창 제목에 전파하여 여러 탭을 구분 가능. `set-titles`는 기본이 off라 지금까진 제목이 갱신되지 않았음. `allow-rename off`와 보완 관계(앱의 이름 탈취는 막되 tmux가 직접 외부 제목 설정).
- **`default-command "zsh -l"` 제거**: tmux는 `default-command`가 비어 있으면 `default-shell`을 **login shell**로 실행하므로 수동 `-l`은 기본 동작을 중복 재현한 것. 동작 동일, 설정 단순화.
- **CLAUDE.md 문서 드리프트 정정**: tmux는 네이티브 OSC52 사용(pbcopy/xclip 아님), resurrect/continuum 세션 영속성은 실제로 없음(`plugins = []`).

## 테스트 계획

- [x] `make test` 통과 (preflight Fast Tests + pre-commit)
- [x] `make build` 통과 (darwin 시스템 빌드 성공, 생성된 tmux.conf에 set-titles 반영 / default-command 부재 확인)
- [x] `tmux-set-titles` 통합 테스트 추가 후 nix build로 통과 검증
- [ ] `make switch` + `tmux kill-server`로 로컬 동작 확인 (머지 후 직접)

## 추가 정보

리서치에서 검토 후 **기각**한 항목(참고): resurrect/continuum 추가(coding agent는 복원이 불안정 → 문서만 정정), display-popup·pane-border-status·copy-mode search 바인딩(취향), `aggressive-resize`(single-client 환경에선 무의미), Ghostty `title-report`(보안상 비활성 유지), `clipboard-paste-protection=false`(안전장치 유지), Ghostty 네이티브 tmux control-mode(1.4까지 미지원). SSH 원격 terminfo(`ssh-env,ssh-terminfo`)는 이미 Ghostty config에 적용되어 있어 변경 불필요.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음