### PR TITLE
feat(neru): add Neru keyboard navigation bound to Hyper+F

### DIFF
--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -28,6 +28,7 @@ let
     "alt-tab"
     "claude"
     "karabiner-elements" # Key remapping and modification tool
+    "y3owk1n/tap/neru" # Free, open-source keyboard navigation (Homerow alternative)
     "orbstack" # Docker and Linux VM management
     "tailscale-app" # VPN mesh network with GUI
     "teleport-connect" # Teleport GUI client for secure infrastructure access
@@ -92,6 +93,7 @@ in
     # Note: homebrew/cask is now built into Homebrew by default (since 2023)
     taps = [
       "daipeihust/tap" # im-select
+      "y3owk1n/tap" # neru
     ];
   };
 }

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -20,6 +20,7 @@
     ./programs/ssh.nix
     ./programs/hammerspoon.nix
     ./programs/karabiner.nix
+    ./programs/neru.nix
 
     # Package categories — modules.packages.<name>.enable
     ./packages/core.nix

--- a/users/shared/programs/.config/neru/config.toml
+++ b/users/shared/programs/.config/neru/config.toml
@@ -1,0 +1,362 @@
+# Neru default configuration
+# Copy to ~/.config/neru/config.toml to customize.
+
+# Full config reference: https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md
+# Full CLI reference: https://github.com/y3owk1n/neru/blob/main/docs/CLI.md
+
+# General settings
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#general
+[general]
+excluded_apps = []                           # Bundle IDs to ignore (e.g. "com.apple.Terminal")
+kb_layout_to_use = ""                        # Force a keyboard layout InputSourceID (empty = auto)
+passthrough_unbounded_keys = false           # Let unbound Cmd/Ctrl/Alt shortcuts reach macOS
+should_exit_after_passthrough = false        # Exit the current mode after a shortcut is passed through
+passthrough_unbounded_keys_blacklist = []    # Shortcuts to still consume when passthrough is on
+hide_overlay_in_screen_share = false         # Hide overlay from screen sharing apps
+exec_shell = "/bin/bash"                     # Shell used for exec commands (e.g. "/bin/dash", "/bin/zsh")
+exec_shell_args = ["-lc"]                    # Shell arguments, where the last argument will be the command string
+
+# Theme palette
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#theme
+[theme.light]
+surface = "#EEF2FF"
+accent = "#465FBC"
+accent_alt = "#0B2377"
+on_accent_alt = "#F8FAFF"
+text = "#17327A"
+
+[theme.dark]
+surface = "#0A1338"
+accent = "#6E82D6"
+accent_alt = "#8FA2F0"
+on_accent_alt = "#081022"
+text = "#E8EEFF"
+
+# Hotkeys
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hotkeys
+# See https://github.com/y3owk1n/neru/blob/main/docs/CLI.md
+[hotkeys]
+"Cmd+Ctrl+Alt+Shift+F" = "hints"   # Hyper+F (right_command+F via Karabiner mega-chord)
+"Primary+Shift+G" = "grid"
+"Primary+Shift+C" = "recursive_grid"
+"Primary+Shift+S" = "scroll"
+
+# Hint mode
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hints
+[hints]
+enabled = true
+strategy = "axtree"                          # Element detection: "axtree" (AX API) or "vision" (Vision Framework)
+hint_characters = "asdfghjkl"               # Characters used for hint labels
+max_depth = 50                              # Max accessibility tree depth (0 = unlimited)
+include_menubar_hints = false
+additional_menubar_hints_targets = [
+    "com.apple.TextInputMenuAgent",
+    "com.apple.controlcenter",
+    "com.apple.systemuiserver",
+    "com.y3owk1n.neru",
+]
+include_dock_hints = false
+include_nc_hints = false
+include_stage_manager_hints = false
+include_pip_hints = false
+include_screen_capture_hints = false
+detect_mission_control = false
+clickable_roles = [
+    "AXButton",
+	"AXMenuButton",
+    "AXComboBox",
+    "AXCheckBox",
+    "AXRadioButton",
+    "AXLink",
+    "AXPopUpButton",
+    "AXTextField",
+    "AXSlider",
+    "AXTabButton",
+    "AXSwitch",
+    "AXDisclosureTriangle",
+    "AXTextArea",
+    "AXMenuItem",
+    "AXCell",
+    "AXRow",
+	"AXGenericElement",
+]
+ignore_clickable_check = false
+visible_check_enabled = false
+
+[hints.hotkeys]
+"Escape" = "idle"
+"/" = "action search_hints"
+"Backspace" = "action backspace"
+"Tab" = "action cycle_hint"
+"Shift+Tab" = "action cycle_hint --backward"
+"Shift+L" = "action left_click"
+"Shift+R" = "action right_click"
+"Shift+M" = "action middle_click"
+"Shift+I" = "action mouse_down"
+"Shift+U" = "action mouse_up"
+"Up" = "action move_mouse_relative --dx=0 --dy=-10"
+"Down" = "action move_mouse_relative --dx=0 --dy=10"
+"Left" = "action move_mouse_relative --dx=-10 --dy=0"
+"Right" = "action move_mouse_relative --dx=10 --dy=0"
+
+[hints.additional_ax_support]
+enable = false                              # Enable enhanced AX for Electron/Chromium/Firefox/WebKit apps
+additional_electron_bundles = []
+additional_chromium_bundles = []
+additional_firefox_bundles = []
+additional_webkit_bundles = []
+
+[hints.ui]
+font_size = 10
+font_family = ""                            # Empty = system font
+border_radius = -1                          # -1 = auto pill
+padding_x = -1                              # -1 = auto based on font size
+padding_y = -1                              # -1 = auto based on font size
+border_width = 1
+placement = "bottom"                        # top, center, bottom
+
+[hints.search_input_ui]
+font_size = 10
+font_family = ""                            # Empty = system font
+border_radius = -1                          # -1 = auto pill
+padding_x = -1                              # -1 = auto based on font size
+padding_y = -1                              # -1 = auto based on font size
+border_width = 1
+position = "bottom_center"                     # top_left, top_center, top_right, center, bottom_left, bottom_center, bottom_right
+x_offset = 0                                # Offset from the selected position on the active screen
+y_offset = 24                               # Offset from the selected position on the active screen
+width = 320                                 # Search input width in pixels
+
+[hints.boundary_highlight]
+enabled = false                             # Draw a subtle outline around each target element
+border_width = 1
+border_radius = -1                          # -1 = auto pill
+
+[hints.vision]
+detect_text = true                           # Enable text detection via Vision framework
+detect_rectangles = true                     # Enable rectangle detection via Vision framework
+request_timeout_ms = 5000                    # Timeout for Vision requests in milliseconds
+minimum_confidence = 0.0                     # Minimum confidence threshold for keeping vision observations
+merge_iou_threshold = 0.5                    # Overlap threshold (Intersection over Union) for merging redundant boxes
+rectangle_max_candidates = 100               # Maximum number of rectangle candidate observations to track
+rectangle_min_size = 0.01                    # Minimum size of detected rectangles (0.01 = 1% of screen/window width/height)
+rectangle_min_aspect = 0.3                   # Minimum aspect ratio (width/height) for rectangles
+rectangle_max_aspect = 10.0                  # Maximum aspect ratio (width/height) for rectangles
+button_min_confidence = 0.3                  # Minimum confidence for button classification
+button_min_aspect = 0.8                      # Minimum aspect ratio for button elements
+button_max_aspect = 8.0                      # Maximum aspect ratio for button elements
+button_icon_max_size = 48                    # Maximum width/height for square button/icon elements (px)
+link_min_aspect = 5.0                        # Minimum aspect ratio for text link elements
+link_max_height = 40                         # Maximum height for link elements (px)
+link_min_width = 50                          # Minimum width for link elements (px)
+image_min_size = 48                          # Minimum width/height for image elements (px)
+checkbox_max_size = 32                       # Maximum width/height for checkbox elements (px)
+generic_clickable_min_confidence = 0.5       # Minimum confidence for generic clickable classification
+
+# Grid mode
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#grid
+[grid]
+enabled = true
+characters = "abcdefghijklmnpqrstuvwxyz"    # Primary grid labels
+sublayer_keys = "abcdefghijklmnpqrstuvwxyz" # Subgrid labels (fallback to characters)
+live_match_update = true                    # Highlight cells as you type
+hide_unmatched = true                       # Hide non-matching cells
+prewarm_enabled = true                      # Pre-compute grid on startup (~1.5MB RAM)
+enable_gc = false                           # Periodic memory cleanup (adds CPU overhead)
+
+[grid.hotkeys]
+"Escape" = "idle"
+"`" = "toggle-cursor-follow-selection"
+"Space" = "action reset"
+"Backspace" = "action backspace"
+"Shift+L" = "action left_click"
+"Shift+R" = "action right_click"
+"Shift+M" = "action middle_click"
+"Shift+I" = "action mouse_down"
+"Shift+U" = "action mouse_up"
+"Up" = "action move_mouse_relative --dx=0 --dy=-10"
+"Down" = "action move_mouse_relative --dx=0 --dy=10"
+"Left" = "action move_mouse_relative --dx=-10 --dy=0"
+"Right" = "action move_mouse_relative --dx=10 --dy=0"
+
+[grid.ui]
+font_size = 10
+font_family = ""
+border_width = 1
+
+# Recursive grid mode (recommended)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#recursive_grid
+[recursive_grid]
+enabled = true
+grid_cols = 3                               # Number of columns (>= 1)
+grid_rows = 3                               # Number of rows (>= 1)
+keys = "rtyfghvbn"                          # Cell selection keys (must be grid_cols * grid_rows chars)
+min_size_width = 25                         # Stop subdividing below this width (px)
+min_size_height = 25                        # Stop subdividing below this height (px)
+max_depth = 10                              # Maximum recursion levels (1–20)
+
+[recursive_grid.animation]
+enabled = true                              # Opt out from native depth transition animation on supported platforms
+duration_ms = 50                            # Recursive-grid animation duration in milliseconds
+
+[recursive_grid.hotkeys]
+"Escape" = "idle"
+"`" = "toggle-cursor-follow-selection"
+"Space" = "action reset"
+"Backspace" = "action backspace"
+"Shift+L" = "action left_click"
+"Shift+R" = "action right_click"
+"Shift+M" = "action middle_click"
+"Shift+I" = "action mouse_down"
+"Shift+U" = "action mouse_up"
+"Up" = "action move_mouse_relative --dx=0 --dy=-10"
+"Down" = "action move_mouse_relative --dx=0 --dy=10"
+"Left" = "action move_mouse_relative --dx=-10 --dy=0"
+"Right" = "action move_mouse_relative --dx=10 --dy=0"
+
+[recursive_grid.ui]
+line_width = 1
+font_size = 10
+font_family = ""
+label_background = false                    # Add rounded backgrounds behind cell labels
+label_background_padding_x = -1
+label_background_padding_y = -1
+label_background_border_radius = -1
+label_background_border_width = 1
+sub_key_preview = false                     # Draw miniature key grid inside each cell
+sub_key_preview_font_size = 8
+sub_key_preview_autohide_multiplier = 1.5
+
+# Virtual pointer
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#virtual_pointer
+[virtual_pointer]
+enabled = true
+
+[virtual_pointer.ui]
+size = 3
+
+# Mouse action indicator (macOS)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#mouse_action_indicator
+[mouse_action_indicator]
+enabled = false                             # Disabled by default
+actions = ["left_click", "right_click", "middle_click", "mouse_down", "mouse_up"]
+
+[mouse_action_indicator.ui]
+size = 36
+border_width = 2
+shape = "circle"                            # circle or square
+
+[mouse_action_indicator.animation]
+duration_ms = 260
+start_scale = 0.55
+end_scale = 1.35
+start_opacity = 0.85
+end_opacity = 0.0
+easing = "ease_out"                         # linear, ease_in, ease_out, ease_in_out
+
+# Scroll mode
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#scroll
+[scroll]
+scroll_step = 50                            # Pixels per j/k press
+scroll_step_half = 500                      # Pixels for d/u (half page)
+scroll_step_full = 1000000                  # Pixels for gg/G (top/bottom)
+invert_scroll = false                       # Invert scroll direction (for tools like Mos)
+
+[scroll.hotkeys]
+"Escape" = "idle"
+"k" = "action scroll_up"
+"j" = "action scroll_down"
+"h" = "action scroll_left"
+"l" = "action scroll_right"
+"gg" = "action go_top"
+"Shift+G" = "action go_bottom"
+"u" = "action page_up"
+"PageUp" = "action page_up"
+"d" = "action page_down"
+"PageDown" = "action page_down"
+"Shift+L" = "action left_click"
+"Shift+R" = "action right_click"
+"Shift+M" = "action middle_click"
+"Shift+I" = "action mouse_down"
+"Shift+U" = "action mouse_up"
+"Up" = "action move_mouse_relative --dx=0 --dy=-10"
+"Down" = "action move_mouse_relative --dx=0 --dy=10"
+"Left" = "action move_mouse_relative --dx=-10 --dy=0"
+"Right" = "action move_mouse_relative --dx=10 --dy=0"
+
+# Mode indicator
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#mode_indicator
+[mode_indicator]
+
+[mode_indicator.scroll]
+enabled = true
+text = "Scroll"
+
+[mode_indicator.hints]
+enabled = false
+text = "Hints"
+
+[mode_indicator.grid]
+enabled = false
+text = "Grid"
+
+[mode_indicator.recursive_grid]
+enabled = false
+text = "Recursive Grid"
+
+[mode_indicator.ui]
+font_size = 10
+font_family = ""
+border_width = 1
+padding_x = -1
+padding_y = -1
+border_radius = -1
+indicator_x_offset = 20
+indicator_y_offset = 20
+
+# Sticky modifiers
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#sticky_modifiers
+[sticky_modifiers]
+enabled = true
+tap_max_duration = 300
+
+[sticky_modifiers.ui]
+font_size = 10
+font_family = ""
+border_width = 1
+padding_x = -1
+padding_y = -1
+border_radius = -1
+indicator_x_offset = -40
+indicator_y_offset = 20
+
+# Smooth cursor (animates cursor movement between positions)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_cursor
+[smooth_cursor]
+move_mouse_enabled = false                  # Enable smooth mouse movement
+steps = 10                                  # Number of intermediate positions
+max_duration = 200                          # Maximum animation duration in ms
+duration_per_pixel = 0.1                    # Ms per pixel for adaptive duration
+
+# Smooth scroll (animates scroll actions with eased chunking)
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#smooth_scroll
+[smooth_scroll]
+enabled = false                             # Enable smooth scrolling
+steps = 20                                  # Number of animation steps
+max_duration = 180                          # Maximum animation duration in ms
+duration_per_pixel = 1.00                   # Ms per pixel for adaptive duration
+
+# Systray
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#systray
+[systray]
+enabled = true                              # Show menu bar icon (false = headless mode)
+
+# Logging
+# See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#logging
+[logging]
+log_level = "info"                          # debug, info, warn, error
+log_file = ""                               # Custom log path (empty = default location)
+disable_file_logging = true                 # Console only (no file); file logs use JSON
+max_file_size = 10                          # MB before rotation
+max_backups = 5                             # Old log files to keep
+max_age = 30                                # Days to retain old logs

--- a/users/shared/programs/.config/neru/config.toml
+++ b/users/shared/programs/.config/neru/config.toml
@@ -9,7 +9,7 @@
 [general]
 excluded_apps = []                           # Bundle IDs to ignore (e.g. "com.apple.Terminal")
 kb_layout_to_use = ""                        # Force a keyboard layout InputSourceID (empty = auto)
-passthrough_unbounded_keys = false           # Let unbound Cmd/Ctrl/Alt shortcuts reach macOS
+passthrough_unbounded_keys = true            # Let unbound Cmd/Ctrl/Alt shortcuts reach macOS
 should_exit_after_passthrough = false        # Exit the current mode after a shortcut is passed through
 passthrough_unbounded_keys_blacklist = []    # Shortcuts to still consume when passthrough is on
 hide_overlay_in_screen_share = false         # Hide overlay from screen sharing apps
@@ -100,7 +100,7 @@ visible_check_enabled = false
 "Right" = "action move_mouse_relative --dx=10 --dy=0"
 
 [hints.additional_ax_support]
-enable = false                              # Enable enhanced AX for Electron/Chromium/Firefox/WebKit apps
+enable = true                               # Enable enhanced AX for Electron/Chromium/Firefox/WebKit apps
 additional_electron_bundles = []
 additional_chromium_bundles = []
 additional_firefox_bundles = []
@@ -270,6 +270,8 @@ invert_scroll = false                       # Invert scroll direction (for tools
 "l" = "action scroll_right"
 "gg" = "action go_top"
 "Shift+G" = "action go_bottom"
+"Ctrl+U" = "action page_up"
+"Ctrl+D" = "action page_down"
 "u" = "action page_up"
 "PageUp" = "action page_up"
 "d" = "action page_down"
@@ -293,7 +295,7 @@ enabled = true
 text = "Scroll"
 
 [mode_indicator.hints]
-enabled = false
+enabled = true
 text = "Hints"
 
 [mode_indicator.grid]

--- a/users/shared/programs/karabiner.nix
+++ b/users/shared/programs/karabiner.nix
@@ -33,10 +33,6 @@ let
       bundle = "com.apple.mail";
       proc = "Mail";
     };
-    f = {
-      bundle = "com.apple.finder";
-      proc = "Finder";
-    };
     h = {
       bundle = "com.kapeli.dashdoc";
       proc = "Dash";
@@ -70,6 +66,7 @@ let
     comma = "com.culturedcode.ThingsMac";
     period = "com.culturedcode.ThingsMac";
     b = "com.surteesstudios.Bartender";
+    f = "com.y3owk1n.neru"; # Hyper+F → mega-chord; Neru activation key in config.toml
     l = "com.dexterleng.Homerow";
     u = "com.flexibits.cardhop.mac";
     return_or_enter = "com.superultra.Homerow";

--- a/users/shared/programs/neru.nix
+++ b/users/shared/programs/neru.nix
@@ -1,0 +1,29 @@
+# users/shared/programs/neru.nix
+# Neru configuration (macOS keyboard navigation, Homerow alternative)
+#
+# Neru reads ~/.config/neru/config.toml and hot-reloads on change. The hints
+# mode is bound to Hyper+F: Karabiner forwards right_command+F as the mega-chord
+# cmd+ctrl+opt+shift+f (see karabiner.nix hyperLocal.f), which Neru picks up.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.modules.programs.neru;
+in
+{
+  options.modules.programs.neru.enable = lib.mkEnableOption "Neru (macOS)" // {
+    default = pkgs.stdenv.hostPlatform.isDarwin;
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.file.".config/neru/config.toml" = {
+      source = ./.config/neru/config.toml;
+      force = true;
+    };
+  };
+}

--- a/users/shared/programs/ssh.nix
+++ b/users/shared/programs/ssh.nix
@@ -20,11 +20,22 @@ in
     programs.ssh = {
       enable = true;
       includes = [ "~/.orbstack/ssh/config" ];
-      matchBlocks."*" = {
-        serverAliveInterval = 60;
-        serverAliveCountMax = 3;
-        extraOptions = {
-          TCPKeepAlive = "yes";
+      matchBlocks = {
+        "*" = {
+          serverAliveInterval = 60;
+          serverAliveCountMax = 3;
+          extraOptions = {
+            TCPKeepAlive = "yes";
+          };
+        };
+        "github.com" = {
+          hostname = "github.com";
+          user = "git";
+          identityFile = "~/.ssh/id_ed25519_github";
+          identitiesOnly = true;
+          extraOptions = {
+            StrictHostKeyChecking = "no";
+          };
         };
       };
     };


### PR DESCRIPTION
## 요약

Homerow의 무료·오픈소스 대안인 **Neru**(macOS 키보드 내비게이션)를 도입하고 `Hyper+F`에 hints 모드를 바인딩합니다. 적용을 막던 기존 `~/.ssh/config` 충돌도 함께 해소합니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 설정 변경

- **Neru 설치**: `darwin/homebrew.nix`에 cask `y3owk1n/tap/neru` + tap `y3owk1n/tap` 추가
- **config 관리**: `programs/neru.nix` 신규 모듈(macOS 전용 default)로 `~/.config/neru/config.toml` 관리, hints 모드를 `Cmd+Ctrl+Alt+Shift+F`에 바인딩
- **Hyper+F 연결**: `karabiner.nix`에서 기존 `Hyper+F = Finder` 토글을 제거하고 `hyperLocal.f = neru` 추가 → Karabiner가 mega-chord(⌘⌥⌃⇧+F)로 포워딩, Neru가 수신
- **SSH 충돌 수정**: 수동으로 작성돼 있던 `github.com` host 블록을 `ssh.nix`에 선언적으로 편입 → home-manager가 완전한 config를 생성, switch 차단 해소 (설정 유실 없음)

## 테스트 계획

- [x] `make format` 통과 (변경 없음)
- [x] `nix build .#darwinConfigurations.kakaostyle-jito.system` 통과
- [x] 생성될 ssh config가 GitHub host + OrbStack include + keepalive 모두 포함 검증
- [ ] `make switch` 후 손쉬운 접근 권한 부여 + `neru launch` → 우측 Cmd+F로 hints 라벨 표시 확인 (로컬 수동)

## 추가 정보

- `make switch`는 sudo 비밀번호가 필요해 세션 내 실행 불가 — 사용자가 로컬에서 적용 예정
- 적용 후: 시스템 설정 → 개인정보 보호 및 보안 → 손쉬운 접근에서 Neru 허용 필요
- 기존 ssh config는 `~/.ssh/config.pre-hm-backup`으로 백업해둠