### PR TITLE
feat(neru): trigger hints via Hyper+L mega-chord, drop Hammerspoon leader

### DIFF
--- a/users/shared/programs/.config/hammerspoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/init.lua
@@ -36,22 +36,6 @@ Pomodoro:init({
 -- Bind Hyper+P to toggle Pomodoro session
 Hyper:bind({}, 'p', function() Pomodoro:toggleSession() end)
 
--- Neru leader: Hyper+, enters a sub-modal that waits for one key to pick a
--- Neru navigation mode. Triggered via CLI so config.toml needs no [hotkeys].
---   Hyper+, then  f → hints   s → scroll   g → grid   c → recursive grid
--- Esc (or any other key) cancels.
-local neru = "/opt/homebrew/bin/neru"
-local neruModal = hs.hotkey.modal.new()
-local neruModes = { f = "hints", s = "scroll", g = "grid", c = "recursive_grid" }
-for key, mode in pairs(neruModes) do
-  neruModal:bind({}, key, function()
-    neruModal:exit()
-    hs.task.new(neru, nil, { mode }):start()
-  end)
-end
-neruModal:bind({}, 'escape', function() neruModal:exit() end)
-Hyper:bind({}, ',', function() neruModal:enter() end)
-
 -- Warn when Secure Input gets enabled (1Password is the usual culprit).
 -- Why: Secure Input blocks Hammerspoon/Karabiner from receiving key events,
 -- silently breaking the Hyper key. Surface it instead of debugging blind.

--- a/users/shared/programs/.config/neru/config.toml
+++ b/users/shared/programs/.config/neru/config.toml
@@ -35,9 +35,10 @@ text = "#E8EEFF"
 # Hotkeys
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hotkeys
 # See https://github.com/y3owk1n/neru/blob/main/docs/CLI.md
-# Modes are triggered via CLI from Hammerspoon's Neru leader (Hyper+, then
-# f/s/g/c) — see hammerspoon/init.lua. No global hotkeys needed here.
+# Hyper+L (right_command+L) → Karabiner forwards the mega-chord below; Neru
+# opens hints and stays active hands-free until Escape. See karabiner.nix.
 [hotkeys]
+"Cmd+Ctrl+Alt+Shift+L" = "hints"
 
 # Hint mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#hints

--- a/users/shared/programs/karabiner.nix
+++ b/users/shared/programs/karabiner.nix
@@ -62,14 +62,12 @@ let
   # key_code → bundle_identifier. Forward as mega-chord (cmd+ctrl+opt+shift+key)
   # so the app's own global shortcut handler triggers. Replaces Hammerspoon's
   # bindPassThrough — moved here for Secure Input immunity.
-  # Note: comma is intentionally NOT bound here. It passes through to
-  # Hammerspoon (F19+comma) as the Neru leader — see hammerspoon/init.lua.
+  # Hyper+L forwards the mega-chord to Neru, which maps it to hints in
+  # config.toml [hotkeys]; the mode then stays active hands-free until Escape.
   hyperLocal = {
     b = "com.surteesstudios.Bartender";
-    l = "com.dexterleng.Homerow";
+    l = "com.y3owk1n.neru"; # Neru hints
     u = "com.flexibits.cardhop.mac";
-    return_or_enter = "com.superultra.Homerow";
-    tab = "com.superultra.Homerow";
   };
 
   hyperVar = "hyper";


### PR DESCRIPTION
## 요약

Neru hints 활성화를 **`Hyper+L` 단일 키 mega-chord** 방식으로 바꿉니다. evantravers가 Homerow를 다루던 방식과 동일 — Hyper+L 한 번 누르면 Neru가 hints를 켜고, **손을 떼도 모드가 유지**되어 라벨 타이핑/연속 동작이 가능합니다. (이전 Hyper+, push-to-talk leader는 누른 채 유지해야 해서 scroll 같은 반복 모드에 부적합했음)

## 변경사항

- [x] 기능 추가/수정
- [x] 설정 변경

- **karabiner.nix**: `hyperLocal.l` → Neru(`com.y3owk1n.neru`). 안 쓰는 구 Homerow 바인딩(`l`/`return`/`tab`) 제거
- **neru config.toml**: `[hotkeys]`에서 `Cmd+Ctrl+Alt+Shift+L = hints` 매핑
- **hammerspoon/init.lua**: Hyper+, push-to-talk neru 모달 제거 (Hammerspoon은 더 이상 Neru를 안 건드림)

## 동작 흐름

`Hyper+L`(우측⌘+L) → Karabiner가 `⌘⌥⌃⇧+L` mega-chord 전달 → Neru가 hints 모드 켬 → 손 떼고 라벨 타이핑해 클릭 → `Esc`로 종료

## 테스트 계획

- [x] `neru config validate` 통과
- [x] `luac -p init.lua` Lua 문법 통과
- [x] `nix build .#darwinConfigurations.kakaostyle-jito.system` 통과
- [x] pre-commit hooks 통과
- [ ] `make switch` 후 Hyper+L → hints 동작 + 손 떼고 라벨 클릭 확인 (로컬)

## 추가 정보

- 이전 PR #1280(Neru 도입)·#1281(Hyper+, leader)에 이어, leader 방식을 Homerow식 단일 키로 단순화
- scroll/grid/recursive 등 다른 모드는 필요해지면 같은 패턴으로 키 추가 가능
- `make switch`는 sudo 필요 — 로컬 적용 예정