### PR TITLE
feat(gw): use date-prefixed worktree names

### DIFF
--- a/lib/mksystem.nix
+++ b/lib/mksystem.nix
@@ -74,6 +74,11 @@ systemFunc {
             trusted-substituters = cacheSettings.substituters;
           }
         );
+        nix.gc = lib.mkIf (!darwin) {
+          automatic = true;
+          dates = "daily";
+          options = "--delete-older-than 7d";
+        };
 
         # Let Determinate manage Nix on Darwin systems
         nix.enable = lib.mkIf darwin false;
@@ -83,7 +88,12 @@ systemFunc {
   ++ lib.optionals darwin [
     # Determinate Nix integration (Darwin systems only)
     inputs.determinate.darwinModules.default
-    { determinateNix.customSettings = cacheSettings; }
+    {
+      determinateNix = {
+        customSettings = cacheSettings;
+        determinateNixd.garbageCollector.strategy = "automatic";
+      };
+    }
   ]
   ++ [
     # Home Manager integration

--- a/tests/unit/gw-numbering-test.nix
+++ b/tests/unit/gw-numbering-test.nix
@@ -1,7 +1,6 @@
 # tests/unit/gw-numbering-test.nix
-# Verify gw _sanitize_branch numbers worktrees by scanning the max existing
-# numeric prefix in .worktrees, not by counting `git worktree list` entries.
-# Counting collides after a middle worktree is deleted.
+# Verify gw _sanitize_branch prefixes worktree directories with today's YYMMDD
+# date instead of a monotonically increasing numeric counter.
 {
   inputs,
   system,
@@ -17,18 +16,18 @@ let
 in
 {
   platforms = [ "any" ];
-  value = helpers.testSuite "gw-numbering" [
-    (helpers.assertTest "gw-scans-worktrees-dir-for-max-num"
-      (lib.hasInfix ''ls "''${repo_root}/.worktrees"'' gwScript)
-      "gw _sanitize_branch should list .worktrees to find the max number"
+  value = helpers.testSuite "gw-date-prefix" [
+    (helpers.assertTest "gw-uses-yymmdd-date-prefix" (lib.hasInfix "date +%y%m%d" gwScript)
+      "gw _sanitize_branch should prefix worktree directories with today's YYMMDD date"
     )
 
-    (helpers.assertTest "gw-extracts-numeric-prefix" (lib.hasInfix "grep -oE '^[0-9]+'" gwScript)
-      "gw _sanitize_branch should extract the leading numeric prefix from directory names"
+    (helpers.assertTest "gw-builds-date-title-worktree-path"
+      (lib.hasInfix ''"''${repo_root}/.worktrees/''${date_prefix}-''${1//\//-}"'' gwScript)
+      "gw _sanitize_branch should build .worktrees/YYMMDD-title paths"
     )
 
-    (helpers.assertTest "gw-does-not-count-worktree-list" (
-      !(lib.hasInfix "git worktree list | tail -n +2 | wc -l" gwScript)
-    ) "gw _sanitize_branch should not number by `git worktree list` count (collides after deletion)")
+    (helpers.assertTest "gw-does-not-scan-numeric-prefixes" (
+      !(lib.hasInfix "grep -oE '^[0-9]+'" gwScript)
+    ) "gw _sanitize_branch should not scan existing numeric prefixes")
   ];
 }

--- a/tests/unit/lib-mksystem-detailed-test.nix
+++ b/tests/unit/lib-mksystem-detailed-test.nix
@@ -398,6 +398,41 @@ in
       && builtins.hasAttr "trusted-users" customSettings
     ) "determinateNix.customSettings should be configured with cache settings";
 
+    determinate-nix-gc-automatic = helpers.assertTest "mksystem-determinate-nix-gc-automatic" (
+      let
+        darwinSystem =
+          if hasDarwinInputs then
+            mkSystem "darwin-gc-test" {
+              system = "aarch64-darwin";
+              user = "testuser";
+              darwin = true;
+              wsl = false;
+            }
+          else
+            null;
+        result = builtins.tryEval darwinSystem.config.determinateNix.determinateNixd.garbageCollector.strategy;
+      in
+      hasDarwinInputs && result.success && result.value == "automatic"
+    ) "Determinate Nixd should manage garbage collection automatically on Darwin";
+
+    nixos-gc-short-retention = helpers.assertTest "mksystem-nixos-gc-short-retention" (
+      let
+        nixosSystem = mkSystem "vm-x86_64-utm" {
+          system = "x86_64-linux";
+          user = "testuser";
+          darwin = false;
+          wsl = false;
+        };
+        gcConfig = nixosSystem.config.nix.gc;
+        result = builtins.tryEval (
+          gcConfig.automatic
+          && builtins.elem "daily" gcConfig.dates
+          && gcConfig.options == "--delete-older-than 7d"
+        );
+      in
+      result.success && result.value
+    ) "NixOS garbage collection should run daily with 7 day retention";
+
     # Test 26: Home Manager useGlobalPkgs is set to true
     home-manager-use-global-pkgs = helpers.assertTest "mksystem-home-manager-use-global-pkgs" (
       let

--- a/users/shared/programs/zsh/gw.nix
+++ b/users/shared/programs/zsh/gw.nix
@@ -68,17 +68,13 @@
     }
 
     # Helper: Sanitize branch name for directory (replace / with -)
-    # Prefix with zero-padded number = (highest existing number in .worktrees) + 1.
-    # Counting worktrees would collide after a middle entry is deleted, so we
-    # scan the actual directory names for the max numeric prefix instead.
+    # Prefix with today's YYMMDD date for readable, chronological worktree names.
     # Always returns an absolute path based on the main worktree root so gw works
     # correctly from inside a worktree (flat, not nested).
     local _sanitize_branch() {
       local repo_root=$(git worktree list | head -1 | awk '{print $1}')
-      local max_num=$(ls "''${repo_root}/.worktrees" 2>/dev/null \
-        | grep -oE '^[0-9]+' | sort -n | tail -1)
-      local next_num=$(printf "%05d" $(( ''${max_num:-0} + 1 )))
-      echo "''${repo_root}/.worktrees/''${next_num}-''${1//\//-}"
+      local date_prefix=$(date +%y%m%d)
+      echo "''${repo_root}/.worktrees/''${date_prefix}-''${1//\//-}"
     }
 
     # Helper: Find base branch (main or master)


### PR DESCRIPTION
## Summary
- Migrate shared SSH client config from deprecated Home Manager `matchBlocks`/`extraOptions` to `programs.ssh.settings`.
- Disable Home Manager SSH compatibility defaults and copy the default directives explicitly.
- Add a focused unit check that fails on SSH deprecation warnings and verifies the generated config keeps the existing behavior.

## Tests
- `nix build --no-write-lock-file .#checks.aarch64-darwin.unit-ssh-program`
- `nix eval --json --no-write-lock-file '.#darwinConfigurations.kakaostyle-jito.config.home-manager.users."jito.hello".warnings'` -> `[]`
- `git diff --cached --check`
