### PR TITLE
chore(claude): manage Claude/Codex config as writable copies

### DIFF
--- a/users/shared/programs/.config/claude/CLAUDE.md
+++ b/users/shared/programs/.config/claude/CLAUDE.md
@@ -71,11 +71,18 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-## Learning and memory management
+## Learning and Memory Management
 
-- Use MEMORY.md to capture technical insights, failed approaches, and user preferences
-- Before starting complex tasks, read relevant memory files to build on previous experience
-- Update or remove memories that turn out to be wrong or outdated
+- YOU MUST use the journal tool frequently to capture technical insights, failed approaches, and user preferences
+- Before starting complex tasks, search the journal for relevant past experiences and lessons learned
+- Document architectural decisions and their outcomes for future reference
+- Track patterns in user feedback to improve collaboration over time
+- When you notice something that should be fixed but is unrelated to your current task, document it in your journal rather than fixing it immediately
+
+## Recalling past context
+
+- When you don't understand the context of the current task, use the `memmem:search-conversation` skill to search past conversation history
+- Use it when the user references prior work, when intent is hard to infer from code alone, or when you're stuck
 
 ## Language
 

--- a/users/shared/programs/.config/claude/local.md
+++ b/users/shared/programs/.config/claude/local.md
@@ -1,0 +1,4 @@
+## Jira
+
+- Jira site: https://croquis.atlassian.net
+- Project: SEARCH (검색추천제품)

--- a/users/shared/programs/.config/claude/settings.json
+++ b/users/shared/programs/.config/claude/settings.json
@@ -24,13 +24,27 @@
       "Task",
       "mcp__context7__*"
     ],
-    "deny": []
+    "deny": ["Workflow"],
+    "defaultMode": "auto",
+    "additionalDirectories": ["~/.claude/handoff/"]
   },
-  "model": "sonnet",
   "enableAllProjectMcpServers": true,
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/setup-worktree.sh"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
-    "command": "~/.claude/statusline.sh"
+    "command": "bash ~/.claude/statusline.sh"
   },
   "enabledPlugins": {
     "superpowers@superpowers-marketplace": true,
@@ -39,18 +53,47 @@
     "clangd-lsp@claude-plugins-official": false,
     "lua-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true,
     "atlassian@claude-plugins-official": true,
-    "everything-agent@everything-agent": true,
-    "memmem@baleen-marketplace": true,
     "context7@claude-plugins-official": true,
-    "slack@claude-plugins-official": true
+    "slack@claude-plugins-official": true,
+    "ks-amplitude@search-claude-code-plugins": true,
+    "ks-databricks@search-claude-code-plugins": true,
+    "ks-git-guard@search-claude-code-plugins": true,
+    "ks-grafana@search-claude-code-plugins": true,
+    "ks-onboarding@search-claude-code-plugins": true,
+    "ks-opensearch@search-claude-code-plugins": true,
+    "gopls-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "jdtls-lsp@claude-plugins-official": true,
+    "php-lsp@claude-plugins-official": true,
+    "swift-lsp@claude-plugins-official": true,
+    "kotlin-lsp@claude-plugins-official": true,
+    "ruby-lsp@claude-plugins-official": true,
+    "elixir-ls-lsp@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "ks-langfuse@search-claude-code-plugins": true,
+    "ks-internal@search-claude-code-plugins": true,
+    "notion@claude-plugins-official": true,
+    "autoresearch@baleen-marketplace": true,
+    "jira@baleen-marketplace": true,
+    "me@baleen-marketplace": true,
+    "memmem@baleen-marketplace": true,
+    "private-journal-mcp@baleen-marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "search-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "croquiscom/search-claude-code-plugins"
+      }
+    }
   },
   "alwaysThinkingEnabled": false,
+  "tui": "default",
   "skipDangerousModePermissionPrompt": true,
+  "skipAutoPermissionPrompt": true,
   "installMethod": "native",
   "rejectedMcpServers": [],
-  "hooks": {},
   "feedbackSurveyState": {
     "lastShownTime": 1755225425616
   }

--- a/users/shared/programs/claude-code.nix
+++ b/users/shared/programs/claude-code.nix
@@ -4,14 +4,33 @@
 #
 # NOTE: commands, agents, skills, and hooks are now managed via external plugin:
 # https://github.com/baleen37/claude-plugins
+#
+# These config files (CLAUDE.md, settings.json, statusline.sh, local.md) are
+# copied as real, writable files rather than read-only store symlinks, because
+# Claude Code mutates them at runtime (e.g. feedbackSurveyState, plugin toggles,
+# /remember). The copy only runs when the file is absent, so local edits and
+# runtime writes are preserved across rebuilds. To pull dotfiles updates into an
+# existing file, delete it and re-run switch.
 
 { config, lib, ... }:
 
 let
   cfg = config.modules.programs.claude-code;
+  src = ./.config/claude;
 in
 {
   options.modules.programs.claude-code.enable = lib.mkEnableOption "Claude Code configuration";
 
-  config = lib.mkIf cfg.enable { };
+  config = lib.mkIf cfg.enable {
+    home.activation.claudeConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p ~/.claude
+      for f in CLAUDE.md local.md settings.json statusline.sh; do
+        if [ ! -f ~/.claude/"$f" ]; then
+          run cp ${src}/"$f" ~/.claude/"$f"
+          run chmod u+w ~/.claude/"$f"
+        fi
+      done
+      run chmod +x ~/.claude/statusline.sh
+    '';
+  };
 }

--- a/users/shared/programs/codex.nix
+++ b/users/shared/programs/codex.nix
@@ -14,9 +14,12 @@ in
   options.modules.programs.codex.enable = lib.mkEnableOption "Codex CLI configuration";
 
   config = lib.mkIf cfg.enable {
-    # Share the same instruction file used by Claude via symlink.
+    # Share Claude's instruction file: AGENTS.md -> live ~/.claude/CLAUDE.md
+    # (the writable copy managed by claude-code.nix), so both tools read the
+    # same file and edits to either propagate. force overrides the symlink the
+    # `me` plugin may install at runtime.
     home.file.".codex/AGENTS.md" = {
-      source = ./.config/claude/CLAUDE.md;
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.claude/CLAUDE.md";
       force = true;
     };
 


### PR DESCRIPTION
## Summary

Claude Code mutates its own config files at runtime (`feedbackSurveyState`, plugin toggles, `/remember`), which conflicts with deploying them as read-only Nix store symlinks. This changes the deployment so those files are copied as real, writable files.

- `claude-code.nix`: copy `CLAUDE.md`, `local.md`, `settings.json`, `statusline.sh` into `~/.claude` via a home-manager activation script. The copy runs only when a file is absent, so both local edits and runtime writes survive rebuilds. To pull dotfiles updates into an existing file, delete it and re-run switch.
- `codex.nix`: point `~/.codex/AGENTS.md` at the live `~/.claude/CLAUDE.md` (out-of-store symlink) so Claude and Codex share one instruction file.
- `settings.json` / `CLAUDE.md`: sync current runtime state (plugin list, hooks, memory/journal guidance).
- Add `local.md` (Jira site/project pointers).

## Test plan

- `make switch` on macOS, confirm `~/.claude/*` files are present, writable, and preserved across a second switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for AI assistant configuration files, including a writable local instruction file and startup hooks.
  * Added Jira workspace details to support project-related workflows.
  * Expanded available assistant plugins and marketplace options.

* **Bug Fixes**
  * Improved how assistant settings and instructions are kept in sync across tools.
  * Updated configuration handling so existing local files are preserved instead of being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->