### PR TITLE
fix(hammerspoon): enable focus when starting pomodoro

### DIFF
--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -145,21 +145,15 @@ in
       "Pomodoro Spoon should return obj"
     )
 
-    (helpers.assertTest "pomodoro-activates-focus-shortcut"
-      (
-        lib.hasInfix "function activatePomodoroFocus()" pomodoroInitContent
-        && lib.hasInfix "/usr/bin/shortcuts run" pomodoroInitContent
-      )
-      "Pomodoro Spoon should run the Pomodoro Shortcut to enable macOS Focus"
-    )
+    (helpers.assertTest "pomodoro-activates-focus-shortcut" (
+      lib.hasInfix "function activatePomodoroFocus()" pomodoroInitContent
+      && lib.hasInfix "/usr/bin/shortcuts run" pomodoroInitContent
+    ) "Pomodoro Spoon should run the Pomodoro Shortcut to enable macOS Focus")
 
-    (helpers.assertTest "pomodoro-work-session-enables-focus"
-      (
-        lib.hasInfix "function TimerManager.startWorkSession()" pomodoroInitContent
-        && lib.hasInfix "activatePomodoroFocus()" pomodoroInitContent
-      )
-      "Starting a Pomodoro work session should enable macOS Focus"
-    )
+    (helpers.assertTest "pomodoro-work-session-enables-focus" (
+      lib.hasInfix "function TimerManager.startWorkSession()" pomodoroInitContent
+      && lib.hasInfix "activatePomodoroFocus()" pomodoroInitContent
+    ) "Starting a Pomodoro work session should enable macOS Focus")
 
     # Hyper Spoon tests
     (helpers.assertTest "hyper-spoon-metadata" (lib.hasInfix "m.name = \"Hyper\"" hyperInitContent)

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -48,7 +48,6 @@ let
   spoonsContents = if spoonsDirUsable then spoonsDirResult.value else { };
   expectedSpoons = [
     "Hyper.spoon"
-    "HyperModal.spoon"
     "Pomodoro.spoon"
   ];
   hasExpectedSpoons = lib.all (spoon: builtins.hasAttr spoon spoonsContents) expectedSpoons;
@@ -104,17 +103,12 @@ in
     )
 
     # ========================================================================
-    # Section 2: init.lua Content Validation (10 tests)
+    # Section 2: init.lua Content Validation
     # ========================================================================
 
     # Spoon loading tests
     (helpers.assertTest "init-loads-hyper" (lib.hasInfix "hs.loadSpoon('Hyper')" initLuaContent)
       "init.lua should load Hyper Spoon"
-    )
-
-    (helpers.assertTest "init-loads-hypermodal"
-      (lib.hasInfix "hs.loadSpoon('HyperModal')" initLuaContent)
-      "init.lua should load HyperModal Spoon"
     )
 
     (helpers.assertTest "init-loads-pomodoro" (lib.hasInfix "hs.loadSpoon('Pomodoro')" initLuaContent)
@@ -124,11 +118,6 @@ in
     # Hyper key binding tests
     (helpers.assertTest "init-hyper-hotkeys" (lib.hasInfix "Hyper:bindHotKeys" initLuaContent)
       "init.lua should bind Hyper hotkeys"
-    )
-
-    (helpers.assertTest "init-hyper-modal-binding"
-      (lib.hasInfix "Hyper:bind({}, 'm', function()" initLuaContent)
-      "init.lua should bind HyperModal toggle"
     )
 
     (helpers.assertTest "init-pomodoro-binding"
@@ -154,6 +143,22 @@ in
 
     (helpers.assertTest "pomodoro-spoon-structure" (lib.hasInfix "return obj" pomodoroInitContent)
       "Pomodoro Spoon should return obj"
+    )
+
+    (helpers.assertTest "pomodoro-activates-focus-shortcut"
+      (
+        lib.hasInfix "function activatePomodoroFocus()" pomodoroInitContent
+        && lib.hasInfix "/usr/bin/shortcuts run" pomodoroInitContent
+      )
+      "Pomodoro Spoon should run the Pomodoro Shortcut to enable macOS Focus"
+    )
+
+    (helpers.assertTest "pomodoro-work-session-enables-focus"
+      (
+        lib.hasInfix "function TimerManager.startWorkSession()" pomodoroInitContent
+        && lib.hasInfix "activatePomodoroFocus()" pomodoroInitContent
+      )
+      "Starting a Pomodoro work session should enable macOS Focus"
     )
 
     # Hyper Spoon tests

--- a/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
@@ -93,6 +93,19 @@ local function formatTime(seconds)
   return string.format("%02d:%02d", minutes, secs)
 end
 
+local function shellQuote(value)
+  return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
+end
+
+local function activatePomodoroFocus()
+  local command = "/usr/bin/shortcuts run " .. shellQuote(obj.config.focusMode)
+  local _, ok = hs.execute(command, true)
+  if not ok then
+    hs.alert.show("Pomodoro Focus Shortcut 실행 실패", 2)
+  end
+  return ok
+end
+
 -- ============================================================================
 -- CACHE MANAGEMENT
 -- ============================================================================
@@ -527,6 +540,7 @@ function TimerManager.startWorkSession()
   State.timerRunning = true
   State.sessionStartTime = os.time()
 
+  activatePomodoroFocus()
   updateMenubarDisplay()
 
   -- Create overlay if not exists


### PR DESCRIPTION
## 요약

Pomodoro를 Hammerspoon에서 시작할 때 macOS Focus도 함께 켜지도록 수정합니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [ ] 설정 변경

- Pomodoro work session 시작 시 `shortcuts run Pomodoro`를 실행합니다.
- Shortcut 실행 실패 시 Hammerspoon alert로 실패를 드러냅니다.
- 현재 Hammerspoon 구성에 맞게 제거된 HyperModal 기대값을 테스트에서 정리했습니다.
- Pomodoro 시작 경로가 Focus Shortcut을 호출하는 회귀 테스트를 추가했습니다.

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

검증한 명령:

- `nix build '.#checks.aarch64-darwin.integration-hammerspoon' --impure --no-link`
- `luac -p users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua users/shared/programs/.config/hammerspoon/init.lua users/shared/programs/.config/hammerspoon/Spoons/Hyper.spoon/init.lua`
- Hammerspoon 컨텍스트에서 `/usr/bin/shortcuts run Pomodoro` 실행: `true exit 0`
- Hammerspoon 컨텍스트에서 현재 Focus 확인: `Pomodoro`

## 추가 정보

`make switch-home`은 GitHub API rate limit 때문에 실패했고, 직접 Home Manager activation은 기존 `~/.zprofile` 충돌로 중단되어 건드리지 않았습니다. 변경된 Hammerspoon Pomodoro 파일만 새 Home Manager store 산출물로 live symlink 반영 후 Hammerspoon reload까지 확인했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pomodoro work sessions now automatically trigger a macOS Focus mode shortcut when they start.
  * If the shortcut fails, an alert is shown so the issue is visible immediately.

* **Bug Fixes**
  * Updated Hammerspoon validation to match the current set of installed components.
  * Removed outdated checks for a deprecated hotkey and loading behavior, while keeping coverage for the remaining integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->