### PR TITLE
fix(darwin): persist one-finger lookup setting

### DIFF
--- a/tests/unit/darwin-test.nix
+++ b/tests/unit/darwin-test.nix
@@ -79,6 +79,25 @@ in
 
       # Spaces가 디스플레이 간 스패닝되지 않는지 확인
       (darwinHelpers.assertSpacesNoSpanDisplays darwinConfig)
+
+      # One-finger lookup 설정이 Nix로 유지되는지 확인
+      (helpers.assertTest "trackpad-force-click-lookup-enabled" (
+        darwinConfig.system.defaults.CustomUserPreferences."NSGlobalDomain"."com.apple.trackpad.forceClick"
+        == true
+      ) "Trackpad force click lookup should be enabled")
+
+      (helpers.assertTest "trackpad-force-click-not-suppressed" (
+        darwinConfig.system.defaults.CustomUserPreferences."com.apple.AppleMultitouchTrackpad".ForceSuppressed
+        == 0
+      ) "Trackpad force click should not be suppressed")
+
+      (helpers.assertTest "trackpad-three-finger-lookup-disabled" (
+        darwinConfig.system.defaults.CustomUserPreferences."com.apple.AppleMultitouchTrackpad".TrackpadThreeFingerTapGesture
+        == 0
+        &&
+          darwinConfig.system.defaults.CustomUserPreferences."com.apple.driver.AppleBluetoothMultitouch.trackpad".TrackpadThreeFingerTapGesture
+          == 0
+      ) "Three-finger lookup should be disabled")
     ]
     # ===== 성능 최적화 검증 (darwin-helpers 사용) =====
     ++ (darwinHelpers.assertDarwinOptimizationsLevel1 darwinConfig)

--- a/users/shared/darwin/default.nix
+++ b/users/shared/darwin/default.nix
@@ -96,6 +96,16 @@ in
     CustomUserPreferences = {
       "NSGlobalDomain" = {
         "com.apple.scrollwheel.scaling" = 1.0; # 스크롤 속도 (최대값, -1은 가속 비활성화)
+        "com.apple.trackpad.forceClick" = true; # Enable one-finger force click lookup
+      };
+
+      "com.apple.AppleMultitouchTrackpad" = {
+        ForceSuppressed = 0; # Enable force click
+        TrackpadThreeFingerTapGesture = 0; # Disable three-finger lookup
+      };
+
+      "com.apple.driver.AppleBluetoothMultitouch.trackpad" = {
+        TrackpadThreeFingerTapGesture = 0; # Disable three-finger lookup
       };
     };
   };


### PR DESCRIPTION
## 요약

macOS one-finger lookup 설정을 nix-darwin 설정에 영속화합니다.

## 변경사항

- [ ] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

- `CustomUserPreferences`에 force click lookup defaults를 추가했습니다.
- built-in/Bluetooth 트랙패드의 three-finger lookup gesture를 비활성화하도록 선언했습니다.
- Darwin unit test에서 해당 defaults 값들을 검증하도록 추가했습니다.

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

실행한 검증:

- `nix fmt -- users/shared/darwin/default.nix tests/unit/darwin-test.nix`
- `git diff --check -- users/shared/darwin/default.nix tests/unit/darwin-test.nix`
- `nix build --impure --accept-flake-config '.#checks.aarch64-darwin.unit-darwin' --show-trace --print-build-logs`

## 추가 정보

런타임 defaults는 별도로 적용했으며, 이 PR은 다음 `darwin-rebuild switch` 이후에도 같은 설정이 유지되도록 합니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [ ] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함