### PR TITLE
fix(zsh): stop exporting GitHub token

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -261,9 +261,9 @@ in
     )
 
     # GitHub token configuration
-    (helpers.assertTest "github-token-export" (initContentHas "GITHUB_TOKEN")
-      "GITHUB_TOKEN should be exported via gh auth token"
-    )
+    (helpers.assertTest "github-token-not-exported" (
+      !initContentHas "GITHUB_TOKEN"
+    ) "GITHUB_TOKEN should not be exported from shell init")
 
     # 1Password SSH agent platform-specific detection tests (Darwin-only)
     (helpers.assertTest "onepassword-group-containers" (

--- a/users/shared/programs/zsh/env.nix
+++ b/users/shared/programs/zsh/env.nix
@@ -5,7 +5,6 @@
 # - Locale: en_US.UTF-8
 # - Editor: vim
 # - npm config
-# - GitHub CLI token
 
 # Note: isDarwin is not available here since this is a raw string import.
 # Homebrew PATH is handled inline via the isDarwin conditional in default.nix.
@@ -39,6 +38,4 @@
   # npm configuration
   export NPM_CONFIG_PREFIX="$HOME/.npm-global"
 
-  # GitHub CLI token (silent if not authenticated, e.g. on remote SSH hosts)
-  export GITHUB_TOKEN=$(gh auth token 2>/dev/null || true)
 ''


### PR DESCRIPTION
## Summary
- Stop exporting `GITHUB_TOKEN` from zsh init generated by Home Manager.
- Update the zsh integration test to assert the token is not injected into shell init.

## Test Plan
- [x] `nix build '.#checks.aarch64-darwin.integration-zsh' --impure --accept-flake-config --show-trace --print-build-logs`
- [x] `env -u GITHUB_TOKEN -u GH_TOKEN zsh -lc 'printenv GITHUB_TOKEN >/dev/null && echo GITHUB_TOKEN=set || echo GITHUB_TOKEN=unset; printenv GH_TOKEN >/dev/null && echo GH_TOKEN=set || echo GH_TOKEN=unset'`
- [x] pre-commit hooks during commit
- [x] pre-push `All Tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic GitHub token export from shell startup, so `GITHUB_TOKEN` is no longer injected into Zsh initialization output.
  * Updated the related integration test to verify the token is not present during shell startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->