### PR TITLE
fix(karabiner): accept held right_command on Hyper bindings

### DIFF
--- a/tests/integration/karabiner-test.nix
+++ b/tests/integration/karabiner-test.nix
@@ -52,6 +52,9 @@ let
   hasOneRule = builtins.length rules == 1;
   manipulators = if hasOneRule then (builtins.elemAt rules 0).manipulators else [ ];
 
+  simpleModifications = firstProfile.simple_modifications or [ ];
+  hasNoSimpleModifications = simpleModifications == [ ];
+
   # Find the trigger manipulator: from.key_code == "right_command"
   triggerCandidates = builtins.filter (m: (m.from.key_code or null) == "right_command") manipulators;
   hasTrigger = builtins.length triggerCandidates == 1;
@@ -98,9 +101,9 @@ let
   expectedAppLaunchers = {
     i = "com.mitchellh.ghostty";
     e = "com.apple.mail";
-    f = "com.apple.finder";
     h = "com.kapeli.dashdoc";
     k = "com.kakao.KakaoTalkMac";
+    m = "com.tinyspeck.slackmacgap";
     n = "notion.id";
     o = "md.obsidian";
     t = "com.culturedcode.ThingsMac";
@@ -116,7 +119,7 @@ let
     lib.sort builtins.lessThan hideKeys
     == lib.sort builtins.lessThan (builtins.attrNames expectedAppLaunchers);
 
-  # Every open manipulator must be gated by hyper=1 AND frontmost_application_unless
+  # Every open manipulator must be gated by hyper=1 AND frontmost_application_unless.
   hasFrontmostUnless =
     m: builtins.any (c: (c.type or "") == "frontmost_application_unless") (m.conditions or [ ]);
   hasFrontmostIf =
@@ -127,8 +130,11 @@ let
       c: (c.type or "") == "variable_if" && (c.name or "") == "hyper" && (c.value or null) == 1
     ) (m.conditions or [ ]);
 
+  acceptsHeldModifiers = m: builtins.elem "any" (m.from.modifiers.optional or [ ]);
   appOpensGated = builtins.all (m: hasHyperGate m && hasFrontmostUnless m) appOpens;
   appHidesGated = builtins.all (m: hasHyperGate m && hasFrontmostIf m) appHides;
+  appOpensAcceptHeldModifiers = builtins.all acceptsHeldModifiers appOpens;
+  appHidesAcceptHeldModifiers = builtins.all acceptsHeldModifiers appHides;
 
   # Local bindings: to[0].modifiers contains the four mega-mods, no software_function
   megaMods = [
@@ -147,14 +153,12 @@ let
   localBindingKeys = builtins.map (m: m.from.key_code) localBindings;
   expectedLocalKeys = [
     "b"
-    "comma"
     "l"
-    "period"
-    "return_or_enter"
-    "tab"
     "u"
   ];
   localBindingsPresent = lib.sort builtins.lessThan localBindingKeys == expectedLocalKeys;
+  localBindingsAcceptHeldModifiers = builtins.all acceptsHeldModifiers localBindings;
+  localBindingsGated = builtins.all hasHyperGate localBindings;
 
 in
 {
@@ -180,6 +184,9 @@ in
     (helpers.assertTest "karabiner-single-rule" hasOneRule
       "complex_modifications must have exactly one rule (the Hyper rule)"
     )
+    (helpers.assertTest "karabiner-no-simple-modifications" hasNoSimpleModifications
+      "simple_modifications must stay empty because Karabiner applies simple modifications before complex modifications"
+    )
     (helpers.assertTest "karabiner-trigger-present" hasTrigger
       "rule must contain exactly one right_command trigger manipulator"
     )
@@ -198,14 +205,27 @@ in
     (helpers.assertTest "karabiner-app-opens-gated" appOpensGated
       "every open manipulator must require hyper=1 AND frontmost_application_unless"
     )
+    (helpers.assertTest "karabiner-app-opens-accept-held-modifiers" appOpensAcceptHeldModifiers
+      "every open manipulator must accept held right_command so Hyper+key does not leak as Cmd+key"
+    )
     (helpers.assertTest "karabiner-app-hides-keys" hideKeysCorrect
       "all 8 app keys must have a corresponding hide manipulator"
     )
     (helpers.assertTest "karabiner-app-hides-gated" appHidesGated
       "every hide manipulator must require hyper=1 AND frontmost_application_if"
     )
+    (helpers.assertTest "karabiner-app-hides-accept-held-modifiers" appHidesAcceptHeldModifiers
+      "every hide manipulator must accept held right_command so Hyper+key does not leak as Cmd+key"
+    )
     (helpers.assertTest "karabiner-local-bindings-present" localBindingsPresent
-      "7 expected local-binding keys must emit mega-modifier chord"
+      "3 expected local-binding keys must emit mega-modifier chord"
+    )
+    (helpers.assertTest "karabiner-local-bindings-accept-held-modifiers"
+      localBindingsAcceptHeldModifiers
+      "every local binding must accept held right_command so Hyper+key does not leak as Cmd+key"
+    )
+    (helpers.assertTest "karabiner-local-bindings-gated" localBindingsGated
+      "every local binding must require hyper=1"
     )
   ];
 }

--- a/users/shared/programs/karabiner.nix
+++ b/users/shared/programs/karabiner.nix
@@ -9,8 +9,9 @@
 #       Otherwise → software_function.open_application (launch/focus).
 #     - Local bindings: forward as mega-chord (cmd+ctrl+opt+shift+key) so
 #       target app's own shortcut handler picks it up.
-#   Unintercepted keys pass through to Hammerspoon as F19+key (HyperModal,
-#   Pomodoro, etc.).
+#   Keep this in complex_modifications. Karabiner applies simple_modifications
+#   before complex_modifications, so simple right_command → F19 would prevent
+#   right_command+key app launchers from matching.
 {
   config,
   lib,
@@ -70,13 +71,14 @@ let
     u = "com.flexibits.cardhop.mac";
   };
 
-  hyperVar = "hyper";
   megaMods = [
     "left_command"
     "left_control"
     "left_option"
     "left_shift"
   ];
+
+  hyperVar = "hyper";
 
   # right_command itself: set variable + emit F19 (for Hammerspoon modal).
   hyperTrigger = {
@@ -108,7 +110,10 @@ let
   # `^` and `$` anchor the bundle id regex (frontmost_application_if uses regex).
   mkHideManipulator = key: app: {
     type = "basic";
-    from.key_code = key;
+    from = {
+      key_code = key;
+      modifiers.optional = [ "any" ];
+    };
     conditions = [
       {
         type = "variable_if";
@@ -129,7 +134,10 @@ let
 
   mkOpenManipulator = key: app: {
     type = "basic";
-    from.key_code = key;
+    from = {
+      key_code = key;
+      modifiers.optional = [ "any" ];
+    };
     conditions = [
       {
         type = "variable_if";
@@ -155,7 +163,10 @@ let
 
   mkLocalBinding = key: _bundleId: {
     type = "basic";
-    from.key_code = key;
+    from = {
+      key_code = key;
+      modifiers.optional = [ "any" ];
+    };
     conditions = [
       {
         type = "variable_if";
@@ -175,7 +186,7 @@ let
   localManipulators = lib.mapAttrsToList mkLocalBinding hyperLocal;
 
   hyperRule = {
-    description = "Hyper key: right_command → F19 + hyper var, Secure Input-immune app toggles and local bindings";
+    description = "Hyper key: Secure Input-immune app toggles and local bindings";
     manipulators = [ hyperTrigger ] ++ appManipulators ++ localManipulators;
   };
 


### PR DESCRIPTION
## Summary
- Add `modifiers.optional = [ "any" ]` to the open/hide/local Hyper manipulators so a held `right_command` no longer leaks as `Cmd+key`
- Swap the Finder (`f`) launcher for Slack (`m`) and trim local bindings down to `b`/`l`/`u`
- Document why the config must stay in `complex_modifications` (Karabiner applies `simple_modifications` first, which would shadow the launchers)

## Test plan
- `nix build '.#checks.aarch64-darwin.integration-karabiner' --impure` ✅
- New assertions cover held-modifier acceptance, empty `simple_modifications`, and gated local bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut matching so app and local bindings work more reliably, even when extra optional modifiers are held.
  * Tightened validation around generated shortcut rules to better ensure the expected app-specific and hyper-key behaviors.

* **Tests**
  * Expanded integration checks for shortcut generation and modifier handling to catch regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->