### PR TITLE
feat(pomodoro): sync timer from macOS Focus start time

### DIFF
--- a/docs/superpowers/plans/2026-07-03-pomodoro-focus-elapsed-sync.md
+++ b/docs/superpowers/plans/2026-07-03-pomodoro-focus-elapsed-sync.md
@@ -39,10 +39,12 @@
 ## Task 1: 타이머 구동 로직을 재사용 헬퍼로 추출 (동작 변경 없음)
 
 **Files:**
+
 - Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:535-589`
 - Test: `tests/integration/hammerspoon-test.nix`
 
 **Interfaces:**
+
 - Produces:
   - `TimerManager.completeSession()` — 세션 완료 처리(카운트++, stop, 통계저장, 모달, onComplete).
   - `TimerManager.runWork(timeLeft, sessionStartTime)` — 작업 카운트다운 시작(완료 시 startBreakSession).
@@ -55,6 +57,7 @@
 `init.lua`의 535–589행(아래 원본)을 통째로 교체한다.
 
 원본(참고):
+
 ```lua
 function TimerManager.startWorkSession()
   TimerManager.cleanup()
@@ -114,6 +117,7 @@ end
 ```
 
 교체 후:
+
 ```lua
 function TimerManager.completeSession()
   State.sessionsCompleted = State.sessionsCompleted + 1
@@ -186,14 +190,18 @@ end
 - [ ] **Step 2: 런타임 재적재 후 사용자 시작 경로 동작 확인 (회귀 없음)**
 
 Run:
+
 ```bash
 hs -c 'hs.reload()' && sleep 1
 hs -c 'spoon.Pomodoro:toggleSession(); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
 ```
+
 Expected: `run=true break=false left=1500` (± 1). 이후 정리:
+
 ```bash
 hs -c 'spoon.Pomodoro:toggleSession(); return tostring(spoon.Pomodoro:isRunning())'
 ```
+
 Expected: `false`
 
 > 주의: `toggleSession()`은 `startWorkSession`→`activatePomodoroFocus()`로 실제 Focus 단축키를 실행한다. 테스트 후 Focus가 켜졌으면 수동으로 꺼둔다.
@@ -201,6 +209,7 @@ Expected: `false`
 - [ ] **Step 3: content assertion 추가**
 
 `tests/integration/hammerspoon-test.nix`의 Section 3 마지막 assertion(163-165행의 `hyper-spoon-structure`) **앞**에 다음을 추가:
+
 ```nix
     (helpers.assertTest "pomodoro-timer-helpers-extracted" (
       lib.hasInfix "function TimerManager.completeSession()" pomodoroInitContent
@@ -227,10 +236,12 @@ git commit -m "refactor(pomodoro): extract reusable timer helpers"
 ## Task 2: 순수 보정 계산 + `syncFromFocus` 진입점
 
 **Files:**
+
 - Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua` (유틸 영역 ~94행, TimerManager 영역, obj 메서드 영역)
 - Test: `tests/integration/hammerspoon-test.nix`
 
 **Interfaces:**
+
 - Consumes: `TimerManager.runWork`, `TimerManager.runBreak`, `TimerManager.stop`, `saveCurrentStatistics`, `obj.config.workDuration/breakDuration` (Task 1).
 - Produces:
   - `computeSyncPlan(elapsed, workDuration, breakDuration) -> { stage = "work"|"break"|"complete", timeLeft = number }` (파일 로컬 순수 함수).
@@ -240,6 +251,7 @@ git commit -m "refactor(pomodoro): extract reusable timer helpers"
 - [ ] **Step 1: 순수 함수 `computeSyncPlan` 추가**
 
 `init.lua`의 `formatTime` 함수(90-94행) **바로 뒤**, `shellQuote`(96행) **앞**에 추가:
+
 ```lua
 -- Decide the pomodoro phase from elapsed seconds since Focus started.
 -- Returns { stage = "work" | "break" | "complete", timeLeft = <seconds> }.
@@ -259,6 +271,7 @@ end
 - [ ] **Step 2: `TimerManager.syncFromFocus` 추가**
 
 Task 1에서 만든 `TimerManager.startBreakSession` 함수 정의 **바로 뒤**에 추가:
+
 ```lua
 function TimerManager.syncFromFocus(startTime)
   local elapsed = os.time() - (startTime or os.time())
@@ -279,6 +292,7 @@ end
 - [ ] **Step 3: 공개 메서드 `obj:syncFromFocus` 추가**
 
 `obj:toggleSession()` 함수 정의(868-876행) **바로 뒤**에 추가:
+
 ```lua
 --- Pomodoro:syncFromFocus(startTime) -> Pomodoro
 --- Method
@@ -299,23 +313,30 @@ end
 - [ ] **Step 4: 런타임 경계 검증**
 
 Run:
+
 ```bash
 hs -c 'hs.reload()' && sleep 1
 hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 60); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
 ```
+
 Expected: `run=true break=false left=1440` (±2)
+
 ```bash
 hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 26*60); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
 ```
+
 Expected: `run=true break=true left=240` (±2)
+
 ```bash
 hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 31*60); return string.format("run=%s left=%d", tostring(spoon.Pomodoro:isRunning()), spoon.Pomodoro:getTimeLeft())'
 ```
+
 Expected: `run=false left=0`
 
 - [ ] **Step 5: content assertion 추가**
 
 Task 1에서 추가한 `pomodoro-timer-helpers-extracted` assertion **뒤**에 추가:
+
 ```nix
     (helpers.assertTest "pomodoro-sync-from-focus" (
       lib.hasInfix "local function computeSyncPlan(" pomodoroInitContent
@@ -342,10 +363,12 @@ git commit -m "feat(pomodoro): reconcile timer from focus start time"
 ## Task 3: Focus 시작시각을 포함한 감지 (`getCurrentFocusInfo`)
 
 **Files:**
+
 - Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:597-630` (getCurrentFocusMode), obj 메서드 영역
 - Test: `tests/integration/hammerspoon-test.nix`
 
 **Interfaces:**
+
 - Produces:
   - `FocusManager.getCurrentFocusInfo() -> { name = string, startTime = number|nil } | nil` — 현재 활성 Focus의 이름과 Unix 시작시각.
   - `FocusManager.getCurrentFocusMode() -> string|nil` — `getCurrentFocusInfo().name` 래퍼(기존 인터페이스 유지).
@@ -354,6 +377,7 @@ git commit -m "feat(pomodoro): reconcile timer from focus start time"
 - [ ] **Step 1: `getCurrentFocusMode`(597-630)를 `getCurrentFocusInfo` + 래퍼로 교체**
 
 `init.lua` 597–630행(원본 `function FocusManager.getCurrentFocusMode() ... end`)을 아래로 교체:
+
 ```lua
 local FOCUS_COCOA_EPOCH_OFFSET = 978307200 -- seconds between 1970-01-01 and 2001-01-01
 
@@ -418,6 +442,7 @@ end
 - [ ] **Step 2: 공개 introspection 메서드 `obj:currentFocusInfo` 추가**
 
 Task 2에서 추가한 `obj:syncFromFocus` 정의 **바로 뒤**에 추가:
+
 ```lua
 --- Pomodoro:currentFocusInfo() -> table or nil
 --- Method
@@ -433,21 +458,26 @@ end
 - [ ] **Step 3: 런타임 검증 (실제 Focus 필요)**
 
 먼저 Pomodoro Focus를 켠다(예: `hs -c 'hs.execute("/usr/bin/shortcuts run Pomodoro", true)'` 또는 수동). 그런 다음:
+
 ```bash
 hs -c 'hs.reload()' && sleep 1
 hs -c 'local i = spoon.Pomodoro:currentFocusInfo(); if not i then return "nil" end; return string.format("name=%s startAgo=%ds", tostring(i.name), i.startTime and (os.time() - i.startTime) or -1)'
 ```
+
 Expected: `name=Pomodoro startAgo=<0 이상 초, 방금 켰다면 한 자리~두 자리 초>`
 
 Focus를 끈 상태에서:
+
 ```bash
 hs -c 'return spoon.Pomodoro:currentFocusInfo() == nil and "nil-ok" or "unexpected"'
 ```
+
 Expected: `nil-ok`
 
 - [ ] **Step 4: content assertion 추가**
 
 Task 2의 `pomodoro-sync-from-focus` assertion **뒤**에 추가:
+
 ```nix
     (helpers.assertTest "pomodoro-focus-info-with-start-time" (
       lib.hasInfix "function FocusManager.getCurrentFocusInfo()" pomodoroInitContent
@@ -474,15 +504,18 @@ git commit -m "feat(pomodoro): read focus start timestamp for reconciliation"
 ## Task 4: 감지→보정 배선 + 워쳐 통일
 
 **Files:**
+
 - Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:637-675` (handleFocusChange, startMonitoring)
 - Test: `tests/integration/hammerspoon-test.nix`
 
 **Interfaces:**
+
 - Consumes: `FocusManager.getCurrentFocusInfo` (Task 3), `TimerManager.syncFromFocus` (Task 2), `obj.config.focusMode`.
 
 - [ ] **Step 1: `handleFocusChange`(637-651)를 보정 기반으로 교체**
 
 `init.lua` 637–651행(원본 `function FocusManager.handleFocusChange() ... end`)을 아래로 교체:
+
 ```lua
 function FocusManager.handleFocusChange()
   local info = FocusManager.getCurrentFocusInfo()
@@ -505,6 +538,7 @@ end
 - [ ] **Step 2: `startMonitoring`(653-675)의 두 워쳐를 `handleFocusChange` 호출로 통일**
 
 `init.lua` 653–675행(원본 `function FocusManager.startMonitoring() ... end`)을 아래로 교체:
+
 ```lua
 function FocusManager.startMonitoring()
   -- Focus mode enabled/disabled 모두 현재 focus를 다시 읽어 상태를 재조정한다.
@@ -525,21 +559,26 @@ end
 - [ ] **Step 3: 통합 런타임 검증 (실제 Focus 토글)**
 
 Pomodoro Focus를 켜고 잠깐(예: 30초 이상) 둔 뒤:
+
 ```bash
 hs -c 'hs.reload()' && sleep 1
 hs -c 'return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
 ```
+
 Expected: `run=true break=false left=<1500에서 경과초를 뺀 값>` (부팅 경로 `start()`가 자동 보정)
 
 Focus를 끈다(수동 또는 `hs -c 'hs.execute("/usr/bin/shortcuts run Pomodoro", true)'`로 토글 off). 몇 초 후:
+
 ```bash
 hs -c 'return tostring(spoon.Pomodoro:isRunning())'
 ```
+
 Expected: `false`
 
 - [ ] **Step 4: content assertion 추가**
 
 Task 3의 `pomodoro-focus-info-with-start-time` assertion **뒤**에 추가:
+
 ```nix
     (helpers.assertTest "pomodoro-focus-change-reconciles" (
       lib.hasInfix "TimerManager.syncFromFocus(info.startTime)" pomodoroInitContent

--- a/docs/superpowers/plans/2026-07-03-pomodoro-focus-elapsed-sync.md
+++ b/docs/superpowers/plans/2026-07-03-pomodoro-focus-elapsed-sync.md
@@ -1,0 +1,578 @@
+# Pomodoro Focus 시작시각 보정 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** macOS Focus가 켜진 실제 시각을 기준으로 Pomodoro 타이머의 남은 시간·단계를 보정한다.
+
+**Architecture:** `Assertions.json`(FDA 필요)에서 현재 Focus 이름과 `assertionStartDateTimestamp`를 읽어, 경과 시간으로 작업/휴식/완료 단계를 계산한다(`computeSyncPlan`). Focus 감지 워쳐와 부팅 경로는 모두 `handleFocusChange()`로 통일되어, focus가 이미 켜져 있던 경우에도 시작시각 기준으로 재동기화한다. 사용자 시작 경로(`startWorkSession`)는 Focus를 직접 켜고 지금부터 25분으로 시작하는 기존 동작을 유지한다.
+
+**Tech Stack:** Lua (Hammerspoon Spoon), JXA(osascript), Nix(content-assertion 통합 테스트).
+
+## Global Constraints
+
+- 대상 파일: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua`, `tests/integration/hammerspoon-test.nix`.
+- Cocoa→Unix 변환 오프셋: `978307200` (초, 1970↔2001).
+- `workDuration = 25*60`, `breakDuration = 5*60` (obj.config에서 참조; 하드코딩 금지).
+- 완료(`elapsed ≥ workDuration+breakDuration`) 처리 = 타이머 idle + `saveCurrentStatistics()`, **완료 카운트 증가 없음**.
+- Focus 감지 경로(syncFromFocus)는 **`activatePomodoroFocus()`를 호출하지 않는다**(focus 이미 켜짐).
+- 런타임 검증은 `hs` CLI(IPC)로 수행. HS가 실행 중이어야 하며 각 코드 변경 후 `hs -c 'hs.reload()'`로 재적재한다.
+- 코드 스타일은 기존 파일 관례(2-space 들여쓰기, `TimerManager.`/`FocusManager.`/`obj:` 네임스페이스)를 따른다.
+- 계획서의 줄 번호는 **수정 전 기준**이다. 앞 태스크가 함수를 삽입하면 이후 줄 번호가 밀리므로,
+  위치는 반드시 각 스텝에 명시된 **함수명/원본 코드 블록**을 앵커로 찾는다.
+
+---
+
+## File Structure
+
+- `Spoons/Pomodoro.spoon/init.lua`
+  - `computeSyncPlan(elapsed, workDuration, breakDuration)` — 순수 함수, 단계/남은시간 계산 (신규, 유틸 영역).
+  - `TimerManager.completeSession/runWork/runBreak` — 타이머 구동 저수준 헬퍼 (신규, 기존 로직 추출).
+  - `TimerManager.syncFromFocus(startTime)` — 보정 진입점 (신규).
+  - `TimerManager.startWorkSession/startBreakSession` — 헬퍼 위로 재작성 (수정).
+  - `FocusManager.getCurrentFocusInfo()` — 이름+시작시각 (신규); `getCurrentFocusMode()`는 래퍼 (수정).
+  - `FocusManager.handleFocusChange/startMonitoring` — 보정 배선 + 워쳐 통일 (수정).
+  - `obj:syncFromFocus/obj:currentFocusInfo` — 공개 test seam/introspection (신규).
+- `tests/integration/hammerspoon-test.nix` — 신규 함수/배선 content assertion 추가 (수정).
+
+---
+
+## Task 1: 타이머 구동 로직을 재사용 헬퍼로 추출 (동작 변경 없음)
+
+**Files:**
+- Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:535-589`
+- Test: `tests/integration/hammerspoon-test.nix`
+
+**Interfaces:**
+- Produces:
+  - `TimerManager.completeSession()` — 세션 완료 처리(카운트++, stop, 통계저장, 모달, onComplete).
+  - `TimerManager.runWork(timeLeft, sessionStartTime)` — 작업 카운트다운 시작(완료 시 startBreakSession).
+  - `TimerManager.runBreak(timeLeft)` — 휴식 카운트다운 시작(완료 시 completeSession).
+  - `TimerManager.startWorkSession()` — 사용자 시작(Focus 켜기 + 지금부터 workDuration).
+  - `TimerManager.startBreakSession()` — 휴식 세션 시작.
+
+- [ ] **Step 1: 기존 `startWorkSession`/`startBreakSession`(535-589)을 헬퍼 기반으로 교체**
+
+`init.lua`의 535–589행(아래 원본)을 통째로 교체한다.
+
+원본(참고):
+```lua
+function TimerManager.startWorkSession()
+  TimerManager.cleanup()
+
+  State.isBreak = false
+  State.timeLeft = obj.config.workDuration
+  State.timerRunning = true
+  State.sessionStartTime = os.time()
+
+  activatePomodoroFocus()
+  updateMenubarDisplay()
+
+  -- Create overlay if not exists
+  if not UI.overlayCanvas then
+    OverlayManager.create()
+  end
+
+  ModalManager.show("Work session begins!", "🍅", 2)
+
+  -- Callback: onWorkStart
+  if obj.config.onWorkStart then
+    obj.config.onWorkStart()
+  end
+
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.startBreakSession))
+  UI.countdownTimer:start()
+end
+
+function TimerManager.startBreakSession()
+  TimerManager.cleanup()
+
+  State.isBreak = true
+  State.timeLeft = obj.config.breakDuration
+  State.timerRunning = true
+
+  updateMenubarDisplay()
+  ModalManager.show("25 minutes complete! Take a break", "🍅", 2)
+
+  -- Callback: onBreakStart
+  if obj.config.onBreakStart then
+    obj.config.onBreakStart()
+  end
+
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(function()
+    State.sessionsCompleted = State.sessionsCompleted + 1
+    TimerManager.stop()
+    saveCurrentStatistics()
+    ModalManager.show("Session complete! Great job", "✅", 2)
+
+    -- Callback: onComplete
+    if obj.config.onComplete then
+      obj.config.onComplete()
+    end
+  end))
+  UI.countdownTimer:start()
+end
+```
+
+교체 후:
+```lua
+function TimerManager.completeSession()
+  State.sessionsCompleted = State.sessionsCompleted + 1
+  TimerManager.stop()
+  saveCurrentStatistics()
+  ModalManager.show("Session complete! Great job", "✅", 2)
+
+  -- Callback: onComplete
+  if obj.config.onComplete then
+    obj.config.onComplete()
+  end
+end
+
+function TimerManager.runWork(timeLeft, sessionStartTime)
+  TimerManager.cleanup()
+
+  State.isBreak = false
+  State.timeLeft = timeLeft
+  State.timerRunning = true
+  State.sessionStartTime = sessionStartTime
+
+  updateMenubarDisplay()
+
+  -- Create overlay if not exists
+  if not UI.overlayCanvas then
+    OverlayManager.create()
+  end
+
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.startBreakSession))
+  UI.countdownTimer:start()
+end
+
+function TimerManager.runBreak(timeLeft)
+  TimerManager.cleanup()
+
+  State.isBreak = true
+  State.timeLeft = timeLeft
+  State.timerRunning = true
+
+  updateMenubarDisplay()
+
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.completeSession))
+  UI.countdownTimer:start()
+end
+
+function TimerManager.startWorkSession()
+  activatePomodoroFocus()
+  TimerManager.runWork(obj.config.workDuration, os.time())
+
+  ModalManager.show("Work session begins!", "🍅", 2)
+
+  -- Callback: onWorkStart
+  if obj.config.onWorkStart then
+    obj.config.onWorkStart()
+  end
+end
+
+function TimerManager.startBreakSession()
+  TimerManager.runBreak(obj.config.breakDuration)
+
+  ModalManager.show("25 minutes complete! Take a break", "🍅", 2)
+
+  -- Callback: onBreakStart
+  if obj.config.onBreakStart then
+    obj.config.onBreakStart()
+  end
+end
+```
+
+- [ ] **Step 2: 런타임 재적재 후 사용자 시작 경로 동작 확인 (회귀 없음)**
+
+Run:
+```bash
+hs -c 'hs.reload()' && sleep 1
+hs -c 'spoon.Pomodoro:toggleSession(); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
+```
+Expected: `run=true break=false left=1500` (± 1). 이후 정리:
+```bash
+hs -c 'spoon.Pomodoro:toggleSession(); return tostring(spoon.Pomodoro:isRunning())'
+```
+Expected: `false`
+
+> 주의: `toggleSession()`은 `startWorkSession`→`activatePomodoroFocus()`로 실제 Focus 단축키를 실행한다. 테스트 후 Focus가 켜졌으면 수동으로 꺼둔다.
+
+- [ ] **Step 3: content assertion 추가**
+
+`tests/integration/hammerspoon-test.nix`의 Section 3 마지막 assertion(163-165행의 `hyper-spoon-structure`) **앞**에 다음을 추가:
+```nix
+    (helpers.assertTest "pomodoro-timer-helpers-extracted" (
+      lib.hasInfix "function TimerManager.completeSession()" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.runWork(" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.runBreak(" pomodoroInitContent
+    ) "Pomodoro Spoon should expose reusable timer helpers")
+
+```
+
+- [ ] **Step 4: 테스트 실행**
+
+Run: `USER=$(whoami) make test`
+Expected: PASS (hammerspoon 통합 테스트 포함, 실패 assertion 없음)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua tests/integration/hammerspoon-test.nix
+git commit -m "refactor(pomodoro): extract reusable timer helpers"
+```
+
+---
+
+## Task 2: 순수 보정 계산 + `syncFromFocus` 진입점
+
+**Files:**
+- Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua` (유틸 영역 ~94행, TimerManager 영역, obj 메서드 영역)
+- Test: `tests/integration/hammerspoon-test.nix`
+
+**Interfaces:**
+- Consumes: `TimerManager.runWork`, `TimerManager.runBreak`, `TimerManager.stop`, `saveCurrentStatistics`, `obj.config.workDuration/breakDuration` (Task 1).
+- Produces:
+  - `computeSyncPlan(elapsed, workDuration, breakDuration) -> { stage = "work"|"break"|"complete", timeLeft = number }` (파일 로컬 순수 함수).
+  - `TimerManager.syncFromFocus(startTime)` — startTime(Unix초) 기준 보정. Focus 재점화 없음.
+  - `obj:syncFromFocus(startTime) -> obj` — 공개 test seam.
+
+- [ ] **Step 1: 순수 함수 `computeSyncPlan` 추가**
+
+`init.lua`의 `formatTime` 함수(90-94행) **바로 뒤**, `shellQuote`(96행) **앞**에 추가:
+```lua
+-- Decide the pomodoro phase from elapsed seconds since Focus started.
+-- Returns { stage = "work" | "break" | "complete", timeLeft = <seconds> }.
+local function computeSyncPlan(elapsed, workDuration, breakDuration)
+  if elapsed < 0 then
+    elapsed = 0
+  end
+  if elapsed < workDuration then
+    return { stage = "work", timeLeft = workDuration - elapsed }
+  elseif elapsed < workDuration + breakDuration then
+    return { stage = "break", timeLeft = workDuration + breakDuration - elapsed }
+  end
+  return { stage = "complete", timeLeft = 0 }
+end
+```
+
+- [ ] **Step 2: `TimerManager.syncFromFocus` 추가**
+
+Task 1에서 만든 `TimerManager.startBreakSession` 함수 정의 **바로 뒤**에 추가:
+```lua
+function TimerManager.syncFromFocus(startTime)
+  local elapsed = os.time() - (startTime or os.time())
+  local plan = computeSyncPlan(elapsed, obj.config.workDuration, obj.config.breakDuration)
+
+  if plan.stage == "work" then
+    TimerManager.runWork(plan.timeLeft, startTime)
+  elseif plan.stage == "break" then
+    TimerManager.runBreak(plan.timeLeft)
+  else
+    -- 사이클이 이미 끝남: 러닝 상태 해제 + 통계 저장(완료 카운트는 올리지 않음)
+    TimerManager.stop()
+    saveCurrentStatistics()
+  end
+end
+```
+
+- [ ] **Step 3: 공개 메서드 `obj:syncFromFocus` 추가**
+
+`obj:toggleSession()` 함수 정의(868-876행) **바로 뒤**에 추가:
+```lua
+--- Pomodoro:syncFromFocus(startTime) -> Pomodoro
+--- Method
+--- Reconcile the timer to a Focus mode start time (Unix seconds).
+--- Picks work/break/complete from elapsed time. Does NOT enable Focus.
+---
+--- Parameters:
+---  * startTime - Unix timestamp (seconds) when the Focus mode started
+---
+--- Returns:
+---  * The Pomodoro object
+function obj:syncFromFocus(startTime)
+  TimerManager.syncFromFocus(startTime)
+  return self
+end
+```
+
+- [ ] **Step 4: 런타임 경계 검증**
+
+Run:
+```bash
+hs -c 'hs.reload()' && sleep 1
+hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 60); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
+```
+Expected: `run=true break=false left=1440` (±2)
+```bash
+hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 26*60); return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
+```
+Expected: `run=true break=true left=240` (±2)
+```bash
+hs -c 'spoon.Pomodoro:syncFromFocus(os.time() - 31*60); return string.format("run=%s left=%d", tostring(spoon.Pomodoro:isRunning()), spoon.Pomodoro:getTimeLeft())'
+```
+Expected: `run=false left=0`
+
+- [ ] **Step 5: content assertion 추가**
+
+Task 1에서 추가한 `pomodoro-timer-helpers-extracted` assertion **뒤**에 추가:
+```nix
+    (helpers.assertTest "pomodoro-sync-from-focus" (
+      lib.hasInfix "local function computeSyncPlan(" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.syncFromFocus(" pomodoroInitContent
+      && lib.hasInfix "function obj:syncFromFocus(" pomodoroInitContent
+    ) "Pomodoro Spoon should reconcile timer state from Focus start time")
+
+```
+
+- [ ] **Step 6: 테스트 실행**
+
+Run: `USER=$(whoami) make test`
+Expected: PASS
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua tests/integration/hammerspoon-test.nix
+git commit -m "feat(pomodoro): reconcile timer from focus start time"
+```
+
+---
+
+## Task 3: Focus 시작시각을 포함한 감지 (`getCurrentFocusInfo`)
+
+**Files:**
+- Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:597-630` (getCurrentFocusMode), obj 메서드 영역
+- Test: `tests/integration/hammerspoon-test.nix`
+
+**Interfaces:**
+- Produces:
+  - `FocusManager.getCurrentFocusInfo() -> { name = string, startTime = number|nil } | nil` — 현재 활성 Focus의 이름과 Unix 시작시각.
+  - `FocusManager.getCurrentFocusMode() -> string|nil` — `getCurrentFocusInfo().name` 래퍼(기존 인터페이스 유지).
+  - `obj:currentFocusInfo() -> table|nil` — 공개 introspection/test seam.
+
+- [ ] **Step 1: `getCurrentFocusMode`(597-630)를 `getCurrentFocusInfo` + 래퍼로 교체**
+
+`init.lua` 597–630행(원본 `function FocusManager.getCurrentFocusMode() ... end`)을 아래로 교체:
+```lua
+local FOCUS_COCOA_EPOCH_OFFSET = 978307200 -- seconds between 1970-01-01 and 2001-01-01
+
+function FocusManager.getCurrentFocusInfo()
+  local script = [[
+    (function() {
+      const app = Application.currentApplication();
+      app.includeStandardAdditions = true;
+
+      function getJSON(path) {
+        const fullPath = path.replace(/^~/, app.pathTo('home folder'));
+        return JSON.parse(app.read(fullPath));
+      }
+
+      try {
+        const assertions = getJSON("~/Library/DoNotDisturb/DB/Assertions.json").data[0].storeAssertionRecords;
+        const config = getJSON("~/Library/DoNotDisturb/DB/ModeConfigurations.json").data[0].modeConfigurations;
+
+        if (!assertions || assertions.length === 0) {
+          return null;
+        }
+
+        const record = assertions[0];
+        const modeid = record.assertionDetails.assertionDetailsModeIdentifier;
+        const name = config[modeid] ? config[modeid].mode.name : null;
+        if (!name) {
+          return null;
+        }
+        return JSON.stringify({ name: name, startTimestamp: record.assertionStartDateTimestamp });
+      } catch (e) {
+        return null;
+      }
+    })();
+  ]]
+
+  local ok, result = hs.osascript.javascript(script)
+  if not ok or not result then
+    return nil
+  end
+
+  local decoded = hs.json.decode(result)
+  if not decoded or not decoded.name then
+    return nil
+  end
+
+  local startTime = nil
+  if decoded.startTimestamp then
+    startTime = math.floor(decoded.startTimestamp + FOCUS_COCOA_EPOCH_OFFSET)
+  end
+
+  return { name = decoded.name, startTime = startTime }
+end
+
+function FocusManager.getCurrentFocusMode()
+  local info = FocusManager.getCurrentFocusInfo()
+  return info and info.name or nil
+end
+```
+
+> 참고: 활성 레코드는 `storeAssertionRecords[0]`을 사용한다(현재 동작과 동일). `startTime`은 pomodoro 활성이 확인된 뒤(`handleFocusChange`)에만 소비되므로 [0]이 pomodoro임이 보장된다.
+
+- [ ] **Step 2: 공개 introspection 메서드 `obj:currentFocusInfo` 추가**
+
+Task 2에서 추가한 `obj:syncFromFocus` 정의 **바로 뒤**에 추가:
+```lua
+--- Pomodoro:currentFocusInfo() -> table or nil
+--- Method
+--- Returns the current macOS Focus mode info, or nil if none is active.
+---
+--- Returns:
+---  * A table `{ name = <string>, startTime = <unix seconds or nil> }`, or nil
+function obj:currentFocusInfo()
+  return FocusManager.getCurrentFocusInfo()
+end
+```
+
+- [ ] **Step 3: 런타임 검증 (실제 Focus 필요)**
+
+먼저 Pomodoro Focus를 켠다(예: `hs -c 'hs.execute("/usr/bin/shortcuts run Pomodoro", true)'` 또는 수동). 그런 다음:
+```bash
+hs -c 'hs.reload()' && sleep 1
+hs -c 'local i = spoon.Pomodoro:currentFocusInfo(); if not i then return "nil" end; return string.format("name=%s startAgo=%ds", tostring(i.name), i.startTime and (os.time() - i.startTime) or -1)'
+```
+Expected: `name=Pomodoro startAgo=<0 이상 초, 방금 켰다면 한 자리~두 자리 초>`
+
+Focus를 끈 상태에서:
+```bash
+hs -c 'return spoon.Pomodoro:currentFocusInfo() == nil and "nil-ok" or "unexpected"'
+```
+Expected: `nil-ok`
+
+- [ ] **Step 4: content assertion 추가**
+
+Task 2의 `pomodoro-sync-from-focus` assertion **뒤**에 추가:
+```nix
+    (helpers.assertTest "pomodoro-focus-info-with-start-time" (
+      lib.hasInfix "function FocusManager.getCurrentFocusInfo()" pomodoroInitContent
+      && lib.hasInfix "assertionStartDateTimestamp" pomodoroInitContent
+      && lib.hasInfix "978307200" pomodoroInitContent
+    ) "Pomodoro Spoon should read the Focus start timestamp")
+
+```
+
+- [ ] **Step 5: 테스트 실행**
+
+Run: `USER=$(whoami) make test`
+Expected: PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua tests/integration/hammerspoon-test.nix
+git commit -m "feat(pomodoro): read focus start timestamp for reconciliation"
+```
+
+---
+
+## Task 4: 감지→보정 배선 + 워쳐 통일
+
+**Files:**
+- Modify: `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua:637-675` (handleFocusChange, startMonitoring)
+- Test: `tests/integration/hammerspoon-test.nix`
+
+**Interfaces:**
+- Consumes: `FocusManager.getCurrentFocusInfo` (Task 3), `TimerManager.syncFromFocus` (Task 2), `obj.config.focusMode`.
+
+- [ ] **Step 1: `handleFocusChange`(637-651)를 보정 기반으로 교체**
+
+`init.lua` 637–651행(원본 `function FocusManager.handleFocusChange() ... end`)을 아래로 교체:
+```lua
+function FocusManager.handleFocusChange()
+  local info = FocusManager.getCurrentFocusInfo()
+  local hasPomodoro = info ~= nil and info.name == obj.config.focusMode
+
+  if hasPomodoro then
+    if not State.timerRunning then
+      TimerManager.syncFromFocus(info.startTime)
+    end
+  else
+    if State.timerRunning then
+      ModalManager.show("Pomodoro session stopped", "⏹️", 2)
+      saveCurrentStatistics()
+      TimerManager.stop()
+    end
+  end
+end
+```
+
+- [ ] **Step 2: `startMonitoring`(653-675)의 두 워쳐를 `handleFocusChange` 호출로 통일**
+
+`init.lua` 653–675행(원본 `function FocusManager.startMonitoring() ... end`)을 아래로 교체:
+```lua
+function FocusManager.startMonitoring()
+  -- Focus mode enabled/disabled 모두 현재 focus를 다시 읽어 상태를 재조정한다.
+  UI.focusWatcherEnabled = hs.distributednotifications.new(function()
+    FocusManager.handleFocusChange()
+  end, "_NSDoNotDisturbEnabledNotification")
+  UI.focusWatcherEnabled:start()
+
+  UI.focusWatcherDisabled = hs.distributednotifications.new(function()
+    FocusManager.handleFocusChange()
+  end, "_NSDoNotDisturbDisabledNotification")
+  UI.focusWatcherDisabled:start()
+
+  UI.lastKnownFocus = FocusManager.isPomodoroActive()
+end
+```
+
+- [ ] **Step 3: 통합 런타임 검증 (실제 Focus 토글)**
+
+Pomodoro Focus를 켜고 잠깐(예: 30초 이상) 둔 뒤:
+```bash
+hs -c 'hs.reload()' && sleep 1
+hs -c 'return string.format("run=%s break=%s left=%d", tostring(spoon.Pomodoro:isRunning()), tostring(spoon.Pomodoro:isBreak()), spoon.Pomodoro:getTimeLeft())'
+```
+Expected: `run=true break=false left=<1500에서 경과초를 뺀 값>` (부팅 경로 `start()`가 자동 보정)
+
+Focus를 끈다(수동 또는 `hs -c 'hs.execute("/usr/bin/shortcuts run Pomodoro", true)'`로 토글 off). 몇 초 후:
+```bash
+hs -c 'return tostring(spoon.Pomodoro:isRunning())'
+```
+Expected: `false`
+
+- [ ] **Step 4: content assertion 추가**
+
+Task 3의 `pomodoro-focus-info-with-start-time` assertion **뒤**에 추가:
+```nix
+    (helpers.assertTest "pomodoro-focus-change-reconciles" (
+      lib.hasInfix "TimerManager.syncFromFocus(info.startTime)" pomodoroInitContent
+      && lib.hasInfix "FocusManager.handleFocusChange()" pomodoroInitContent
+    ) "Focus change should reconcile timer via handleFocusChange")
+
+```
+
+- [ ] **Step 5: 테스트 실행**
+
+Run: `USER=$(whoami) make test`
+Expected: PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua tests/integration/hammerspoon-test.nix
+git commit -m "feat(pomodoro): sync timer on focus change from start time"
+```
+
+---
+
+## 검증 요약 (전체 완료 후)
+
+- `USER=$(whoami) make test` — 통합 테스트 통과.
+- 실제 Pomodoro Focus를 N분 전에 켠 상태에서 `hs -c 'hs.reload()'` 후
+  `Pomodoro:getTimeLeft()` ≈ `1500 - N*60`인지 확인.
+- Focus를 끄면 `Pomodoro:isRunning()`이 `false`가 되는지 확인.
+- Hyper+P로 시작하면 Focus가 켜지고 25:00부터 시작하는지 확인(회귀 없음).
+
+## 비고 (테스트 한계)
+
+- 이 저장소에는 Lua 유닛 테스트 러너가 없다. `hammerspoon-test.nix`의 content assertion은
+  함수/배선의 존재만 정적으로 확인하며, 실제 동작 검증은 `hs` CLI 런타임 스텝이 담당한다.
+- `obj:syncFromFocus`/`obj:currentFocusInfo`는 런타임 검증을 위한 공개 seam이며,
+  기존 introspection 메서드(`getStatistics`/`isRunning`/`getTimeLeft`/`isBreak`)와 같은 스타일이다.

--- a/docs/superpowers/specs/2026-07-03-pomodoro-focus-elapsed-sync-design.md
+++ b/docs/superpowers/specs/2026-07-03-pomodoro-focus-elapsed-sync-design.md
@@ -1,0 +1,99 @@
+# Pomodoro Focus 시작시각 보정 설계
+
+## 배경 / 문제
+
+`Pomodoro.spoon`은 macOS Focus 모드 변경을 감지해 타이머 상태를 바꾼다.
+현재 두 가지 문제가 있다.
+
+1. **감지 자체가 동작하지 않음 (근본 원인, 이미 해결).**
+   `FocusManager.getCurrentFocusMode()`는 `~/Library/DoNotDisturb/DB/Assertions.json`을
+   JXA로 읽어 현재 Focus 모드를 판별한다. 이 경로는 macOS TCC가 보호하며
+   **Full Disk Access(FDA)** 가 필요하다. Hammerspoon에 FDA가 부여되지 않아 읽기가
+   항상 "File permission error"로 실패 → `getCurrentFocusMode()`가 항상 `nil` →
+   `isPomodoroActive()`가 항상 `false` → focus가 바뀌어도 상태가 전혀 바뀌지 않았다.
+   **해결:** Hammerspoon에 FDA 부여 (라이브 검증 완료: 읽기 성공).
+
+2. **시작 시각 보정 부재 (이번 작업 대상).**
+   `TimerManager.startWorkSession()`은 감지 시점을 세션 시작으로 보고 무조건 25분으로
+   리셋한다. focus가 이미 10분 전에 켜져 있었다면 15분 남아야 하지만 25분으로 초기화된다.
+
+## 실측으로 확정된 사실
+
+- 활성 focus는 `Assertions.json`의 `data[0].storeAssertionRecords`에 있다.
+- 각 레코드는 `assertionDetails.assertionDetailsModeIdentifier`(모드 id)와
+  `assertionStartDateTimestamp`(시작 시각)를 가진다.
+- 모드 id → 표시 이름은 `ModeConfigurations.json`의
+  `data[0].modeConfigurations[id].mode.name`으로 해석한다.
+- `assertionStartDateTimestamp`는 **Cocoa 기준일(2001-01-01)** epoch이다.
+  Unix 변환: `unixStart = assertionStartDateTimestamp + 978307200`.
+  (경과 시간이 실제와 일치함을 라이브 검증: 8.0분 예시.)
+
+## 보정 규칙
+
+`elapsed = os.time() - unixStart` (nil/음수면 0으로 방어)
+
+| 조건 | 동작 | timeLeft |
+|---|---|---|
+| `elapsed < workDuration` (25분) | 작업 세션 | `workDuration - elapsed` |
+| `workDuration ≤ elapsed < workDuration+breakDuration` (25~30분) | 휴식 세션 | `(workDuration+breakDuration) - elapsed` |
+| `elapsed ≥ workDuration+breakDuration` (≥30분) | 완료 처리 | 타이머 미가동(idle) + 통계 저장, **완료 카운트 증가 없음** |
+
+> 완료 카운트를 올리지 않는 이유: 이 경로는 주로 부팅/리로드 시 재동기화 상황이라,
+> 카운트를 올리면 리로드마다 통계가 부풀 수 있다. 기존 통계만 저장한다.
+
+## 설계
+
+### 1. 감지 소스 확장 — `FocusManager`
+- 신규 `getCurrentFocusInfo()` → `{ name = <string>, startTime = <unix seconds> }` 또는 `nil`.
+  - `storeAssertionRecords`에서 **해석된 이름이 `config.focusMode`와 일치하는 레코드**를
+    찾아 그 `assertionStartDateTimestamp`를 사용 (기존 `[0]` 고정보다 견고).
+  - `startTime = assertionStartDateTimestamp + 978307200`.
+- `getCurrentFocusMode()`는 `getCurrentFocusInfo()`의 `name`을 반환하는 얇은 래퍼로 유지.
+  `isPomodoroActive()`는 변경 없음.
+
+### 2. 보정 로직 — `TimerManager.syncFromFocus(startTime)`
+- 위 보정 규칙에 따라 stage(work/break/complete)와 `timeLeft`를 계산.
+- 작업/휴식이면 `sessionStartTime = startTime`으로 두고 해당 카운트다운 타이머를 시작.
+- 완료면 러닝 상태 해제 + `saveCurrentStatistics()`.
+- **`activatePomodoroFocus()`를 호출하지 않는다** (focus가 이미 켜져 있음).
+- 기존 `startWorkSession()`/`startBreakSession()`의 타이머 구동 부분을 재사용하도록
+  낮은 수준 헬퍼(예: 초기 `timeLeft`/`isBreak`/`sessionStartTime`을 받는 함수)로 정리.
+
+### 3. 감지→보정 배선 + 워쳐 단순화 — `FocusManager`
+- `handleFocusChange()`:
+  - pomodoro 활성 & `!State.timerRunning` → `getCurrentFocusInfo()`로 startTime을 얻어
+    `TimerManager.syncFromFocus(startTime)`.
+  - 비활성 & `State.timerRunning` → 기존대로 stop + 통계 저장.
+- `startMonitoring()`의 enabled/disabled 두 워쳐를 **각각 `handleFocusChange()` 한 번 호출**로
+  교체한다. 중복·부분 로직을 제거하며, "focus 모드를 직접 갈아탈 때 상태가 안 바뀌던"
+  잠재 버그도 함께 해소된다.
+
+### 4. 사용자 시작 경로 유지
+- `TimerManager.startWorkSession()`은 **사용자 시작 전용**으로 남긴다:
+  `activatePomodoroFocus()` 호출 + 지금부터 `workDuration`.
+- 진입점: `toggleSession()`(Hyper+P), `bindHotkeys`의 start, 메뉴바 Start.
+
+## 영향 파일
+
+- `users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua`
+  - `TimerManager` (start 로직 헬퍼화, `syncFromFocus` 추가)
+  - `FocusManager` (`getCurrentFocusInfo`, `getCurrentFocusMode` 래퍼, `handleFocusChange`,
+    `startMonitoring`)
+- `tests/integration/hammerspoon-test.nix` — 신규 함수 존재/배선을 검증하는 content assertion 추가.
+
+## 테스트 / 검증
+
+- **정적 테스트:** hammerspoon-test.nix에 `getCurrentFocusInfo`, `syncFromFocus`,
+  워쳐가 `handleFocusChange`를 호출하는지 등 content assertion 추가.
+- **런타임 검증(수동, `hs` CLI):**
+  - focus를 켠 뒤 N분 경과 → HS 리로드 → `Pomodoro:getTimeLeft()`가 `workDuration - N분`에
+    근사하는지 확인.
+  - 25~30분 경과 상태에서 리로드 → 휴식 단계로 진입하는지.
+  - 30분 초과 상태에서 리로드 → 러닝 아님(idle)인지.
+  - focus를 끄면 타이머가 정지하는지.
+
+## 범위 밖 (YAGNI)
+
+- FDA-불필요 감지(Shortcuts 등) 대안: 시작 시각을 못 얻어 이 요구사항과 상충하므로 채택하지 않음.
+- 여러 사이클 wrap-around(30분 초과를 2번째 사이클로 환산): "현재 사이클 내에서만 보정"으로 합의됨.
+- FDA 부여 자동화: TCC는 SIP로 스크립트 불가. 머신마다 수동 1회 부여 필요.

--- a/docs/superpowers/specs/2026-07-03-pomodoro-focus-elapsed-sync-design.md
+++ b/docs/superpowers/specs/2026-07-03-pomodoro-focus-elapsed-sync-design.md
@@ -32,11 +32,11 @@
 
 `elapsed = os.time() - unixStart` (nil/음수면 0으로 방어)
 
-| 조건 | 동작 | timeLeft |
-|---|---|---|
-| `elapsed < workDuration` (25분) | 작업 세션 | `workDuration - elapsed` |
-| `workDuration ≤ elapsed < workDuration+breakDuration` (25~30분) | 휴식 세션 | `(workDuration+breakDuration) - elapsed` |
-| `elapsed ≥ workDuration+breakDuration` (≥30분) | 완료 처리 | 타이머 미가동(idle) + 통계 저장, **완료 카운트 증가 없음** |
+| 조건                                                            | 동작      | timeLeft                                                   |
+| --------------------------------------------------------------- | --------- | ---------------------------------------------------------- |
+| `elapsed < workDuration` (25분)                                 | 작업 세션 | `workDuration - elapsed`                                   |
+| `workDuration ≤ elapsed < workDuration+breakDuration` (25~30분) | 휴식 세션 | `(workDuration+breakDuration) - elapsed`                   |
+| `elapsed ≥ workDuration+breakDuration` (≥30분)                  | 완료 처리 | 타이머 미가동(idle) + 통계 저장, **완료 카운트 증가 없음** |
 
 > 완료 카운트를 올리지 않는 이유: 이 경로는 주로 부팅/리로드 시 재동기화 상황이라,
 > 카운트를 올리면 리로드마다 통계가 부풀 수 있다. 기존 통계만 저장한다.
@@ -44,6 +44,7 @@
 ## 설계
 
 ### 1. 감지 소스 확장 — `FocusManager`
+
 - 신규 `getCurrentFocusInfo()` → `{ name = <string>, startTime = <unix seconds> }` 또는 `nil`.
   - `storeAssertionRecords`에서 **해석된 이름이 `config.focusMode`와 일치하는 레코드**를
     찾아 그 `assertionStartDateTimestamp`를 사용 (기존 `[0]` 고정보다 견고).
@@ -52,6 +53,7 @@
   `isPomodoroActive()`는 변경 없음.
 
 ### 2. 보정 로직 — `TimerManager.syncFromFocus(startTime)`
+
 - 위 보정 규칙에 따라 stage(work/break/complete)와 `timeLeft`를 계산.
 - 작업/휴식이면 `sessionStartTime = startTime`으로 두고 해당 카운트다운 타이머를 시작.
 - 완료면 러닝 상태 해제 + `saveCurrentStatistics()`.
@@ -60,6 +62,7 @@
   낮은 수준 헬퍼(예: 초기 `timeLeft`/`isBreak`/`sessionStartTime`을 받는 함수)로 정리.
 
 ### 3. 감지→보정 배선 + 워쳐 단순화 — `FocusManager`
+
 - `handleFocusChange()`:
   - pomodoro 활성 & `!State.timerRunning` → `getCurrentFocusInfo()`로 startTime을 얻어
     `TimerManager.syncFromFocus(startTime)`.
@@ -69,6 +72,7 @@
   잠재 버그도 함께 해소된다.
 
 ### 4. 사용자 시작 경로 유지
+
 - `TimerManager.startWorkSession()`은 **사용자 시작 전용**으로 남긴다:
   `activatePomodoroFocus()` 호출 + 지금부터 `workDuration`.
 - 진입점: `toggleSession()`(Hyper+P), `bindHotkeys`의 start, 메뉴바 Start.

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -167,6 +167,12 @@ in
       && lib.hasInfix "function obj:syncFromFocus(" pomodoroInitContent
     ) "Pomodoro Spoon should reconcile timer state from Focus start time")
 
+    (helpers.assertTest "pomodoro-focus-info-with-start-time" (
+      lib.hasInfix "function FocusManager.getCurrentFocusInfo()" pomodoroInitContent
+      && lib.hasInfix "assertionStartDateTimestamp" pomodoroInitContent
+      && lib.hasInfix "978307200" pomodoroInitContent
+    ) "Pomodoro Spoon should read the Focus start timestamp")
+
     # Hyper Spoon tests
     (helpers.assertTest "hyper-spoon-metadata" (lib.hasInfix "m.name = \"Hyper\"" hyperInitContent)
       "Hyper Spoon should define name metadata"

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -155,6 +155,12 @@ in
       && lib.hasInfix "activatePomodoroFocus()" pomodoroInitContent
     ) "Starting a Pomodoro work session should enable macOS Focus")
 
+    (helpers.assertTest "pomodoro-timer-helpers-extracted" (
+      lib.hasInfix "function TimerManager.completeSession()" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.runWork(" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.runBreak(" pomodoroInitContent
+    ) "Pomodoro Spoon should expose reusable timer helpers")
+
     # Hyper Spoon tests
     (helpers.assertTest "hyper-spoon-metadata" (lib.hasInfix "m.name = \"Hyper\"" hyperInitContent)
       "Hyper Spoon should define name metadata"

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -173,6 +173,11 @@ in
       && lib.hasInfix "978307200" pomodoroInitContent
     ) "Pomodoro Spoon should read the Focus start timestamp")
 
+    (helpers.assertTest "pomodoro-focus-change-reconciles" (
+      lib.hasInfix "TimerManager.syncFromFocus(info.startTime)" pomodoroInitContent
+      && lib.hasInfix "FocusManager.handleFocusChange()" pomodoroInitContent
+    ) "Focus change should reconcile timer via handleFocusChange")
+
     # Hyper Spoon tests
     (helpers.assertTest "hyper-spoon-metadata" (lib.hasInfix "m.name = \"Hyper\"" hyperInitContent)
       "Hyper Spoon should define name metadata"

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -161,6 +161,12 @@ in
       && lib.hasInfix "function TimerManager.runBreak(" pomodoroInitContent
     ) "Pomodoro Spoon should expose reusable timer helpers")
 
+    (helpers.assertTest "pomodoro-sync-from-focus" (
+      lib.hasInfix "local function computeSyncPlan(" pomodoroInitContent
+      && lib.hasInfix "function TimerManager.syncFromFocus(" pomodoroInitContent
+      && lib.hasInfix "function obj:syncFromFocus(" pomodoroInitContent
+    ) "Pomodoro Spoon should reconcile timer state from Focus start time")
+
     # Hyper Spoon tests
     (helpers.assertTest "hyper-spoon-metadata" (lib.hasInfix "m.name = \"Hyper\"" hyperInitContent)
       "Hyper Spoon should define name metadata"

--- a/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
@@ -697,11 +697,12 @@ function FocusManager.isPomodoroActive()
 end
 
 function FocusManager.handleFocusChange()
-  local hasPomodoro = FocusManager.isPomodoroActive()
+  local info = FocusManager.getCurrentFocusInfo()
+  local hasPomodoro = info ~= nil and info.name == obj.config.focusMode
 
   if hasPomodoro then
     if not State.timerRunning then
-      TimerManager.startWorkSession()
+      TimerManager.syncFromFocus(info.startTime)
     end
   else
     if State.timerRunning then
@@ -713,23 +714,14 @@ function FocusManager.handleFocusChange()
 end
 
 function FocusManager.startMonitoring()
-  -- Watch for Focus mode enabled
-  UI.focusWatcherEnabled = hs.distributednotifications.new(function(name, object, userInfo)
-    if FocusManager.isPomodoroActive() then
-      if not State.timerRunning then
-        TimerManager.startWorkSession()
-      end
-    end
+  -- Focus mode enabled/disabled 모두 현재 focus를 다시 읽어 상태를 재조정한다.
+  UI.focusWatcherEnabled = hs.distributednotifications.new(function()
+    FocusManager.handleFocusChange()
   end, "_NSDoNotDisturbEnabledNotification")
   UI.focusWatcherEnabled:start()
 
-  -- Watch for Focus mode disabled
-  UI.focusWatcherDisabled = hs.distributednotifications.new(function(name, object, userInfo)
-    if State.timerRunning then
-      ModalManager.show("Pomodoro session stopped", "⏹️", 2)
-      saveCurrentStatistics()
-      TimerManager.stop()
-    end
+  UI.focusWatcherDisabled = hs.distributednotifications.new(function()
+    FocusManager.handleFocusChange()
   end, "_NSDoNotDisturbDisabledNotification")
   UI.focusWatcherDisabled:start()
 

--- a/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
@@ -93,6 +93,20 @@ local function formatTime(seconds)
   return string.format("%02d:%02d", minutes, secs)
 end
 
+-- Decide the pomodoro phase from elapsed seconds since Focus started.
+-- Returns { stage = "work" | "break" | "complete", timeLeft = <seconds> }.
+local function computeSyncPlan(elapsed, workDuration, breakDuration)
+  if elapsed < 0 then
+    elapsed = 0
+  end
+  if elapsed < workDuration then
+    return { stage = "work", timeLeft = workDuration - elapsed }
+  elseif elapsed < workDuration + breakDuration then
+    return { stage = "break", timeLeft = workDuration + breakDuration - elapsed }
+  end
+  return { stage = "complete", timeLeft = 0 }
+end
+
 local function shellQuote(value)
   return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
 end
@@ -599,6 +613,21 @@ function TimerManager.startBreakSession()
   end
 end
 
+function TimerManager.syncFromFocus(startTime)
+  local elapsed = os.time() - (startTime or os.time())
+  local plan = computeSyncPlan(elapsed, obj.config.workDuration, obj.config.breakDuration)
+
+  if plan.stage == "work" then
+    TimerManager.runWork(plan.timeLeft, startTime)
+  elseif plan.stage == "break" then
+    TimerManager.runBreak(plan.timeLeft)
+  else
+    -- 사이클이 이미 끝남: 러닝 상태 해제 + 통계 저장(완료 카운트는 올리지 않음)
+    TimerManager.stop()
+    saveCurrentStatistics()
+  end
+end
+
 -- ============================================================================
 -- FOCUS MODE DETECTION
 -- ============================================================================
@@ -884,6 +913,21 @@ function obj:toggleSession()
     TimerManager.startWorkSession()
     return true
   end
+end
+
+--- Pomodoro:syncFromFocus(startTime) -> Pomodoro
+--- Method
+--- Reconcile the timer to a Focus mode start time (Unix seconds).
+--- Picks work/break/complete from elapsed time. Does NOT enable Focus.
+---
+--- Parameters:
+---  * startTime - Unix timestamp (seconds) when the Focus mode started
+---
+--- Returns:
+---  * The Pomodoro object
+function obj:syncFromFocus(startTime)
+  TimerManager.syncFromFocus(startTime)
+  return self
 end
 
 --- Pomodoro:isRunning() -> boolean

--- a/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
@@ -634,7 +634,9 @@ end
 
 local FocusManager = {}
 
-function FocusManager.getCurrentFocusMode()
+local FOCUS_COCOA_EPOCH_OFFSET = 978307200 -- seconds between 1970-01-01 and 2001-01-01
+
+function FocusManager.getCurrentFocusInfo()
   local script = [[
     (function() {
       const app = Application.currentApplication();
@@ -642,20 +644,24 @@ function FocusManager.getCurrentFocusMode()
 
       function getJSON(path) {
         const fullPath = path.replace(/^~/, app.pathTo('home folder'));
-        const contents = app.read(fullPath);
-        return JSON.parse(contents);
+        return JSON.parse(app.read(fullPath));
       }
 
       try {
-        const assert = getJSON("~/Library/DoNotDisturb/DB/Assertions.json").data[0].storeAssertionRecords;
+        const assertions = getJSON("~/Library/DoNotDisturb/DB/Assertions.json").data[0].storeAssertionRecords;
         const config = getJSON("~/Library/DoNotDisturb/DB/ModeConfigurations.json").data[0].modeConfigurations;
 
-        if (assert && assert.length > 0) {
-          const modeid = assert[0].assertionDetails.assertionDetailsModeIdentifier;
-          return config[modeid].mode.name;
+        if (!assertions || assertions.length === 0) {
+          return null;
         }
 
-        return null;
+        const record = assertions[0];
+        const modeid = record.assertionDetails.assertionDetailsModeIdentifier;
+        const name = config[modeid] ? config[modeid].mode.name : null;
+        if (!name) {
+          return null;
+        }
+        return JSON.stringify({ name: name, startTimestamp: record.assertionStartDateTimestamp });
       } catch (e) {
         return null;
       }
@@ -663,10 +669,26 @@ function FocusManager.getCurrentFocusMode()
   ]]
 
   local ok, result = hs.osascript.javascript(script)
-  if ok and result then
-    return result
+  if not ok or not result then
+    return nil
   end
-  return nil
+
+  local decoded = hs.json.decode(result)
+  if not decoded or not decoded.name then
+    return nil
+  end
+
+  local startTime = nil
+  if decoded.startTimestamp then
+    startTime = math.floor(decoded.startTimestamp + FOCUS_COCOA_EPOCH_OFFSET)
+  end
+
+  return { name = decoded.name, startTime = startTime }
+end
+
+function FocusManager.getCurrentFocusMode()
+  local info = FocusManager.getCurrentFocusInfo()
+  return info and info.name or nil
 end
 
 function FocusManager.isPomodoroActive()
@@ -928,6 +950,16 @@ end
 function obj:syncFromFocus(startTime)
   TimerManager.syncFromFocus(startTime)
   return self
+end
+
+--- Pomodoro:currentFocusInfo() -> table or nil
+--- Method
+--- Returns the current macOS Focus mode info, or nil if none is active.
+---
+--- Returns:
+---  * A table `{ name = <string>, startTime = <unix seconds or nil> }`, or nil
+function obj:currentFocusInfo()
+  return FocusManager.getCurrentFocusInfo()
 end
 
 --- Pomodoro:isRunning() -> boolean

--- a/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/Pomodoro.spoon/init.lua
@@ -532,15 +532,26 @@ function TimerManager.createCallback(onComplete)
   end
 end
 
-function TimerManager.startWorkSession()
+function TimerManager.completeSession()
+  State.sessionsCompleted = State.sessionsCompleted + 1
+  TimerManager.stop()
+  saveCurrentStatistics()
+  ModalManager.show("Session complete! Great job", "✅", 2)
+
+  -- Callback: onComplete
+  if obj.config.onComplete then
+    obj.config.onComplete()
+  end
+end
+
+function TimerManager.runWork(timeLeft, sessionStartTime)
   TimerManager.cleanup()
 
   State.isBreak = false
-  State.timeLeft = obj.config.workDuration
+  State.timeLeft = timeLeft
   State.timerRunning = true
-  State.sessionStartTime = os.time()
+  State.sessionStartTime = sessionStartTime
 
-  activatePomodoroFocus()
   updateMenubarDisplay()
 
   -- Create overlay if not exists
@@ -548,44 +559,44 @@ function TimerManager.startWorkSession()
     OverlayManager.create()
   end
 
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.startBreakSession))
+  UI.countdownTimer:start()
+end
+
+function TimerManager.runBreak(timeLeft)
+  TimerManager.cleanup()
+
+  State.isBreak = true
+  State.timeLeft = timeLeft
+  State.timerRunning = true
+
+  updateMenubarDisplay()
+
+  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.completeSession))
+  UI.countdownTimer:start()
+end
+
+function TimerManager.startWorkSession()
+  activatePomodoroFocus()
+  TimerManager.runWork(obj.config.workDuration, os.time())
+
   ModalManager.show("Work session begins!", "🍅", 2)
 
   -- Callback: onWorkStart
   if obj.config.onWorkStart then
     obj.config.onWorkStart()
   end
-
-  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(TimerManager.startBreakSession))
-  UI.countdownTimer:start()
 end
 
 function TimerManager.startBreakSession()
-  TimerManager.cleanup()
+  TimerManager.runBreak(obj.config.breakDuration)
 
-  State.isBreak = true
-  State.timeLeft = obj.config.breakDuration
-  State.timerRunning = true
-
-  updateMenubarDisplay()
   ModalManager.show("25 minutes complete! Take a break", "🍅", 2)
 
   -- Callback: onBreakStart
   if obj.config.onBreakStart then
     obj.config.onBreakStart()
   end
-
-  UI.countdownTimer = hs.timer.new(1, TimerManager.createCallback(function()
-    State.sessionsCompleted = State.sessionsCompleted + 1
-    TimerManager.stop()
-    saveCurrentStatistics()
-    ModalManager.show("Session complete! Great job", "✅", 2)
-
-    -- Callback: onComplete
-    if obj.config.onComplete then
-      obj.config.onComplete()
-    end
-  end))
-  UI.countdownTimer:start()
 end
 
 -- ============================================================================


### PR DESCRIPTION
## 요약

macOS Focus(집중 모드)가 **실제로 켜진 시각**을 기준으로 Pomodoro 타이머의 남은 시간과 단계를 보정합니다. 기존에는 focus 변경을 감지해도 항상 25:00부터 새로 시작했고(그마저도 Full Disk Access 미부여로 감지 자체가 동작하지 않음), 이제 focus 시작 시각으로부터 경과한 시간을 반영합니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 리팩토링

- `TimerManager` 타이머 구동 로직을 재사용 헬퍼(`completeSession`/`runWork`/`runBreak`)로 추출 (동작 변경 없음)
- 순수 함수 `computeSyncPlan`으로 경과 시간→단계(작업/휴식/완료) 계산
  - 경과 < 25분 → 작업 (남은시간 = 25분 − 경과)
  - 25 ≤ 경과 < 30분 → 휴식 (남은시간 = 30분 − 경과)
  - 경과 ≥ 30분 → idle + 통계 저장 (완료 카운트 증가 없음)
- `TimerManager.syncFromFocus(startTime)` 추가 — focus 감지 경로 전용, `activatePomodoroFocus()` 미호출(이미 켜진 focus 재점화/시작시각 리셋 방지)
- `FocusManager.getCurrentFocusInfo()` — `Assertions.json`의 `assertionStartDateTimestamp`를 Unix 시각으로 변환(Cocoa epoch + 978307200). `getCurrentFocusMode()`는 이름 반환 래퍼로 유지
- `handleFocusChange()`를 보정 기반으로 재작성하고 enabled/disabled 워쳐를 이 함수로 통일 → focus 모드 직접 전환 시 상태가 안 바뀌던 잠재 버그도 해소
- 공개 introspection 메서드 `obj:syncFromFocus`/`obj:currentFocusInfo` 추가

## 테스트 계획

- [x] `make test` 통과 (macOS validation mode)
- [x] 로컬 수동 테스트 — 라이브 Hammerspoon 검증: 부팅 재조정(focus 632초 전→left=868), 경계(60초→1440, 26분→휴식240, 31분→idle), 리로드 시 시작시각 유지
- [x] `make switch`로 실제 배포 후 라이브 동작 확인

## 추가 정보

- 감지에는 Hammerspoon의 **Full Disk Access** 권한이 필요합니다(`Assertions.json` 읽기). 머신마다 1회 수동 부여(TCC는 스크립트 부여 불가).
- 문서: `docs/superpowers/specs/2026-07-03-...-design.md`, `docs/superpowers/plans/2026-07-03-...-sync.md`

## 체크리스트

- [x] 코딩 스타일 준수
- [x] 자체 검토 완료 (task별 리뷰 + opus 전체 브랜치 리뷰: Ready to merge)
- [x] 문서 업데이트
- [x] 기존 기능 손상 없음