### PR TITLE
fix(nix): silence switch warnings

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -136,12 +136,12 @@ in
 
     # Fzf file widget
     (helpers.assertTest "fzf-file-widget-fd" (lib.hasInfix "fd --type f" (
-      fzfSettings.fileWidgetCommand or ""
+      fzfSettings.fileWidget.command or ""
     )) "fzf file widget should use fd")
 
     # Fzf directory widget
     (helpers.assertTest "fzf-cd-widget-fd" (lib.hasInfix "fd --type d" (
-      fzfSettings.changeDirWidgetCommand or ""
+      fzfSettings.changeDirWidget.command or ""
     )) "fzf cd widget should use fd for directories")
 
     # Direnv integration

--- a/tests/unit/home-manager-manual-test.nix
+++ b/tests/unit/home-manager-manual-test.nix
@@ -1,0 +1,28 @@
+# Home Manager manual settings regression test.
+#
+# The default Home Manager manpage manual evaluates options documentation,
+# which can emit options.json context warnings during darwin-rebuild switch.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  hmConfig = import ../../users/shared/home-manager.nix {
+    inherit pkgs lib inputs;
+    currentSystemUser = "baleen";
+  };
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "home-manager-manual" [
+    (helpers.assertTest "home-manager-manual-manpages-disabled" (
+      (hmConfig.manual.manpages.enable or true) == false
+    ) "Home Manager manual manpages should be disabled for warning-free switch builds")
+  ];
+}

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -75,4 +75,6 @@
   };
 
   xdg.enable = true;
+
+  manual.manpages.enable = false;
 }

--- a/users/shared/programs/zsh/default.nix
+++ b/users/shared/programs/zsh/default.nix
@@ -54,16 +54,20 @@ in
       ];
 
       # File search command (Ctrl+T)
-      fileWidgetCommand = "fd --type f --hidden --follow --exclude .git";
-      fileWidgetOptions = [
-        "--preview 'bat --style=numbers --color=always --line-range :500 {}'"
-      ];
+      fileWidget = {
+        command = "fd --type f --hidden --follow --exclude .git";
+        options = [
+          "--preview 'bat --style=numbers --color=always --line-range :500 {}'"
+        ];
+      };
 
       # Directory search command (Alt+C)
-      changeDirWidgetCommand = "fd --type d --hidden --follow --exclude .git";
-      changeDirWidgetOptions = [
-        "--preview 'tree -C {} | head -200'"
-      ];
+      changeDirWidget = {
+        command = "fd --type d --hidden --follow --exclude .git";
+        options = [
+          "--preview 'tree -C {} | head -200'"
+        ];
+      };
     };
 
     programs.direnv = {


### PR DESCRIPTION
## Summary
- Update Home Manager fzf widget options to the new nested option names.
- Disable Home Manager manpage manual generation to avoid options-doc warnings during switch builds.
- Add/update regression tests for warning-free switch behavior.

## Test Plan
- `nix fmt -- tests/integration/zsh-test.nix tests/unit/home-manager-manual-test.nix users/shared/home-manager.nix users/shared/programs/zsh/default.nix`
- `NIX_CONFIG='warn-dirty = false' nix build --impure --accept-flake-config --show-trace .#checks.aarch64-darwin.unit-home-manager-manual`
- `NIX_CONFIG='warn-dirty = false' nix build --impure --accept-flake-config --show-trace .#checks.aarch64-darwin.integration-zsh`
- `NIX_CONFIG='warn-dirty = false' NIXPKGS_ALLOW_UNFREE=1 darwin-rebuild build --flake .#$(hostname -s)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the shell file-search and directory-jump widgets to use a clearer, nested configuration style.
  * Disabled Home Manager manpage generation for the shared user setup.

* **Tests**
  * Added regression coverage to ensure the new widget configuration and manpage setting behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->