### PR TITLE
Add Hammerspoon Vim IME guard

### DIFF
--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -196,6 +196,13 @@ in
       "Vim IME guard should handle Ctrl-[ through a plain Escape replay"
     )
 
+    (helpers.assertTest "vim-ime-guard-spoon-requires-exact-modifiers"
+      (lib.hasInfix "local function hasExactModifiers(flags, required)" vimImeGuardInitContent
+        && lib.hasInfix "(flags[name] == true) ~= (required[name] == true)" vimImeGuardInitContent
+        && lib.hasInfix "hasExactModifiers(event:getFlags(), {ctrl = true})" vimImeGuardInitContent)
+      "Vim IME guard should not treat plain [ as Ctrl-["
+    )
+
     # ========================================================================
     # Section 3: Spoon Metadata Validation (4 tests)
     # ========================================================================

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -93,8 +93,7 @@ in
       "Spoons directory should be readable and usable"
     )
 
-    (helpers.assertTest "vim-ime-guard-spoon-usable"
-      (isFileUsable vimImeGuardInitResult)
+    (helpers.assertTest "vim-ime-guard-spoon-usable" (isFileUsable vimImeGuardInitResult)
       "Vim IME guard Spoon should be readable and have content"
     )
 
@@ -146,16 +145,13 @@ in
     )
 
     # Vim IME guard tests
-    (helpers.assertTest "init-starts-vim-ime-guard"
-      (lib.hasInfix "VimImeGuard:start()" initLuaContent)
+    (helpers.assertTest "init-starts-vim-ime-guard" (lib.hasInfix "VimImeGuard:start()" initLuaContent)
       "init.lua should start VimImeGuard Spoon"
     )
 
-    (helpers.assertTest "init-configures-vim-ime-guard-for-obsidian"
-      (lib.hasInfix "bundleIDs = {" initLuaContent
-        && lib.hasInfix "['md.obsidian'] = true" initLuaContent)
-      "init.lua should configure VimImeGuard for Obsidian"
-    )
+    (helpers.assertTest "init-configures-vim-ime-guard-for-obsidian" (
+      lib.hasInfix "bundleIDs = {" initLuaContent && lib.hasInfix "['md.obsidian'] = true" initLuaContent
+    ) "init.lua should configure VimImeGuard for Obsidian")
 
     (helpers.assertTest "vim-ime-guard-spoon-metadata"
       (lib.hasInfix "obj.name = \"VimImeGuard\"" vimImeGuardInitContent)
@@ -172,36 +168,31 @@ in
       "VimImeGuard Spoon should use configured bundle IDs"
     )
 
-    (helpers.assertTest "vim-ime-guard-spoon-switches-abc"
-      (lib.hasInfix "hs.keycodes.currentSourceID(self.inputEnglish)" vimImeGuardInitContent
-        && lib.hasInfix "com.apple.keylayout.ABC" vimImeGuardInitContent)
-      "Vim IME guard should switch to ABC before sending Escape"
-    )
+    (helpers.assertTest "vim-ime-guard-spoon-switches-abc" (
+      lib.hasInfix "hs.keycodes.currentSourceID(self.inputEnglish)" vimImeGuardInitContent
+      && lib.hasInfix "com.apple.keylayout.ABC" vimImeGuardInitContent
+    ) "Vim IME guard should switch to ABC before sending Escape")
 
-    (helpers.assertTest "vim-ime-guard-spoon-pending-switch"
-      (lib.hasInfix "vimEscapePendingUntil" vimImeGuardInitContent
-        && lib.hasInfix "hasPendingVimEscape()" vimImeGuardInitContent)
-      "Vim IME guard should protect rapid keys after Escape"
-    )
+    (helpers.assertTest "vim-ime-guard-spoon-pending-switch" (
+      lib.hasInfix "vimEscapePendingUntil" vimImeGuardInitContent
+      && lib.hasInfix "hasPendingVimEscape()" vimImeGuardInitContent
+    ) "Vim IME guard should protect rapid keys after Escape")
 
-    (helpers.assertTest "vim-ime-guard-spoon-delayed-replay"
-      (lib.hasInfix "obj.vimEscapeReplayDelay = 0.01" vimImeGuardInitContent
-        && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeReplayDelay)" vimImeGuardInitContent)
-      "Vim IME guard should replay Escape after Korean composition clears"
-    )
+    (helpers.assertTest "vim-ime-guard-spoon-delayed-replay" (
+      lib.hasInfix "obj.vimEscapeReplayDelay = 0.01" vimImeGuardInitContent
+      && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeReplayDelay)" vimImeGuardInitContent
+    ) "Vim IME guard should replay Escape after Korean composition clears")
 
-    (helpers.assertTest "vim-ime-guard-spoon-ctrl-bracket"
-      (lib.hasInfix "obj.vimEscapeCtrlReplayDelay = 0" vimImeGuardInitContent
-        && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeCtrlReplayDelay)" vimImeGuardInitContent)
-      "Vim IME guard should handle Ctrl-[ through a plain Escape replay"
-    )
+    (helpers.assertTest "vim-ime-guard-spoon-ctrl-bracket" (
+      lib.hasInfix "obj.vimEscapeCtrlReplayDelay = 0" vimImeGuardInitContent
+      && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeCtrlReplayDelay)" vimImeGuardInitContent
+    ) "Vim IME guard should handle Ctrl-[ through a plain Escape replay")
 
-    (helpers.assertTest "vim-ime-guard-spoon-requires-exact-modifiers"
-      (lib.hasInfix "local function hasExactModifiers(flags, required)" vimImeGuardInitContent
-        && lib.hasInfix "(flags[name] == true) ~= (required[name] == true)" vimImeGuardInitContent
-        && lib.hasInfix "hasExactModifiers(event:getFlags(), {ctrl = true})" vimImeGuardInitContent)
-      "Vim IME guard should not treat plain [ as Ctrl-["
-    )
+    (helpers.assertTest "vim-ime-guard-spoon-requires-exact-modifiers" (
+      lib.hasInfix "local function hasExactModifiers(flags, required)" vimImeGuardInitContent
+      && lib.hasInfix "(flags[name] == true) ~= (required[name] == true)" vimImeGuardInitContent
+      && lib.hasInfix "hasExactModifiers(event:getFlags(), {ctrl = true})" vimImeGuardInitContent
+    ) "Vim IME guard should not treat plain [ as Ctrl-[")
 
     # ========================================================================
     # Section 3: Spoon Metadata Validation (4 tests)

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -49,6 +49,7 @@ let
   expectedSpoons = [
     "Hyper.spoon"
     "Pomodoro.spoon"
+    "VimImeGuard.spoon"
   ];
   hasExpectedSpoons = lib.all (spoon: builtins.hasAttr spoon spoonsContents) expectedSpoons;
 
@@ -61,12 +62,15 @@ let
   # Spoon init.lua files
   pomodoroInit = hammerspoonDir + "/Spoons/Pomodoro.spoon/init.lua";
   hyperInit = hammerspoonDir + "/Spoons/Hyper.spoon/init.lua";
+  vimImeGuardInit = hammerspoonDir + "/Spoons/VimImeGuard.spoon/init.lua";
 
   pomodoroInitResult = validateFile pomodoroInit;
   hyperInitResult = validateFile hyperInit;
+  vimImeGuardInitResult = validateFile vimImeGuardInit;
 
   pomodoroInitContent = if pomodoroInitResult.success then pomodoroInitResult.value else "";
   hyperInitContent = if hyperInitResult.success then hyperInitResult.value else "";
+  vimImeGuardInitContent = if vimImeGuardInitResult.success then vimImeGuardInitResult.value else "";
 
 in
 {
@@ -87,6 +91,11 @@ in
     # Spoons directory test
     (helpers.assertTest "spoons-dir-usable" spoonsDirUsable
       "Spoons directory should be readable and usable"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-usable"
+      (isFileUsable vimImeGuardInitResult)
+      "Vim IME guard Spoon should be readable and have content"
     )
 
     # Structure validation tests
@@ -115,6 +124,11 @@ in
       "init.lua should load Pomodoro Spoon"
     )
 
+    (helpers.assertTest "init-loads-vim-ime-guard"
+      (lib.hasInfix "hs.loadSpoon('VimImeGuard')" initLuaContent)
+      "init.lua should load VimImeGuard Spoon"
+    )
+
     # Hyper key binding tests
     (helpers.assertTest "init-hyper-hotkeys" (lib.hasInfix "Hyper:bindHotKeys" initLuaContent)
       "init.lua should bind Hyper hotkeys"
@@ -129,6 +143,57 @@ in
     (helpers.assertTest "init-local-config-support"
       (lib.hasInfix "require('localConfig')" initLuaContent)
       "init.lua should support local config override"
+    )
+
+    # Vim IME guard tests
+    (helpers.assertTest "init-starts-vim-ime-guard"
+      (lib.hasInfix "VimImeGuard:start()" initLuaContent)
+      "init.lua should start VimImeGuard Spoon"
+    )
+
+    (helpers.assertTest "init-configures-vim-ime-guard-for-obsidian"
+      (lib.hasInfix "bundleIDs = {" initLuaContent
+        && lib.hasInfix "['md.obsidian'] = true" initLuaContent)
+      "init.lua should configure VimImeGuard for Obsidian"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-metadata"
+      (lib.hasInfix "obj.name = \"VimImeGuard\"" vimImeGuardInitContent)
+      "VimImeGuard Spoon should define name metadata"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-eventtap"
+      (lib.hasInfix "self.vimEscapeTap = hs.eventtap.new" vimImeGuardInitContent)
+      "VimImeGuard Spoon should register an eventtap"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-uses-configured-apps"
+      (lib.hasInfix "self.bundleIDs[bundleID] == true" vimImeGuardInitContent)
+      "VimImeGuard Spoon should use configured bundle IDs"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-switches-abc"
+      (lib.hasInfix "hs.keycodes.currentSourceID(self.inputEnglish)" vimImeGuardInitContent
+        && lib.hasInfix "com.apple.keylayout.ABC" vimImeGuardInitContent)
+      "Vim IME guard should switch to ABC before sending Escape"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-pending-switch"
+      (lib.hasInfix "vimEscapePendingUntil" vimImeGuardInitContent
+        && lib.hasInfix "hasPendingVimEscape()" vimImeGuardInitContent)
+      "Vim IME guard should protect rapid keys after Escape"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-delayed-replay"
+      (lib.hasInfix "obj.vimEscapeReplayDelay = 0.01" vimImeGuardInitContent
+        && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeReplayDelay)" vimImeGuardInitContent)
+      "Vim IME guard should replay Escape after Korean composition clears"
+    )
+
+    (helpers.assertTest "vim-ime-guard-spoon-ctrl-bracket"
+      (lib.hasInfix "obj.vimEscapeCtrlReplayDelay = 0" vimImeGuardInitContent
+        && lib.hasInfix "self:scheduleVimEscape({}, 'escape', self.vimEscapeCtrlReplayDelay)" vimImeGuardInitContent)
+      "Vim IME guard should handle Ctrl-[ through a plain Escape replay"
     )
 
     # ========================================================================

--- a/users/shared/programs/.config/hammerspoon/Spoons/VimImeGuard.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/VimImeGuard.spoon/init.lua
@@ -1,0 +1,119 @@
+--- === VimImeGuard ===
+---
+--- Keeps Vim normal mode usable in configured apps when a non-English IME is
+--- active.
+---
+--- The guard lets the original Escape clear IME composition, then switches to
+--- ABC before rapid follow-up keys like "jjj" can leak composed text.
+
+local obj = {}
+obj.__index = obj
+
+obj.name = "VimImeGuard"
+obj.version = "1.0"
+obj.author = "local"
+obj.license = "MIT"
+obj.homepage = "https://github.com/evantravers/dotfiles"
+obj.description = "Switches configured Vim apps back to ABC after Escape."
+
+obj.inputEnglish = 'com.apple.keylayout.ABC'
+obj.bundleIDs = {}
+obj.vimEscapePendingSeconds = 0.25
+obj.vimEscapeReplayDelay = 0.01
+obj.vimEscapeCtrlReplayDelay = 0
+obj.vimEscapeSyntheticResetDelay = 0.05
+
+function obj:init(config)
+  config = config or {}
+  self.inputEnglish = config.inputEnglish or self.inputEnglish
+  self.bundleIDs = config.bundleIDs or self.bundleIDs
+  self.vimEscapeSynthetic = false
+  self.vimEscapePendingUntil = 0
+  return self
+end
+
+function obj:frontmostAppUsesVimImeGuard()
+  local app = hs.application.frontmostApplication()
+  local bundleID = app and app:bundleID()
+  return bundleID and self.bundleIDs[bundleID] == true
+end
+
+local function hasOnlyModifiers(flags, allowed)
+  for _, name in ipairs({'cmd', 'alt', 'shift', 'ctrl', 'fn'}) do
+    if flags[name] and not allowed[name] then
+      return false
+    end
+  end
+  return true
+end
+
+local function isPlainEscape(event)
+  return event:getKeyCode() == 53 and hasOnlyModifiers(event:getFlags(), {})
+end
+
+local function isCtrlLeftBracket(event)
+  return event:getKeyCode() == 33 and hasOnlyModifiers(event:getFlags(), {ctrl = true})
+end
+
+function obj:hasPendingVimEscape()
+  return self.vimEscapePendingUntil > hs.timer.secondsSinceEpoch()
+end
+
+function obj:scheduleVimEscape(modifiers, key, delay)
+  self.vimEscapePendingUntil = hs.timer.secondsSinceEpoch() + self.vimEscapePendingSeconds
+  hs.timer.doAfter(delay, function()
+    hs.keycodes.currentSourceID(self.inputEnglish)
+    self.vimEscapeSynthetic = true
+    hs.eventtap.keyStroke(modifiers, key, 0)
+    hs.timer.doAfter(self.vimEscapeSyntheticResetDelay, function()
+      self.vimEscapeSynthetic = false
+    end)
+  end)
+end
+
+function obj:start()
+  if self.vimEscapeTap then
+    self.vimEscapeTap:stop()
+  end
+
+  self.vimEscapeSynthetic = false
+  self.vimEscapePendingUntil = 0
+
+  self.vimEscapeTap = hs.eventtap.new({hs.eventtap.event.types.keyDown}, function(event)
+    if self.vimEscapeSynthetic or not self:frontmostAppUsesVimImeGuard() then
+      return false
+    end
+
+    if self:hasPendingVimEscape() then
+      hs.keycodes.currentSourceID(self.inputEnglish)
+    end
+
+    if isPlainEscape(event) then
+      self:scheduleVimEscape({}, 'escape', self.vimEscapeReplayDelay)
+      return false
+    end
+
+    if isCtrlLeftBracket(event) then
+      self:scheduleVimEscape({}, 'escape', self.vimEscapeCtrlReplayDelay)
+      return false
+    end
+
+    return false
+  end)
+
+  self.vimEscapeTap:start()
+  return self
+end
+
+function obj:stop()
+  if self.vimEscapeTap then
+    self.vimEscapeTap:stop()
+  end
+  return self
+end
+
+function obj:isEnabled()
+  return self.vimEscapeTap and self.vimEscapeTap:isEnabled() or false
+end
+
+return obj

--- a/users/shared/programs/.config/hammerspoon/Spoons/VimImeGuard.spoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/Spoons/VimImeGuard.spoon/init.lua
@@ -38,9 +38,9 @@ function obj:frontmostAppUsesVimImeGuard()
   return bundleID and self.bundleIDs[bundleID] == true
 end
 
-local function hasOnlyModifiers(flags, allowed)
+local function hasExactModifiers(flags, required)
   for _, name in ipairs({'cmd', 'alt', 'shift', 'ctrl', 'fn'}) do
-    if flags[name] and not allowed[name] then
+    if (flags[name] == true) ~= (required[name] == true) then
       return false
     end
   end
@@ -48,11 +48,11 @@ local function hasOnlyModifiers(flags, allowed)
 end
 
 local function isPlainEscape(event)
-  return event:getKeyCode() == 53 and hasOnlyModifiers(event:getFlags(), {})
+  return event:getKeyCode() == 53 and hasExactModifiers(event:getFlags(), {})
 end
 
 local function isCtrlLeftBracket(event)
-  return event:getKeyCode() == 33 and hasOnlyModifiers(event:getFlags(), {ctrl = true})
+  return event:getKeyCode() == 33 and hasExactModifiers(event:getFlags(), {ctrl = true})
 end
 
 function obj:hasPendingVimEscape()

--- a/users/shared/programs/.config/hammerspoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/init.lua
@@ -2,6 +2,7 @@ require('hs.ipc')
 hs.allowAppleScript(true)
 hs.loadSpoon('Hyper')
 hs.loadSpoon('Pomodoro')
+hs.loadSpoon('VimImeGuard')
 
 
 Hyper = spoon.Hyper
@@ -10,6 +11,14 @@ Hyper = spoon.Hyper
 -- Karabiner intercepts app-launcher and local-binding keys directly for Secure
 -- Input immunity; Hammerspoon only handles logic-heavy bindings below.
 Hyper:bindHotKeys({hyperKey = {{}, 'F19'}})
+
+VimImeGuard = spoon.VimImeGuard
+VimImeGuard:init({
+  bundleIDs = {
+    ['md.obsidian'] = true,
+  },
+})
+VimImeGuard:start()
 
 -- provide the ability to override config per computer
 if (hs.fs.displayName('./localConfig.lua')) then


### PR DESCRIPTION
## Summary
- add a reusable VimImeGuard Hammerspoon Spoon
- configure it for Obsidian via bundle ID in init.lua
- add integration assertions for the Spoon and Obsidian configuration

## Verification
- luac -p users/shared/programs/.config/hammerspoon/init.lua users/shared/programs/.config/hammerspoon/Spoons/VimImeGuard.spoon/init.lua
- nix build .#checks.aarch64-darwin.integration-hammerspoon --impure --no-link
- make switch-home
- verified Ghostty keeps Korean 2-Set after Esc
- verified Obsidian switches Korean 2-Set to ABC after Esc
- verified Obsidian Korean input followed by Esc/jjj does not leave bad jamo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new keyboard-input guard for supported apps, helping Vim-style shortcuts work more reliably when using non-English input methods.
  * Enabled the guard in the Hammerspoon setup for the configured app list.

* **Tests**
  * Expanded integration coverage to verify the new behavior, including app support, shortcut handling, and delayed key replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->