### PR TITLE
chore(claude): journal 섹션을 obra upstream 원문과 일치

### DIFF
--- a/users/shared/programs/.config/claude/CLAUDE.md
+++ b/users/shared/programs/.config/claude/CLAUDE.md
@@ -73,10 +73,11 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ## Learning and Memory Management
 
-- Use `write_journal` from `private-journal-mcp` for durable technical insights, failed approaches, user preferences, project decisions, and notable observations.
-- Before complex or unfamiliar tasks, use `search_journal`, `list_journal`, and `read_journal` to look for relevant prior lessons.
-- Do not write journal entries for trivial lookups or one-off answers unless they reveal a durable preference or reusable lesson.
-- When you notice something that should be fixed but is unrelated to your current task, document it with `write_journal` rather than fixing it immediately.
+- YOU MUST use the journal tool frequently to capture technical insights, failed approaches, and user preferences
+- Before starting complex tasks, search the journal for relevant past experiences and lessons learned
+- Document architectural decisions and their outcomes for future reference
+- Track patterns in user feedback to improve collaboration over time
+- When you notice something that should be fixed but is unrelated to your current task, document it in your journal rather than fixing it immediately
 
 ## Recalling past context
 


### PR DESCRIPTION
## 요약
`~/.claude/CLAUDE.md`의 `## Learning and Memory Management` 섹션을 [obra dotfiles](https://github.com/obra/dotfiles) 원문 5줄과 동일하게 맞춤.

## 변경
```diff
-- Use `write_journal` from `private-journal-mcp` for durable technical insights, ...
-- Before complex or unfamiliar tasks, use `search_journal`, `list_journal`, and `read_journal` ...
-- Do not write journal entries for trivial lookups ...
-- When you notice something ... document it with `write_journal` ...
++ YOU MUST use the journal tool frequently to capture technical insights, failed approaches, and user preferences
++ Before starting complex tasks, search the journal for relevant past experiences and lessons learned
++ Document architectural decisions and their outcomes for future reference
++ Track patterns in user feedback to improve collaboration over time
++ When you notice something ... document it in your journal rather than fixing it immediately
```

## 비고
- 이 변경은 #1307("clarify memory tool guidance")의 journal 섹션 수정을 되돌려 obra upstream 원문과 일치시킴.
- 도구명(`write_journal` 등) 명시와 "trivial 제외" 규칙은 obra 원문에 없으므로 제거됨.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for journal usage to encourage more consistent note-taking during work.
  * Added recommendations to search past notes before complex tasks, record key decisions and outcomes, and track recurring feedback patterns.
  * Clarified how to handle unrelated changes by logging them for later instead of addressing them immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->