### PR TITLE
fix(tmux): preserve truecolor over mosh

### DIFF
--- a/docs/superpowers/plans/2026-07-16-mosh-tmux-truecolor.md
+++ b/docs/superpowers/plans/2026-07-16-mosh-tmux-truecolor.md
@@ -20,10 +20,12 @@
 ### Task 1: Declare and test mosh truecolor support
 
 **Files:**
+
 - Modify: `tests/integration/tmux-functionality-test.nix`
 - Modify: `users/shared/programs/tmux.nix`
 
 **Interfaces:**
+
 - Consumes: `programs.tmux.extraConfig` from the shared Home Manager module.
 - Produces: `terminal-features` entry `xterm-256color:RGB` for mosh-facing tmux clients.
 
@@ -86,10 +88,12 @@ git commit -m "fix(tmux): preserve truecolor over mosh"
 ### Task 2: Activate and verify on baleen-macbook
 
 **Files:**
+
 - Read: `flake-modules/home.nix`
 - Runtime target: `baleen@baleens-macbook.ojos-in.ts.net`
 
 **Interfaces:**
+
 - Consumes: `homeConfigurations.baleen.activationPackage` produced by the flake.
 - Produces: active remote tmux config whose fresh mosh client includes `RGB`.
 

--- a/docs/superpowers/plans/2026-07-16-mosh-tmux-truecolor.md
+++ b/docs/superpowers/plans/2026-07-16-mosh-tmux-truecolor.md
@@ -1,0 +1,148 @@
+# Mosh + tmux Truecolor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve 24-bit colors when Ghostty reaches remote tmux through mosh.
+
+**Architecture:** Keep the existing `tmux-256color` inner terminal and teach tmux that mosh's outer `xterm-256color` client supports RGB. Guard the contract with the existing Home Manager module integration test, then build and activate the `baleen` Home Manager closure remotely and verify through a fresh isolated mosh session.
+
+**Tech Stack:** Nix, Home Manager, tmux 3.7b, mosh 1.4.0, SSH
+
+## Global Constraints
+
+- Retain the existing `xterm-ghostty:RGB` terminal feature.
+- Add only RGB support for `xterm-256color`; do not add `extkeys`.
+- Do not change mosh prediction behavior or upgrade terminal packages.
+- Do not refactor unrelated tmux configuration.
+
+---
+
+### Task 1: Declare and test mosh truecolor support
+
+**Files:**
+- Modify: `tests/integration/tmux-functionality-test.nix`
+- Modify: `users/shared/programs/tmux.nix`
+
+**Interfaces:**
+- Consumes: `programs.tmux.extraConfig` from the shared Home Manager module.
+- Produces: `terminal-features` entry `xterm-256color:RGB` for mosh-facing tmux clients.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add this assertion after `tmux-set-titles`:
+
+```nix
+  tmux-mosh-truecolor =
+    mkConfigTest "tmux-mosh-truecolor"
+      (hasConfigString "set -as terminal-features ',xterm-256color:RGB'")
+      "tmux should preserve truecolor when mosh presents xterm-256color";
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' build --no-link --impure \
+  --expr 'let flake = builtins.getFlake (toString ./.); in (import ./tests/integration/tmux-functionality-test.nix { inputs = flake.inputs; system = builtins.currentSystem; }).tmux-mosh-truecolor'
+```
+
+Expected: FAIL with `tmux should preserve truecolor when mosh presents xterm-256color`.
+
+- [ ] **Step 3: Add the minimal tmux capability**
+
+Extend the truecolor section in `users/shared/programs/tmux.nix`:
+
+```nix
+        # Mosh 1.4 preserves truecolor and exports COLORTERM=truecolor, but its
+        # outer terminal is xterm-256color rather than xterm-ghostty.
+        set -as terminal-features ',xterm-256color:RGB'
+```
+
+- [ ] **Step 4: Run the focused test and Darwin smoke verification**
+
+Run the focused command from Step 2 again.
+
+Expected: PASS and a built `test-tmux-mosh-truecolor-pass` derivation.
+
+Run:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 nix --extra-experimental-features 'nix-command flakes' \
+  eval '.#checks.aarch64-darwin.smoke' --impure --accept-flake-config
+```
+
+Expected: exit 0 and a smoke-test derivation.
+
+- [ ] **Step 5: Commit the tested change**
+
+```bash
+git add tests/integration/tmux-functionality-test.nix users/shared/programs/tmux.nix
+git commit -m "fix(tmux): preserve truecolor over mosh"
+```
+
+---
+
+### Task 2: Activate and verify on baleen-macbook
+
+**Files:**
+- Read: `flake-modules/home.nix`
+- Runtime target: `baleen@baleens-macbook.ojos-in.ts.net`
+
+**Interfaces:**
+- Consumes: `homeConfigurations.baleen.activationPackage` produced by the flake.
+- Produces: active remote tmux config whose fresh mosh client includes `RGB`.
+
+- [ ] **Step 1: Build and copy the Home Manager activation closure**
+
+Run:
+
+```bash
+activation=$(NIXPKGS_ALLOW_UNFREE=1 nix --extra-experimental-features 'nix-command flakes' \
+  build '.#homeConfigurations.baleen.activationPackage' --no-link \
+  --print-out-paths --impure --accept-flake-config)
+nix copy --to 'ssh-ng://baleen@baleens-macbook.ojos-in.ts.net' "$activation"
+```
+
+Expected: one activation package path and successful closure copy.
+
+- [ ] **Step 2: Activate and reload the existing tmux server**
+
+Run:
+
+```bash
+ssh baleen@baleens-macbook.ojos-in.ts.net "$activation/activate"
+ssh baleen@baleens-macbook.ojos-in.ts.net \
+  'tmux source-file ~/.config/tmux/tmux.conf && tmux show-options -g terminal-features'
+```
+
+Expected: activation succeeds and `terminal-features` contains both `xterm-ghostty:RGB` and `xterm-256color:RGB`.
+
+- [ ] **Step 3: Verify through a fresh isolated mosh + tmux client**
+
+Start mosh with `/bin/zsh -f`, then run:
+
+```bash
+tmux -L codex-mosh-verify -f ~/.config/tmux/tmux.conf new-session -s verify /bin/zsh -f
+printf '\e[48;2;1;2;3mRGB_VERIFY\e[0m\n'
+```
+
+From SSH, run:
+
+```bash
+tmux -L codex-mosh-verify list-clients -F \
+  'term=#{client_termname} features=#{client_termfeatures}'
+```
+
+Expected: client term is `xterm-256color`, features include `RGB`, and the mosh output preserves `48;2;1;2;3` rather than reducing it to `48;5`.
+
+- [ ] **Step 4: Clean up verification processes and record evidence**
+
+Exit the isolated tmux pane and mosh shell. Confirm:
+
+```bash
+ssh baleen@baleens-macbook.ojos-in.ts.net \
+  'tmux -L codex-mosh-verify list-sessions 2>&1 || true; ps -axo command= | grep "[m]osh-server new" || true'
+```
+
+Expected: no `codex-mosh-verify` server and no mosh server created by verification.

--- a/docs/superpowers/specs/2026-07-16-mosh-tmux-truecolor-design.md
+++ b/docs/superpowers/specs/2026-07-16-mosh-tmux-truecolor-design.md
@@ -1,0 +1,45 @@
+# Mosh + tmux Truecolor Design
+
+## Context
+
+Ghostty starts mosh with truecolor support, but mosh presents the remote tmux
+client as `xterm-256color`. The current tmux configuration only enables `RGB`
+for `xterm-ghostty`, so tmux reduces 24-bit SGR colors to the 256-color palette.
+
+The behavior was reproduced through an isolated mosh and tmux session:
+
+- Before the override, `48;2;1;2;3` became `48;5;16`.
+- With `xterm-256color:RGB`, `48;2;1;2;3` passed through unchanged.
+- The remote pane already received `COLORTERM=truecolor`.
+
+## Decision
+
+Add `xterm-256color:RGB` to tmux `terminal-features` while retaining the
+existing `xterm-ghostty:RGB` entry. Do not add `extkeys` for
+`xterm-256color`; the observed defect is color capability detection, and mosh
+did not advertise extended-key support.
+
+## Scope
+
+- Update `users/shared/programs/tmux.nix` with the mosh-facing RGB capability.
+- Add a focused integration assertion for the new terminal feature.
+- Apply the Home Manager configuration on the remote MacBook.
+- Reconnect through mosh and verify that the attached tmux client reports
+  `RGB` and preserves a truecolor SGR sequence.
+
+## Non-goals
+
+- Changing mosh prediction behavior.
+- Changing tmux extended-key handling.
+- Upgrading mosh, tmux, or Ghostty.
+- Refactoring unrelated tmux configuration.
+
+## Verification
+
+1. The focused tmux integration test fails before the config change and passes
+   afterward.
+2. Darwin smoke evaluation remains successful.
+3. After remote Home Manager activation and a fresh mosh attach,
+   `client_termfeatures` includes `RGB`.
+4. A truecolor SGR input remains `38;2` or `48;2` instead of being reduced to
+   `38;5` or `48;5`.

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -80,6 +80,11 @@ in
     mkConfigTest "tmux-set-titles" (hasConfigString "set -g set-titles on")
       "tmux should propagate session/window to the terminal title (Ghostty tab identification)";
 
+  tmux-mosh-truecolor =
+    mkConfigTest "tmux-mosh-truecolor"
+      (hasConfigString "set -as terminal-features ',xterm-256color:RGB'")
+      "tmux should preserve truecolor when mosh presents xterm-256color";
+
   # ============================================================================
   # OSC52 clipboard integration (cross-platform, works over SSH)
   # ============================================================================

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -162,6 +162,10 @@ in
         # so no manual terminal-overrides are needed for those.
         set -as terminal-features ',xterm-ghostty:RGB'
 
+        # Mosh 1.4 preserves truecolor and exports COLORTERM=truecolor, but its
+        # outer terminal is xterm-256color rather than xterm-ghostty.
+        set -as terminal-features ',xterm-256color:RGB'
+
         # Extended keys (CSI u). Ghostty speaks the CSI-u encoding; tmux 3.6
         # defaults extended-keys-format to xterm form, so set csi-u explicitly
         # for modifier combos (e.g. Shift+Enter) to reach apps inside tmux.


### PR DESCRIPTION
## 요약

Mosh가 원격 tmux에 `TERM=xterm-256color`로 연결될 때 24-bit color가 256-color로 양자화되는 문제를 수정합니다.

## 변경사항

- [x] 버그 수정
- [x] 문서 업데이트
- [x] 테스트 추가/수정
- [x] 설정 변경

- tmux `terminal-features`에 `xterm-256color:RGB` 추가
- 기존 `xterm-ghostty:RGB`와 Ghostty extkeys 설정 유지
- 정확한 설정 문자열을 검증하는 integration regression test 추가
- 설계 및 실행 계획 문서 추가

## 테스트 계획

- [x] focused `tmux-mosh-truecolor` Nix build 통과
- [x] Darwin smoke evaluation 통과
- [x] pre-push `All Tests` 통과
- [x] 관련 플랫폼에서 테스트 완료

원격 `baleens-macbook`에 Home Manager closure를 활성화하고 fresh mosh + isolated tmux로 검증했습니다. Client feature에 `RGB`가 포함됐고 raw PTY에서 `48;2;1;2;3`가 보존되며 `48;5` 양자화는 없었습니다.

## 추가 정보

- 패키지 버전 변경 및 mosh prediction 변경 없음
- `xterm-256color:extkeys`는 추가하지 않음
- 기존 tmux session은 유지했고 검증용 tmux/mosh process는 정리함

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성을 추가하지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved truecolor rendering for remote sessions using Mosh and tmux.
  * RGB color sequences are now preserved when connecting through Mosh instead of being reduced to a 256-color palette.

* **Tests**
  * Added integration coverage to verify truecolor support in Mosh-connected tmux sessions.

* **Documentation**
  * Added design and implementation documentation for configuring and validating Mosh + tmux truecolor support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->