### PR TITLE
fix(ghostty): standardize terminal type

### DIFF
--- a/tests/integration/ghostty-test.nix
+++ b/tests/integration/ghostty-test.nix
@@ -104,6 +104,10 @@ let
       "Ghostty should have shell-integration-features set to cursor,sudo,title"
     )
 
+    (helpers.assertTest "ghostty-terminal-type-xterm-256color" (hasConfigLine "term.*=.*xterm-256color")
+      "Ghostty should report xterm-256color for every shell"
+    )
+
     # macOS-specific keybinding test (Option key as Alt)
     (helpers.assertTest "ghostty-macos-option-as-alt" (hasConfigLine "macos-option-as-alt.*=.*left")
       "Ghostty should have macos-option-as-alt set to left for Claude Code compatibility"

--- a/users/shared/programs/.config/ghostty/config
+++ b/users/shared/programs/.config/ghostty/config
@@ -1,6 +1,9 @@
 # Ghostty Terminal Configuration
 # Managed via Nix Home Manager
 
+# Terminal Compatibility
+term = xterm-256color
+
 # Font Configuration
 font-family = JetBrains Mono
 font-family = D2Coding


### PR DESCRIPTION
## 요약

Ghostty가 모든 새 셸에서 `TERM=xterm-256color`를 사용하도록 통일합니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정
- [x] 설정 변경

- Ghostty managed config에 `term = xterm-256color` 추가
- 해당 설정을 고정하는 Nix 회귀 테스트 추가
- SSH keychain 및 tmux 설정은 변경하지 않음

## 테스트 계획

- [x] focused `checks.aarch64-darwin.integration-ghostty` 통과
- [x] pre-commit Fast Tests 통과
- [x] 로컬 Home Manager 적용 및 Ghostty resolved config 확인
- [x] 원격 MacBook Home Manager 적용 및 새 SSH 로그인에서 경고 0건 확인

## 추가 정보

로컬과 `baleen@baleens-macbook.ojos-in.ts.net`에 activation을 적용했고, 새 원격 로그인 셸에서 `TERM=xterm-256color`를 확인했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit terminal compatibility configuration for Ghostty using `xterm-256color`.

* **Tests**
  * Added integration coverage to verify the terminal compatibility setting is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->