### PR TITLE
feat(tmux): add vim-tmux-navigator plugin and use typed hm options

### DIFF
--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -66,12 +66,12 @@ in
   # Key bindings
   # ============================================================================
   tmux-split-vertical =
-    mkConfigTest "tmux-split-vertical" (hasConfigString "bind | split-window -h")
-      "tmux should bind | to vertical split";
+    mkConfigTest "tmux-split-vertical" (hasConfigString "bind % split-window -h")
+      "tmux should keep the default % vertical split with current pane path";
 
   tmux-split-horizontal =
-    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind - split-window -v")
-      "tmux should bind - to horizontal split";
+    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind '\"' split-window -v")
+      "tmux should keep the default \" horizontal split with current pane path";
 
   tmux-vim-pane-navigation =
     mkConfigTest "tmux-vim-pane-navigation" (hasConfigString "bind h select-pane -L")

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -1,5 +1,5 @@
 # tests/integration/tmux-functionality.nix
-# Tmux configuration integration tests for Oh My Tmux style
+# Tmux configuration integration tests
 # Tests that tmux is properly integrated with home manager
 {
   inputs,
@@ -43,11 +43,11 @@ let
 in
 {
   # ============================================================================
-  # Core configuration - Oh My Tmux style
+  # Core configuration
   # ============================================================================
   tmux-prefix-is-ctrl-a = helpers.assertTest "tmux-prefix-is-ctrl-a" (
     tmuxConfig.prefix == "C-a"
-  ) "tmux prefix should be Ctrl-a (Oh My Tmux style)";
+  ) "tmux prefix should be Ctrl-a (screen-style)";
 
   tmux-prefix-send-prefix =
     mkConfigTest "tmux-prefix-send-prefix" (hasConfigString "bind C-a send-prefix")
@@ -57,12 +57,13 @@ in
     mkConfigTest "tmux-prefix-last-window" (hasConfigString "bind a last-window")
       "tmux should bind a to toggle last window";
 
-  tmux-has-zero-plugins = helpers.assertTest "tmux-has-zero-plugins" (
-    builtins.length tmuxConfig.plugins == 0
-  ) "tmux should have 0 plugins (functionality provided via extraConfig)";
+  tmux-has-vim-navigator-plugin = helpers.assertTest "tmux-has-vim-navigator-plugin" (lib.any
+    (p: lib.hasInfix "vim-tmux-navigator" (p.pname or p.plugin.pname or ""))
+    tmuxConfig.plugins
+  ) "tmux should load vim-tmux-navigator (pairs with the vim plugin for C-h/j/k/l navigation)";
 
   # ============================================================================
-  # Oh My Tmux style key bindings
+  # Key bindings
   # ============================================================================
   tmux-split-vertical =
     mkConfigTest "tmux-split-vertical" (hasConfigString "bind | split-window -h")

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -2,7 +2,7 @@
 #
 # Features:
 #   - Ctrl-a prefix (screen-style)
-#   - Intuitive split bindings: | (vertical), - (horizontal)
+#   - Default split keys (" and %) that inherit the current pane's directory
 #   - Vim-style pane navigation: h/j/k/l
 #   - Vi-style copy mode with tmux-native OSC52 clipboard support
 #   - Truecolor (RGB) + undercurl inherited from xterm-ghostty terminfo
@@ -11,7 +11,7 @@
 #
 # Key Bindings:
 #   - Prefix: Ctrl+a
-#   - Split panes: Prefix+| (vertical), Prefix+- (horizontal)
+#   - Split panes: Prefix+" (horizontal), Prefix+% (vertical)
 #   - Navigate panes: Prefix+h/j/k/l or Ctrl+h/j/k/l (with Vim)
 #   - New window: Prefix+c
 #   - Next/Prev window: Prefix+n/p
@@ -98,11 +98,9 @@ in
         # ============================================================================
         # Pane management
         # ============================================================================
-        # Intuitive split bindings
-        bind | split-window -h -c "#{pane_current_path}"
-        bind - split-window -v -c "#{pane_current_path}"
-        unbind '"'
-        unbind %
+        # Default split keys, but inherit the current pane's directory
+        bind '"' split-window -v -c "#{pane_current_path}"
+        bind % split-window -h -c "#{pane_current_path}"
 
         # Vim-style pane navigation
         bind h select-pane -L

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -1,7 +1,5 @@
 # Tmux Terminal Multiplexer Configuration
 #
-# Oh My Tmux Inspired Configuration
-#
 # Features:
 #   - Ctrl-a prefix (screen-style)
 #   - Intuitive split bindings: | (vertical), - (horizontal)
@@ -46,25 +44,27 @@ in
     programs.tmux = {
       enable = true;
 
-      plugins = [ ];
+      plugins = [ pkgs.tmuxPlugins.vim-tmux-navigator ];
 
       terminal = "tmux-256color";
       prefix = "C-a";
       escapeTime = 0;
       historyLimit = 50000;
+      keyMode = "vi";
+      mouse = true;
+      focusEvents = true;
 
-      # Oh My Tmux inspired configuration
       extraConfig = ''
         # ============================================================================
         # Base configuration
         # ============================================================================
         # default-terminal is emitted by programs.tmux.terminal = "tmux-256color"
+        # mouse, focus-events, mode-keys/status-keys are emitted by the
+        # corresponding programs.tmux options (mouse, focusEvents, keyMode)
         set -g default-shell ${pkgs.zsh}/bin/zsh
         # default-command left unset: tmux runs default-shell as a login shell
-        set -g focus-events on
 
         # Terminal and display settings
-        set -g mouse on
         bind-key -n MouseDown2Pane paste-buffer
         set -g base-index 1
         set -g pane-base-index 1
@@ -96,7 +96,7 @@ in
         bind a last-window
 
         # ============================================================================
-        # Pane management (Oh My Tmux style)
+        # Pane management
         # ============================================================================
         # Intuitive split bindings
         bind | split-window -h -c "#{pane_current_path}"
@@ -131,7 +131,6 @@ in
         # ============================================================================
         # Copy mode with OSC52 support
         # ============================================================================
-        setw -g mode-keys vi
         bind [ copy-mode
         bind ] paste-buffer
 


### PR DESCRIPTION
## 요약

vim.nix에는 vim-tmux-navigator가 이미 있었지만 tmux 쪽 플러그인이 빠져 있어, 헤더 주석이 약속하던 Ctrl+h/j/k/l pane↔split 이동이 실제로는 동작하지 않았습니다. tmux 쪽 플러그인을 추가하고, 일부 raw 설정을 home-manager typed 옵션으로 정리합니다. 또한 커스텀 분할 키(`|`/`-`)를 tmux 기본 키(`"`/`%`)로 되돌립니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 테스트 추가/수정
- [x] 설정 변경

**users/shared/programs/tmux.nix**
- `tmuxPlugins.vim-tmux-navigator` 플러그인 추가 — vim(pane)↔tmux(split) 간 Ctrl+h/j/k/l 이동 활성화
- `setw -g mode-keys vi` / `set -g mouse on` / `set -g focus-events on`을 typed 옵션(`keyMode`/`mouse`/`focusEvents`)으로 이동. `keyMode = "vi"`는 기존에 emacs 기본값으로 남아 있던 `status-keys`(`:` 명령 프롬프트)도 vi로 통일
- Oh My Tmux 관련 주석 제거 (해당 설정을 따르지 않는 독립 설정)
- 분할 키를 기본값 `"`/`%`로 복원 (`|`/`-` 바인딩과 `unbind` 제거). 현재 pane 디렉토리 상속(`-c "#{pane_current_path}"`)은 유지

**tests/integration/tmux-functionality-test.nix**
- "플러그인 0개" 단언을 vim-tmux-navigator 포함 단언으로 교체
- 분할 키 단언을 `|`/`-`에서 `"`/`%`로 교체

## 테스트 계획

- [x] `make test` 통과 (pre-commit Fast Tests)
- [x] tmux 통합 테스트 체크 빌드 통과 (신규 플러그인 테스트 포함)
- [x] 생성된 tmux.conf 평가로 확인: `status-keys vi`, `mode-keys vi`, `mouse on`, `focus-events on`, navigator `run-shell` 반영

## 추가 정보

- 플러그인이 Ctrl+L을 가져가므로 화면 클리어는 `prefix + Ctrl+L` 사용
- 적용에는 `make switch` 후 tmux 서버 재시작 필요

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름 (`make format` 통과)
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Vim-style navigation support between tmux and Vim panes.
  - Enabled vi key handling, mouse support, and focus event tracking in tmux.

- **Bug Fixes**
  - Updated tmux integration tests to verify the new navigation plugin and configuration behavior.
  - Simplified configuration handling to improve consistency between module settings and tmux behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
