### PR TITLE
feat: surface pane titles (agent status) in tmux titles and window list

### DIFF
--- a/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
@@ -43,28 +43,16 @@
 
 - **`ts <경로>`**: 경로 → 세션명 계산 → `tmux new-session -A -d -s <name> -c <path>`
   후, `$TMUX` 안이면 `switch-client -t <name>`, 밖이면 `attach -t <name>`
-- **`ts` (인자 없음, 피커 모드)**: 살아있는 세션 목록(`tmux ls`, 최근 attach 순)을
-  fzf로 표시하고, 선택한 세션으로 전환/attach
-- **비스코프(추후 확장점)**: 디렉토리 후보 검색은 이번에 넣지 않는다. 새 세션은
-  `gw`(워크트리) 또는 `ts <경로>`(예: `ts .`)로 만든다. 나중에 필요해지면 피커
-  목록에 디렉토리 소스(검색 루트 또는 zoxide) 한 줄을 추가하는 구조로 둔다
-- 의존성: tmux, fzf (둘 다 기존 설치분). runtimeInputs로 명시
+- 인자 없이 실행하면 usage 출력 (피커 모드 없음)
+- **비스코프(추후 확장점)**: 피커/디렉토리 검색은 넣지 않는다. 세션 간 전환은
+  tmux 내장 `prefix+s`(choose-tree)를 사용한다. 새 세션은 `gw`(워크트리) 또는
+  `ts <경로>`(예: `ts .`)로 만든다
+- 의존성: tmux (기존 설치분). runtimeInputs로 명시
 
 배치: `users/shared/programs/tmux.nix` 안에서 정의 (tmux 전용 부품이므로 동일
 모듈에 둠. 파일이 과도하게 커지면 `tmux/` 하위 분리는 후속 판단)
 
-### 2. tmux 바인딩
-
-`extraConfig`에 추가:
-
-```tmux
-bind f display-popup -E -w 70% -h 60% ts
-```
-
-- `prefix+f`로 어디서든 피커 popup (tmux ≥3.2, 현재 3.7b)
-- 세션 kill 바인딩은 페인포인트가 아니므로 미포함 (YAGNI)
-
-### 3. gw 연동 (`users/shared/programs/zsh/gw.nix`)
+### 2. gw 연동 (`users/shared/programs/zsh/gw.nix`)
 
 워크트리 생성/전환 성공 후 마지막 단계:
 
@@ -73,7 +61,7 @@ bind f display-popup -E -w 70% -h 60% ts
 - tmux 밖이거나 `ts`가 없으면 → 기존처럼 `cd` (동작 보존)
 - 기존 워크트리로 전환하는 분기(`_handle_existing_worktree`)에도 동일 적용
 
-### 4. SSH/mosh 자동 attach (`users/shared/programs/ssh.nix`)
+### 3. SSH/mosh 자동 attach (`users/shared/programs/ssh.nix`)
 
 전역 강제가 아닌 호스트별 옵트인 패턴:
 
@@ -90,28 +78,26 @@ Host <원격호스트>
 ## 에러 처리
 
 - `ts <경로>`: 경로가 디렉토리가 아니면 에러 메시지 후 종료 1
-- 피커에서 ESC(선택 취소): 아무 것도 하지 않고 종료 0
 - tmux 서버가 없을 때 `ts` 단독 실행: `new-session -A`가 서버를 시작하므로 정상 동작
 
 ## 테스트 / 검증
 
 - 통합 테스트 (`tests/integration/tmux-functionality-test.nix` 기존 패턴):
-  - extraConfig에 `bind f display-popup` 포함 단언
   - `ts` 스크립트가 home.packages에 포함되는지 단언
 - 수동 검증 (`make switch` 후):
   1. 레포 디렉토리에서 `ts .` → 레포명 세션 생성 확인, 재실행 시 기존 세션 전환 확인
-  2. `prefix+f` → 세션 목록 fzf 표시, 선택 시 해당 세션으로 전환 확인
-  3. tmux 안에서 `gw` → 워크트리 전용 세션으로 자동 전환 확인
-  4. tmux 밖에서 `gw` → 기존처럼 cd만 되는지 확인
+  2. tmux 안에서 `gw` → 워크트리 전용 세션으로 자동 전환 확인
+  3. tmux 밖에서 `gw` → 기존처럼 cd만 되는지 확인
+  4. `prefix+s`(내장 choose-tree)로 세션 간 전환 확인
 
 ## 변경 파일 목록
 
 | 파일 | 변경 |
 |---|---|
-| `users/shared/programs/tmux.nix` | `ts` 스크립트 정의 + `bind f` 바인딩 |
+| `users/shared/programs/tmux.nix` | `ts` 스크립트 정의 (home.packages) |
 | `users/shared/programs/zsh/gw.nix` | 말미에 tmux 연동 분기 (3~5줄) |
 | `users/shared/programs/ssh.nix` | 옵트인 RemoteCommand 패턴 (호스트는 추후 지정) |
-| `tests/integration/tmux-functionality-test.nix` | 바인딩/패키지 단언 추가 |
+| `tests/integration/tmux-functionality-test.nix` | `ts` 패키지 단언 추가 |
 
 ## 비채택 대안
 

--- a/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
@@ -75,10 +75,10 @@ Host <원격호스트>
 
 ## 변경 파일 목록
 
-| 파일 | 변경 |
-|---|---|
-| `users/shared/programs/zsh/gw.nix` | 말미에 tmux 세션 생성/전환 분기 |
-| `users/shared/programs/ssh.nix` | 옵트인 RemoteCommand 패턴 (호스트는 추후 지정) |
+| 파일                               | 변경                                           |
+| ---------------------------------- | ---------------------------------------------- |
+| `users/shared/programs/zsh/gw.nix` | 말미에 tmux 세션 생성/전환 분기                |
+| `users/shared/programs/ssh.nix`    | 옵트인 RemoteCommand 패턴 (호스트는 추후 지정) |
 
 ## 비채택 대안
 

--- a/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
@@ -43,11 +43,11 @@
 
 - **`ts <경로>`**: 경로 → 세션명 계산 → `tmux new-session -A -d -s <name> -c <path>`
   후, `$TMUX` 안이면 `switch-client -t <name>`, 밖이면 `attach -t <name>`
-- **`ts` (인자 없음, 피커 모드)**: fzf로 다음 목록을 표시하고 선택 시 위 로직 실행
-  - 살아있는 세션 (`tmux ls`, 최근 attach 순, `●` 마커)
-  - 후보 디렉토리: `~/dotfiles`, `~/dev/*`, 그리고 각각의 `.worktrees/*`
-    (`~/dev/*/.worktrees/*`, `~/dotfiles/.worktrees/*`)
-  - 이미 세션이 있는 디렉토리는 후보에서 제거(중복 방지)
+- **`ts` (인자 없음, 피커 모드)**: 살아있는 세션 목록(`tmux ls`, 최근 attach 순)을
+  fzf로 표시하고, 선택한 세션으로 전환/attach
+- **비스코프(추후 확장점)**: 디렉토리 후보 검색은 이번에 넣지 않는다. 새 세션은
+  `gw`(워크트리) 또는 `ts <경로>`(예: `ts .`)로 만든다. 나중에 필요해지면 피커
+  목록에 디렉토리 소스(검색 루트 또는 zoxide) 한 줄을 추가하는 구조로 둔다
 - 의존성: tmux, fzf (둘 다 기존 설치분). runtimeInputs로 명시
 
 배치: `users/shared/programs/tmux.nix` 안에서 정의 (tmux 전용 부품이므로 동일
@@ -99,8 +99,8 @@ Host <원격호스트>
   - extraConfig에 `bind f display-popup` 포함 단언
   - `ts` 스크립트가 home.packages에 포함되는지 단언
 - 수동 검증 (`make switch` 후):
-  1. `prefix+f` → 목록에서 레포 선택 → 새 세션 생성 확인
-  2. 같은 항목 재선택 → 기존 세션 attach(전환) 확인
+  1. 레포 디렉토리에서 `ts .` → 레포명 세션 생성 확인, 재실행 시 기존 세션 전환 확인
+  2. `prefix+f` → 세션 목록 fzf 표시, 선택 시 해당 세션으로 전환 확인
   3. tmux 안에서 `gw` → 워크트리 전용 세션으로 자동 전환 확인
   4. tmux 밖에서 `gw` → 기존처럼 cd만 되는지 확인
 

--- a/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
@@ -16,52 +16,37 @@
 기성 도구(sesh, tms, workmux)를 검토했으나, 이 저장소의 워크트리 컨벤션
 (`<repo>/.worktrees/YYMMDD-<branch>` 평면 레이아웃)이 sesh의 `.bare` 가정과
 어긋나고, tms/workmux는 "워크트리 = window" 모델이라 아래 원칙과 상충한다.
-필요한 기능이 셸 스크립트 40줄 수준이므로 자작(A안)을 채택한다.
+필요한 기능이 gw 함수 내 몇 줄 + SSH 설정 수준이므로 자작(A안)을 채택한다.
+별도 스크립트(`ts`)와 fzf 피커도 검토했으나 스코프에서 제외했다(비채택 대안 참조).
 
 ## 원칙
 
 - **세션 = 작업 단위(체크아웃)**: 일반 레포도, 워크트리도 각각 독립 세션
-- 새 외부 의존성 없음 (기존 tmux + fzf + zsh만 사용)
+- 새 외부 의존성 없음 (기존 tmux + zsh만 사용)
 - 옵트인: 기존 워크플로(tmux 밖 gw, 일반 SSH)를 깨지 않는다
 
-## 세션 이름 규칙
+## 세션 이름 규칙 (gw가 만드는 세션)
 
-| 대상 | 세션 이름 | 예시 |
-|---|---|---|
-| 일반 레포 | 디렉토리명 | `search-data`, `dotfiles` |
-| 워크트리 | `<레포>/<워크트리 디렉토리명>` | `inhouse/260716-feat-jito-recommend...` |
-
+- 세션 이름 = `<레포>/<워크트리 디렉토리명>` (예: `inhouse/260716-feat-jito-...`)
+- 레포명은 `.worktrees` 바로 앞 디렉토리명
 - tmux 세션명에서 특수 취급되는 `.`, `:`는 `_`로 치환한다
-- 워크트리 판별: 경로에 `/.worktrees/` 세그먼트가 포함되면 워크트리로 간주,
-  레포명은 `.worktrees` 바로 앞 디렉토리명
 
 ## 구성 요소
 
-### 1. `ts` 스크립트 (신규, 핵심)
+### 1. gw 연동 (`users/shared/programs/zsh/gw.nix`)
 
-`pkgs.writeShellApplication`으로 만들어 `home.packages`로 배포. 동작:
+워크트리 생성/전환 성공 후 마지막 단계를 분기한다:
 
-- **`ts <경로>`**: 경로 → 세션명 계산 → `tmux new-session -A -d -s <name> -c <path>`
-  후, `$TMUX` 안이면 `switch-client -t <name>`, 밖이면 `attach -t <name>`
-- 인자 없이 실행하면 usage 출력 (피커 모드 없음)
-- **비스코프(추후 확장점)**: 피커/디렉토리 검색은 넣지 않는다. 세션 간 전환은
-  tmux 내장 `prefix+s`(choose-tree)를 사용한다. 새 세션은 `gw`(워크트리) 또는
-  `ts <경로>`(예: `ts .`)로 만든다
-- 의존성: tmux (기존 설치분). runtimeInputs로 명시
-
-배치: `users/shared/programs/tmux.nix` 안에서 정의 (tmux 전용 부품이므로 동일
-모듈에 둠. 파일이 과도하게 커지면 `tmux/` 하위 분리는 후속 판단)
-
-### 2. gw 연동 (`users/shared/programs/zsh/gw.nix`)
-
-워크트리 생성/전환 성공 후 마지막 단계:
-
-- `$TMUX`가 설정되어 있고 `ts`가 PATH에 있으면 → `ts <워크트리 경로>` 호출
-  (cd 대신 세션 생성+전환)
-- tmux 밖이거나 `ts`가 없으면 → 기존처럼 `cd` (동작 보존)
+- **`$TMUX` 안이면**: 위 이름 규칙으로 세션명을 계산해
+  `tmux new-session -A -d -s <name> -c <경로>` 후 `tmux switch-client -t <name>`
+  (별도 스크립트 없이 gw 함수 내 헬퍼 몇 줄로 인라인)
+- **tmux 밖이면**: 기존처럼 `cd` (동작 보존)
 - 기존 워크트리로 전환하는 분기(`_handle_existing_worktree`)에도 동일 적용
 
-### 3. SSH/mosh 자동 attach (`users/shared/programs/ssh.nix`)
+세션 간 전환은 tmux 내장 `prefix+s`(choose-tree)를 사용한다. 일반 레포의
+세션이 필요하면 `tmux new -A -s <이름> -c <경로>`를 직접 쓴다 (도구화하지 않음).
+
+### 2. SSH/mosh 자동 attach (`users/shared/programs/ssh.nix`)
 
 전역 강제가 아닌 호스트별 옵트인 패턴:
 
@@ -77,16 +62,14 @@ Host <원격호스트>
 
 ## 에러 처리
 
-- `ts <경로>`: 경로가 디렉토리가 아니면 에러 메시지 후 종료 1
-- tmux 서버가 없을 때 `ts` 단독 실행: `new-session -A`가 서버를 시작하므로 정상 동작
+- gw의 tmux 분기에서 세션 생성/전환이 실패하면 경고 출력 후 기존 `cd`로 폴백
+  (워크트리 생성 자체는 이미 성공한 상태이므로 작업을 잃지 않는다)
 
 ## 테스트 / 검증
 
-- 통합 테스트 (`tests/integration/tmux-functionality-test.nix` 기존 패턴):
-  - `ts` 스크립트가 home.packages에 포함되는지 단언
 - 수동 검증 (`make switch` 후):
-  1. 레포 디렉토리에서 `ts .` → 레포명 세션 생성 확인, 재실행 시 기존 세션 전환 확인
-  2. tmux 안에서 `gw` → 워크트리 전용 세션으로 자동 전환 확인
+  1. tmux 안에서 `gw` → 워크트리 전용 세션(`<레포>/<워크트리>`)으로 자동 전환 확인
+  2. 같은 브랜치로 다시 `gw` → 기존 세션으로 전환(중복 생성 없음) 확인
   3. tmux 밖에서 `gw` → 기존처럼 cd만 되는지 확인
   4. `prefix+s`(내장 choose-tree)로 세션 간 전환 확인
 
@@ -94,13 +77,13 @@ Host <원격호스트>
 
 | 파일 | 변경 |
 |---|---|
-| `users/shared/programs/tmux.nix` | `ts` 스크립트 정의 (home.packages) |
-| `users/shared/programs/zsh/gw.nix` | 말미에 tmux 연동 분기 (3~5줄) |
+| `users/shared/programs/zsh/gw.nix` | 말미에 tmux 세션 생성/전환 분기 |
 | `users/shared/programs/ssh.nix` | 옵트인 RemoteCommand 패턴 (호스트는 추후 지정) |
-| `tests/integration/tmux-functionality-test.nix` | `ts` 패키지 단언 추가 |
 
 ## 비채택 대안
 
 - **sesh + zoxide**: 워크트리 레이아웃 불일치로 glue가 여전히 필요, 의존성 2개 추가
 - **tms / workmux**: "워크트리 = window" 모델이 본 설계 원칙과 상충
+- **자작 `ts` 스크립트 + fzf 피커**: 검토했으나 스코프 축소 과정에서 제외.
+  세션 전환은 내장 `prefix+s`로 충분하고, 세션 생성은 gw 인라인으로 충분
 - **셸 rc 자동 tmux attach**: scp/비인터랙티브 파손 위험으로 SSH config 방식 채택

--- a/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-18-tmux-session-workflow-design.md
@@ -1,0 +1,120 @@
+# tmux 세션 워크플로 설계 (A안: 자작 미니멀)
+
+- 날짜: 2026-07-18
+- 상태: 설계 승인 대기
+- 관련: PR #1335 (vim-tmux-navigator, 분할 키 기본값 복원 — 본 설계와 독립)
+
+## 배경 / 문제
+
+현재 tmux 사용 패턴은 "터미널 탭 보조 → 단일 세션 멀티 window"를 거쳐 프로젝트별
+세션으로 진화하는 중이며, 다음 세 가지 페인포인트가 있다:
+
+1. **세션 검색**: 기존 세션 이름이 기억나지 않아 `tmux ls` → `attach`를 수동 반복
+2. **gw 워크트리 단절**: `gw`가 워크트리를 만들어도 tmux 세션과 연결되지 않음
+3. **SSH/mosh 수동 attach**: 원격 접속 후 매번 손으로 `tmux attach`
+
+기성 도구(sesh, tms, workmux)를 검토했으나, 이 저장소의 워크트리 컨벤션
+(`<repo>/.worktrees/YYMMDD-<branch>` 평면 레이아웃)이 sesh의 `.bare` 가정과
+어긋나고, tms/workmux는 "워크트리 = window" 모델이라 아래 원칙과 상충한다.
+필요한 기능이 셸 스크립트 40줄 수준이므로 자작(A안)을 채택한다.
+
+## 원칙
+
+- **세션 = 작업 단위(체크아웃)**: 일반 레포도, 워크트리도 각각 독립 세션
+- 새 외부 의존성 없음 (기존 tmux + fzf + zsh만 사용)
+- 옵트인: 기존 워크플로(tmux 밖 gw, 일반 SSH)를 깨지 않는다
+
+## 세션 이름 규칙
+
+| 대상 | 세션 이름 | 예시 |
+|---|---|---|
+| 일반 레포 | 디렉토리명 | `search-data`, `dotfiles` |
+| 워크트리 | `<레포>/<워크트리 디렉토리명>` | `inhouse/260716-feat-jito-recommend...` |
+
+- tmux 세션명에서 특수 취급되는 `.`, `:`는 `_`로 치환한다
+- 워크트리 판별: 경로에 `/.worktrees/` 세그먼트가 포함되면 워크트리로 간주,
+  레포명은 `.worktrees` 바로 앞 디렉토리명
+
+## 구성 요소
+
+### 1. `ts` 스크립트 (신규, 핵심)
+
+`pkgs.writeShellApplication`으로 만들어 `home.packages`로 배포. 동작:
+
+- **`ts <경로>`**: 경로 → 세션명 계산 → `tmux new-session -A -d -s <name> -c <path>`
+  후, `$TMUX` 안이면 `switch-client -t <name>`, 밖이면 `attach -t <name>`
+- **`ts` (인자 없음, 피커 모드)**: fzf로 다음 목록을 표시하고 선택 시 위 로직 실행
+  - 살아있는 세션 (`tmux ls`, 최근 attach 순, `●` 마커)
+  - 후보 디렉토리: `~/dotfiles`, `~/dev/*`, 그리고 각각의 `.worktrees/*`
+    (`~/dev/*/.worktrees/*`, `~/dotfiles/.worktrees/*`)
+  - 이미 세션이 있는 디렉토리는 후보에서 제거(중복 방지)
+- 의존성: tmux, fzf (둘 다 기존 설치분). runtimeInputs로 명시
+
+배치: `users/shared/programs/tmux.nix` 안에서 정의 (tmux 전용 부품이므로 동일
+모듈에 둠. 파일이 과도하게 커지면 `tmux/` 하위 분리는 후속 판단)
+
+### 2. tmux 바인딩
+
+`extraConfig`에 추가:
+
+```tmux
+bind f display-popup -E -w 70% -h 60% ts
+```
+
+- `prefix+f`로 어디서든 피커 popup (tmux ≥3.2, 현재 3.7b)
+- 세션 kill 바인딩은 페인포인트가 아니므로 미포함 (YAGNI)
+
+### 3. gw 연동 (`users/shared/programs/zsh/gw.nix`)
+
+워크트리 생성/전환 성공 후 마지막 단계:
+
+- `$TMUX`가 설정되어 있고 `ts`가 PATH에 있으면 → `ts <워크트리 경로>` 호출
+  (cd 대신 세션 생성+전환)
+- tmux 밖이거나 `ts`가 없으면 → 기존처럼 `cd` (동작 보존)
+- 기존 워크트리로 전환하는 분기(`_handle_existing_worktree`)에도 동일 적용
+
+### 4. SSH/mosh 자동 attach (`users/shared/programs/ssh.nix`)
+
+전역 강제가 아닌 호스트별 옵트인 패턴:
+
+```
+Host <원격호스트>
+  RequestTTY yes
+  RemoteCommand tmux new -A -s main
+```
+
+- 셸 rc 레벨 자동 attach는 채택하지 않음 (scp/rsync/비인터랙티브 셸 파손 위험)
+- mosh: `mosh <host> -- tmux new -A -s main` 형태의 별칭으로 대응
+- 적용 대상 호스트는 구현 시 사용자가 지정 (스펙 범위: 패턴 제공까지)
+
+## 에러 처리
+
+- `ts <경로>`: 경로가 디렉토리가 아니면 에러 메시지 후 종료 1
+- 피커에서 ESC(선택 취소): 아무 것도 하지 않고 종료 0
+- tmux 서버가 없을 때 `ts` 단독 실행: `new-session -A`가 서버를 시작하므로 정상 동작
+
+## 테스트 / 검증
+
+- 통합 테스트 (`tests/integration/tmux-functionality-test.nix` 기존 패턴):
+  - extraConfig에 `bind f display-popup` 포함 단언
+  - `ts` 스크립트가 home.packages에 포함되는지 단언
+- 수동 검증 (`make switch` 후):
+  1. `prefix+f` → 목록에서 레포 선택 → 새 세션 생성 확인
+  2. 같은 항목 재선택 → 기존 세션 attach(전환) 확인
+  3. tmux 안에서 `gw` → 워크트리 전용 세션으로 자동 전환 확인
+  4. tmux 밖에서 `gw` → 기존처럼 cd만 되는지 확인
+
+## 변경 파일 목록
+
+| 파일 | 변경 |
+|---|---|
+| `users/shared/programs/tmux.nix` | `ts` 스크립트 정의 + `bind f` 바인딩 |
+| `users/shared/programs/zsh/gw.nix` | 말미에 tmux 연동 분기 (3~5줄) |
+| `users/shared/programs/ssh.nix` | 옵트인 RemoteCommand 패턴 (호스트는 추후 지정) |
+| `tests/integration/tmux-functionality-test.nix` | 바인딩/패키지 단언 추가 |
+
+## 비채택 대안
+
+- **sesh + zoxide**: 워크트리 레이아웃 불일치로 glue가 여전히 필요, 의존성 2개 추가
+- **tms / workmux**: "워크트리 = window" 모델이 본 설계 원칙과 상충
+- **셸 rc 자동 tmux attach**: scp/비인터랙티브 파손 위험으로 SSH config 방식 채택

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -62,15 +62,15 @@ in
   ) "tmux should have 0 plugins (functionality provided via extraConfig)";
 
   # ============================================================================
-  # Oh My Tmux style key bindings
+  # Key bindings
   # ============================================================================
   tmux-split-vertical =
-    mkConfigTest "tmux-split-vertical" (hasConfigString "bind | split-window -h")
-      "tmux should bind | to vertical split";
+    mkConfigTest "tmux-split-vertical" (hasConfigString "bind % split-window -h")
+      "tmux should keep default % vertical split (with current pane path)";
 
   tmux-split-horizontal =
-    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind - split-window -v")
-      "tmux should bind - to horizontal split";
+    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind '\"' split-window -v")
+      "tmux should keep default \" horizontal split (with current pane path)";
 
   tmux-vim-pane-navigation =
     mkConfigTest "tmux-vim-pane-navigation" (hasConfigString "bind h select-pane -L")

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -4,7 +4,7 @@
 #
 # Features:
 #   - Ctrl-a prefix (screen-style)
-#   - Intuitive split bindings: | (vertical), - (horizontal)
+#   - Default split bindings: % (vertical), " (horizontal)
 #   - Vim-style pane navigation: h/j/k/l
 #   - Vi-style copy mode with tmux-native OSC52 clipboard support
 #   - Truecolor (RGB) + undercurl inherited from xterm-ghostty terminfo
@@ -13,7 +13,7 @@
 #
 # Key Bindings:
 #   - Prefix: Ctrl+a
-#   - Split panes: Prefix+| (vertical), Prefix+- (horizontal)
+#   - Split panes: Prefix+% (vertical), Prefix+" (horizontal)
 #   - Navigate panes: Prefix+h/j/k/l or Ctrl+h/j/k/l (with Vim)
 #   - New window: Prefix+c
 #   - Next/Prev window: Prefix+n/p
@@ -96,13 +96,11 @@ in
         bind a last-window
 
         # ============================================================================
-        # Pane management (Oh My Tmux style)
+        # Pane management
         # ============================================================================
-        # Intuitive split bindings
-        bind | split-window -h -c "#{pane_current_path}"
-        bind - split-window -v -c "#{pane_current_path}"
-        unbind '"'
-        unbind %
+        # Default split bindings (% and "), but keep the current pane's path
+        bind % split-window -h -c "#{pane_current_path}"
+        bind '"' split-window -v -c "#{pane_current_path}"
 
         # Vim-style pane navigation
         bind h select-pane -L

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -80,11 +80,12 @@ in
         set -g allow-rename off
         set -g destroy-unattached off
 
-        # Propagate session/window to the Ghostty tab/window title so multiple
-        # tabs are distinguishable. Complements allow-rename off: apps can't
-        # hijack the name via OSC, but tmux itself sets the outer title.
+        # Propagate session + active pane title to the Ghostty tab/window title.
+        # Complements allow-rename off: that only blocks window-name renames;
+        # pane titles (OSC 2) still flow, which is how coding agents (Claude
+        # Code etc.) report their status (spinner = working, ✳ = waiting).
         set -g set-titles on
-        set -g set-titles-string "#S  #I:#W"
+        set -g set-titles-string "#S  #{?#{!=:#{pane_title},#{host}},#{pane_title},#I:#W}"
 
         # ============================================================================
         # Prefix key bindings (Ctrl-a style)
@@ -182,9 +183,12 @@ in
         set -g status-left '#[fg=colour233,bg=colour241,bold] #S '
         set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M '
 
-        # Window status display
-        setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '
-        setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#W#[fg=colour244]#F '
+        # Window status display. Shows the active pane's title (agent status:
+        # spinner = working, ✳ = waiting) when a program sets one via OSC 2;
+        # falls back to the window name when the title is the default (#{host}).
+        # Truncated to 30 chars to keep the window list readable.
+        setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour50]#F '
+        setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour244]#F '
 
         # ============================================================================
         # Misc


### PR DESCRIPTION
## 요약

tmux 세션 워크플로우 설계 문서 추가와 함께, pane 분할 키를 tmux 기본값(`%`, `"`)으로 되돌리고, 코딩 에이전트 상태(pane title)가 Ghostty 탭 타이틀과 tmux 윈도우 목록에 표시되도록 개선합니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

주요 내용:

- `docs/`: tmux 세션 워크플로우 설계 스펙 추가 (ts 스크립트 제거, gw가 세션을 인라인 처리)
- `users/shared/programs/tmux.nix`:
  - pane 분할 키를 커스텀 `|`/`-`에서 기본값 `%`/`"`로 복원 (`pane_current_path` 유지)
  - `set-titles-string` 및 window status format에 활성 pane의 OSC 2 title 표시 (에이전트 작업 상태 노출, 30자 truncate, 미설정 시 세션/윈도우명 폴백)
- `tests/integration/tmux-functionality-test.nix`: 분할 키 assertion을 기본 키 기준으로 갱신

## 테스트 계획

- [x] pre-commit 훅 통과 (deadnix, Fast Tests 포함)
- [x] nix eval로 새 테스트 assertion과 설정 문자열 일치 확인
- [ ] `make test-all` — CI에서 검증
- [ ] 로컬에서 수동 테스트 완료 (`make switch` 후 tmux 리로드)

## 추가 정보

tmux 통합 테스트는 Linux 전용이라 CI의 Linux 잡에서 실제 검증됩니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a design specification for automatically linking tmux sessions to repositories and worktrees, including optional remote-session support and fallback behavior.

* **Enhancements**
  * Updated tmux pane-splitting shortcuts to use the standard `%` and `"` bindings.
  * Improved tmux window and terminal titles to display meaningful pane titles when available.

* **Tests**
  * Updated integration tests to verify the revised pane-splitting shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->