### PR TITLE
feat(tmux): use intuitive split bindings

### DIFF
--- a/docs/superpowers/plans/2026-07-19-tmux-split-bindings.md
+++ b/docs/superpowers/plans/2026-07-19-tmux-split-bindings.md
@@ -1,0 +1,94 @@
+# tmux Split Bindings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace tmux's default `%` and `"` split keys with `|` for left/right panes and `-` for top/bottom panes.
+
+**Architecture:** Keep the existing Home Manager tmux module and change only its split binding declarations, documentation comments, and focused integration assertions. Preserve `-c "#{pane_current_path}"` so both new panes open in the active pane's directory.
+
+**Tech Stack:** Nix, Home Manager, tmux
+
+## Global Constraints
+
+- `Prefix+|` runs `split-window -h -c "#{pane_current_path}"`.
+- `Prefix+-` runs `split-window -v -c "#{pane_current_path}"`.
+- Default `%` and `"` bindings are explicitly unbound.
+- No unrelated tmux settings change.
+
+---
+
+### Task 1: Replace and verify split bindings
+
+**Files:**
+
+- Modify: `tests/integration/tmux-functionality-test.nix`
+- Modify: `users/shared/programs/tmux.nix`
+
+**Interfaces:**
+
+- Consumes: `programs.tmux.extraConfig` from the shared Home Manager module.
+- Produces: prefix-table bindings `|` and `-`, with `%` and `"` removed.
+
+- [ ] **Step 1: Write failing integration assertions**
+
+Replace the two existing split assertions and add the default-key assertion:
+
+```nix
+  tmux-split-vertical =
+    mkConfigTest "tmux-split-vertical" (hasConfigString "bind | split-window -h")
+      "tmux should bind | to a left/right split with the current pane path";
+
+  tmux-split-horizontal =
+    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind - split-window -v")
+      "tmux should bind - to a top/bottom split with the current pane path";
+
+  tmux-default-split-bindings-unbound =
+    mkConfigTest "tmux-default-split-bindings-unbound"
+      (hasConfigString "unbind '%'" && hasConfigString "unbind '\"'")
+      "tmux should unbind the default % and double-quote split keys";
+```
+
+- [ ] **Step 2: Run the focused assertions and verify RED**
+
+Run each new contract against the unchanged module:
+
+```bash
+for testName in tmux-split-vertical tmux-split-horizontal tmux-default-split-bindings-unbound; do
+  nix --extra-experimental-features 'nix-command flakes' build --no-link --impure \
+    --expr "let flake = builtins.getFlake (toString ./.); in (import ./tests/integration/tmux-functionality-test.nix { inputs = flake.inputs; system = builtins.currentSystem; }).${testName}" || true
+done
+```
+
+Expected: all three builds fail with their corresponding assertion messages because `|`, `-`, and the explicit unbinds are absent.
+
+- [ ] **Step 3: Implement the minimal tmux configuration change**
+
+Update the top-level comments to describe `|` and `-`, then replace the pane-management declarations with:
+
+```tmux
+        # Intuitive split bindings, keeping the current pane's path
+        bind | split-window -h -c "#{pane_current_path}"
+        bind - split-window -v -c "#{pane_current_path}"
+        unbind '%'
+        unbind '"'
+```
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run the three focused builds from Step 2 without `|| true`, then run:
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' build --no-link --impure \
+  --expr 'let flake = builtins.getFlake (toString ./.); tests = import ./tests/integration/tmux-functionality-test.nix { inputs = flake.inputs; system = builtins.currentSystem; }; in builtins.attrValues tests'
+git diff --check
+```
+
+Expected: all derivations build and `git diff --check` exits 0.
+
+- [ ] **Step 5: Commit the verified implementation**
+
+```bash
+git add docs/superpowers/plans/2026-07-19-tmux-split-bindings.md \
+  tests/integration/tmux-functionality-test.nix users/shared/programs/tmux.nix
+git commit -m "feat(tmux): use intuitive split bindings"
+```

--- a/docs/superpowers/specs/2026-07-19-tmux-split-bindings-design.md
+++ b/docs/superpowers/specs/2026-07-19-tmux-split-bindings-design.md
@@ -1,0 +1,24 @@
+# tmux 분할 키 설계
+
+- 날짜: 2026-07-19
+- 상태: 승인됨
+
+## 목표
+
+tmux의 기본 분할 키 대신 입력하기 쉬운 다음 바인딩을 사용한다.
+
+- `Prefix+|`: 현재 pane 경로를 유지하며 좌우 분할 (`split-window -h`)
+- `Prefix+-`: 현재 pane 경로를 유지하며 상하 분할 (`split-window -v`)
+
+기본 `%`와 `"` 바인딩은 해제해 분할 키를 위 두 가지로 한정한다.
+
+## 변경 범위
+
+- `users/shared/programs/tmux.nix`의 바인딩과 설명을 갱신한다.
+- `tests/integration/tmux-functionality-test.nix`가 새 바인딩과 기본 키 해제를 검증하게 한다.
+- 다른 tmux 설정은 변경하지 않는다.
+
+## 검증
+
+- tmux 통합 테스트에서 `|`/`-` 바인딩과 `%`/`"` 해제를 확인한다.
+- 생성된 tmux 설정의 문법을 검사한다.

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -65,12 +65,17 @@ in
   # Key bindings
   # ============================================================================
   tmux-split-vertical =
-    mkConfigTest "tmux-split-vertical" (hasConfigString "bind % split-window -h")
-      "tmux should keep default % vertical split (with current pane path)";
+    mkConfigTest "tmux-split-vertical" (hasConfigString "bind | split-window -h")
+      "tmux should bind | to a left/right split with the current pane path";
 
   tmux-split-horizontal =
-    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind '\"' split-window -v")
-      "tmux should keep default \" horizontal split (with current pane path)";
+    mkConfigTest "tmux-split-horizontal" (hasConfigString "bind - split-window -v")
+      "tmux should bind - to a top/bottom split with the current pane path";
+
+  tmux-default-split-bindings-unbound =
+    mkConfigTest "tmux-default-split-bindings-unbound"
+      (hasConfigString "unbind '%'" && hasConfigString "unbind '\"'")
+      "tmux should unbind the default % and double-quote split keys";
 
   tmux-vim-pane-navigation =
     mkConfigTest "tmux-vim-pane-navigation" (hasConfigString "bind h select-pane -L")

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -72,10 +72,9 @@ in
     mkConfigTest "tmux-split-horizontal" (hasConfigString "bind - split-window -v")
       "tmux should bind - to a top/bottom split with the current pane path";
 
-  tmux-default-split-bindings-unbound =
-    mkConfigTest "tmux-default-split-bindings-unbound"
-      (hasConfigString "unbind '%'" && hasConfigString "unbind '\"'")
-      "tmux should unbind the default % and double-quote split keys";
+  tmux-default-split-bindings-unbound = mkConfigTest "tmux-default-split-bindings-unbound" (
+    hasConfigString "unbind '%'" && hasConfigString "unbind '\"'"
+  ) "tmux should unbind the default % and double-quote split keys";
 
   tmux-vim-pane-navigation =
     mkConfigTest "tmux-vim-pane-navigation" (hasConfigString "bind h select-pane -L")

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -4,7 +4,7 @@
 #
 # Features:
 #   - Ctrl-a prefix (screen-style)
-#   - Default split bindings: % (vertical), " (horizontal)
+#   - Intuitive split bindings: | (left/right), - (top/bottom)
 #   - Vim-style pane navigation: h/j/k/l
 #   - Vi-style copy mode with tmux-native OSC52 clipboard support
 #   - Truecolor (RGB) + undercurl inherited from xterm-ghostty terminfo
@@ -13,7 +13,7 @@
 #
 # Key Bindings:
 #   - Prefix: Ctrl+a
-#   - Split panes: Prefix+% (vertical), Prefix+" (horizontal)
+#   - Split panes: Prefix+| (left/right), Prefix+- (top/bottom)
 #   - Navigate panes: Prefix+h/j/k/l or Ctrl+h/j/k/l (with Vim)
 #   - New window: Prefix+c
 #   - Next/Prev window: Prefix+n/p
@@ -99,9 +99,11 @@ in
         # ============================================================================
         # Pane management
         # ============================================================================
-        # Default split bindings (% and "), but keep the current pane's path
-        bind % split-window -h -c "#{pane_current_path}"
-        bind '"' split-window -v -c "#{pane_current_path}"
+        # Intuitive split bindings, keeping the current pane's path
+        bind | split-window -h -c "#{pane_current_path}"
+        bind - split-window -v -c "#{pane_current_path}"
+        unbind '%'
+        unbind '"'
 
         # Vim-style pane navigation
         bind h select-pane -L


### PR DESCRIPTION
## 요약

tmux pane 분할 키를 `%`/`"` 대신 `|`/`-`로 변경합니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

- `Prefix+|`: 현재 pane 경로를 유지한 좌우 분할
- `Prefix+-`: 현재 pane 경로를 유지한 상하 분할
- 기본 `%` 및 `"` 분할 바인딩 해제
- 새 바인딩과 기본 키 해제를 통합 테스트로 검증

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

검증:
- tmux 통합 테스트 전체 Nix build 통과
- 격리 tmux server의 prefix key table에서 `|`/`-` 확인
- `%`/`"` split binding 부재 확인
- pre-commit Fast Tests 통과

## 추가 정보

새 pane은 기존과 동일하게 `#{pane_current_path}`에서 시작합니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated tmux pane-splitting shortcuts to use `Prefix+|` for horizontal splits and `Prefix+-` for vertical splits.
  * New splits continue opening in the current pane’s directory.

* **Bug Fixes**
  * Removed tmux’s default `%` and `"` split shortcuts to prevent conflicting bindings.

* **Tests**
  * Updated integration coverage to verify the new shortcuts and removed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->