### PR TITLE
fix(darwin): correct VS Code ripgrep path

### DIFF
--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -11,6 +11,20 @@
     # Claude Code - latest from flake input
     claude-code = inputs.claude-code.packages.${prev.stdenv.hostPlatform.system}.default;
 
+    # VS Code 1.129.1 stores Darwin native modules in node_modules.asar.unpacked,
+    # but nixpkgs still patches ripgrep under node_modules.
+    vscode =
+      if prev.stdenv.hostPlatform.isDarwin then
+        prev.vscode.overrideAttrs (oldAttrs: {
+          postPatch =
+            builtins.replaceStrings
+              [ "Contents/Resources/app/node_modules/@vscode/ripgrep-universal" ]
+              [ "Contents/Resources/app/node_modules.asar.unpacked/@vscode/ripgrep-universal" ]
+              oldAttrs.postPatch;
+        })
+      else
+        prev.vscode;
+
     # direnv - fix cgo build issue by removing linkmode=external
     # Disable checkPhase: 2.37.1's `make test-zsh` hangs in zsh integration test
     # under Determinate Nix (sandbox=false) on macOS. Tests are upstream-validated

--- a/tests/unit/vscode-overlay-test.nix
+++ b/tests/unit/vscode-overlay-test.nix
@@ -1,0 +1,22 @@
+{
+  inputs,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  overlays = import ../../lib/overlays.nix { inherit inputs; };
+  darwinPkgs = import inputs.nixpkgs {
+    system = "aarch64-darwin";
+    inherit overlays;
+    config.allowUnfree = true;
+  };
+  postPatch = darwinPkgs.vscode.drvAttrs.postPatch;
+  ripgrepPath = "Contents/Resources/app/node_modules.asar.unpacked/@vscode/ripgrep-universal";
+  brokenRipgrepPath = "Contents/Resources/app/node_modules/@vscode/ripgrep-universal";
+in
+helpers.assertTest "vscode-darwin-ripgrep-path" (
+  lib.hasInfix ripgrepPath postPatch && !lib.hasInfix brokenRipgrepPath postPatch
+) "VS Code must patch ripgrep at its node_modules.asar.unpacked location on Darwin"


### PR DESCRIPTION
## What changed

- Override the Darwin VS Code package patch path to use `node_modules.asar.unpacked`
- Add a regression test covering the corrected ripgrep location

## Root cause

The flake update upgraded VS Code from 1.127.0 to 1.129.1. The Darwin archive stores ripgrep under `node_modules.asar.unpacked`, while nixpkgs still attempted to patch `node_modules`, causing the Darwin closure build to fail.

## Impact

The workaround is scoped to Darwin and becomes a no-op once nixpkgs uses the corrected path. Linux packages are unchanged.

## Validation

- Regression test for the Darwin ripgrep path
- VS Code 1.129.1 Darwin derivation build
- Full `darwinConfigurations.macbook-pro.system` closure build
- `pre-commit run --all-files`
- `make test-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VS Code’s ripgrep module path on Darwin systems, improving compatibility for macOS users.

* **Tests**
  * Added coverage to verify the path adjustment is applied only where expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->