### PR TITLE
feat(zsh): add gw ls/rm subcommands with background nix store gc

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -228,7 +228,7 @@ in
 
     # Git Worktree function (gw)
     (helpers.assertTest "function-gw-exists" (initContentHas "gw()") "gw() function should exist")
-    (helpers.assertTest "function-gw-usage" (initContentHas "Usage: gw <branch-name>")
+    (helpers.assertTest "function-gw-usage" (initContentHas "Usage: gw [branch-name]")
       "gw() should have usage message"
     )
     (helpers.assertTest "function-gw-git-check" (initContentHas "git rev-parse --git-dir")

--- a/tests/unit/gw-subcommands-test.nix
+++ b/tests/unit/gw-subcommands-test.nix
@@ -1,0 +1,46 @@
+# tests/unit/gw-subcommands-test.nix
+# Verify gw subcommands: gw ls (list worktrees) and gw rm (remove worktree
+# paired with background nix store gc).
+# Removing a worktree alone leaves nix-direnv gc-roots in
+# /nix/var/nix/gcroots/per-user/ pointing at the deleted .direnv/;
+# only a subsequent GC run cleans them up and reclaims store space.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  gwScript = import ../../users/shared/programs/zsh/gw.nix;
+in
+{
+  platforms = [ "any" ];
+  value = helpers.testSuite "gw-subcommands" [
+    (helpers.assertTest "gw-ls-subcommand" (lib.hasInfix "ls)" gwScript)
+      "gw should handle an ls subcommand"
+    )
+    (helpers.assertTest "gw-ls-scans-machine-wide-gcroots"
+      (lib.hasInfix "/nix/var/nix/gcroots/auto" gwScript)
+      "gw ls should list worktrees machine-wide via nix-direnv gc-roots, not just the current repo"
+    )
+    (helpers.assertTest "gw-rm-subcommand" (lib.hasInfix "rm)" gwScript)
+      "gw should handle an rm subcommand"
+    )
+    (helpers.assertTest "gw-rm-removes-worktree" (lib.hasInfix "git worktree remove" gwScript)
+      "gw rm should remove the worktree via git worktree remove"
+    )
+    (helpers.assertTest "gw-rm-runs-gc-in-background" (lib.hasInfix "(nix store gc" gwScript)
+      "gw rm should run nix store gc in a detached background subshell"
+    )
+    (helpers.assertTest "gw-create-runs-gc-in-background" (
+      builtins.length (lib.splitString "(nix store gc" gwScript) >= 3
+    ) "gw create path should also trigger background nix store gc (two call sites: create + rm)")
+    (helpers.assertTest "gw-rm-avoids-collect-garbage-d" (
+      !(lib.hasInfix "nix-collect-garbage -d" gwScript)
+    ) "gw rm should not use nix-collect-garbage -d (deletes system generations, breaks rollback)")
+  ];
+}

--- a/users/shared/programs/zsh/gw.nix
+++ b/users/shared/programs/zsh/gw.nix
@@ -1,11 +1,13 @@
 # Git Worktree wrapper for Zsh
 #
 # Returns a pure string of shell code defining the gw function.
-# Usage: gw [branch-name]
+# Usage: gw [branch-name] | gw ls | gw rm <path>
 
 ''
   # Git Worktree wrapper - Create git worktree and cd into it
   # Usage: gw [branch-name]  (generates a random name if omitted)
+  #        gw ls             (list worktrees left on this machine, all repos)
+  #        gw rm <path>      (remove worktree + background nix store gc)
   gw() {
     # Helper: Generate a random branch name like "snappy-greeting-bachman"
     local _random_branch_name() {
@@ -27,12 +29,52 @@
       echo "''${a}-''${n}-''${s}"
     }
 
-    # Help flag
-    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-      echo "Usage: gw <branch-name>"
-      echo "       gw               (generates a random name)"
-      return 0
-    fi
+    # Subcommands. Note: "ls" and "rm" are reserved and cannot be used as
+    # branch names via gw.
+    case "$1" in
+      -h | --help)
+        echo "Usage: gw [branch-name]    Create worktree and cd into it (random name if omitted)"
+        echo "       gw ls               List worktrees left on this machine (all repos)"
+        echo "       gw rm <path> [...]  Remove worktree, then run nix store gc in background"
+        return 0
+        ;;
+      ls)
+        # List worktrees left on this machine, not just this repo's.
+        # Every direnv-entered worktree registers a nix-direnv gc-root
+        # symlink under /nix/var/nix/gcroots/auto pointing into its
+        # .direnv/, so those targets serve as a machine-wide index.
+        # Single readlink invocation over all roots — forking readlink per
+        # symlink takes ~5s with hundreds of roots.
+        local _gc_target _wt_dir
+        readlink /nix/var/nix/gcroots/auto/*(N@) 2>/dev/null | while IFS= read -r _gc_target; do
+          [[ "$_gc_target" == */.worktrees/*/.direnv/* ]] || continue
+          echo "''${_gc_target%/.direnv/*}"
+        done | sort -u | while IFS= read -r _wt_dir; do
+          if [[ -d "$_wt_dir" ]]; then
+            echo "$_wt_dir"
+          else
+            echo "$_wt_dir (removed, gc pending)"
+          fi
+        done
+        return 0
+        ;;
+      rm)
+        shift
+        if [[ $# -eq 0 ]]; then
+          echo "Usage: gw rm <worktree-path> [--force]" >&2
+          return 1
+        fi
+        # Removing the worktree alone leaves nix-direnv gc-roots behind
+        # (/nix/var/nix/gcroots/per-user/ -> .direnv/flake-profile-*), so
+        # pair it with a GC run. GC can take minutes, so it runs detached
+        # in the background. nix store gc only collects unrooted paths,
+        # keeping system generations intact for rollback.
+        git worktree remove "$@" || return 1
+        (nix store gc >/dev/null 2>&1 &)
+        echo "Worktree removed. nix store gc running in background." >&2
+        return 0
+        ;;
+    esac
 
     local branch_name="$1"
 
@@ -188,5 +230,11 @@
 
     _msg "$GREEN" "Worktree created: $worktree_dir"
     cd "$worktree_dir"
+
+    # Opportunistic cleanup: reclaim store space left behind by previously
+    # removed worktrees. Detached background run, so it never blocks the
+    # new worktree. Concurrent GC is safe — live builds and devshells are
+    # protected by temp roots.
+    (nix store gc >/dev/null 2>&1 &)
   }
 ''


### PR DESCRIPTION
## 요약

`gw`를 서브커맨드 스타일로 확장하고, worktree 생성/삭제 시 백그라운드 `nix store gc`를 페어로 실행합니다. worktree만 지우면 nix-direnv gc-root(`/nix/var/nix/gcroots/auto/` → `.direnv/flake-profile-*`)가 남아 store 공간이 회수되지 않는 문제를 해결합니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 테스트 추가/수정

- `gw ls`: 이 머신에 남아있는 worktree를 레포와 무관하게 전체 나열 (nix-direnv gc-root를 머신 전체 인덱스로 사용, 삭제된 항목은 `(removed, gc pending)` 표시). 심링크 전체를 단일 `readlink` 호출로 처리해 5.1s → 0.065s.
- `gw rm <path> [--force]`: `git worktree remove` 후 백그라운드로 `nix store gc` 실행.
- `gw [branch-name]`: 생성 완료 후에도 백그라운드 `nix store gc`로 기회적 정리.
- gc는 `nix store gc` 사용 — 시스템 세대를 보존해 darwin 롤백 가능. `ls`/`rm`은 예약어가 되어 해당 이름의 브랜치는 gw로 생성 불가(help에 명시).
- `tests/unit/gw-subcommands-test.nix` 신규: 서브커맨드 존재, gc 호출 2곳, `nix-collect-garbage -d` 미사용 검증.

## 테스트 계획

- [x] 단위 테스트 통과: `unit-gw-subcommands` + 기존 gw 테스트 4종 (TDD, RED→GREEN 확인)
- [x] 로컬에서 수동 테스트 완료: 스크래치 git 레포에서 생성/ls/rm/help 전 경로 실행, nix 스텁 로그로 gc 호출 확인, 실제 머신 gc-root 데이터로 `gw ls` 39개 worktree 출력 확인
- [x] nixfmt 통과 (pre-commit 훅 통과)

## 추가 정보

배경: worktree 진입이 느린 원인 조사에서 파생된 작업입니다. 진입 지연 자체는 nix-direnv per-worktree 캐시의 첫 부트스트랩 비용(웜 ~3.5s / lock 변경 직후 ~25s)이고, store 재사용은 정상 동작 중임을 확인했습니다.