### PR TITLE
feat(darwin): auto login on boot so SSH sessions skip keychain prompt

### DIFF
--- a/users/shared/darwin/default.nix
+++ b/users/shared/darwin/default.nix
@@ -114,6 +114,30 @@ in
   system.defaults.loginwindow = {
     SHOWFULLNAME = false; # Compact login prompt
     DisableConsoleAccess = false; # Maintain console access
+
+    # Auto login on boot so the GUI session comes up unattended.
+    #
+    # macOS unlocks the login keychain as part of a GUI login. Without one, a
+    # headless reboot leaves the keychain locked and every incoming SSH session
+    # hits the unlock prompt in zsh/keychain-unlock.nix. Auto login restores the
+    # normal unlock path instead of stashing the keychain password anywhere.
+    #
+    # nix-darwin only writes this plist key; it never touches /etc/kcpassword,
+    # which is what actually makes auto login happen. That file holds the login
+    # password, so it cannot live in this repo -- create it once with:
+    #
+    #   sudo sysadminctl -autologin set -userName <user>   # prompts for password
+    #
+    # Omit -password so the password is never in shell history. Verify with
+    # `sysadminctl -autologin status`. Without that file this setting is inert
+    # (the machine still shows the login window).
+    #
+    # Caveat: the GUI login only unlocks the keychain when the account password
+    # and the login keychain password match. They diverge if the account
+    # password was changed in a way that left the old keychain behind (macOS
+    # renames it to login_renamed_N.keychain-db). Re-sync with
+    # `security set-keychain-password ~/Library/Keychains/login.keychain-db`.
+    autoLoginUser = currentSystemUser;
   };
 
   # ===== System Integration Configuration =====

--- a/users/shared/programs/zsh/keychain-unlock.nix
+++ b/users/shared/programs/zsh/keychain-unlock.nix
@@ -4,6 +4,11 @@
 # login), so tools that read credentials from it (e.g. Claude Code) report
 # "Not logged in". This prompts once per session to unlock it.
 #
+# Normally this never fires: darwin/default.nix sets loginwindow.autoLoginUser,
+# so a reboot brings up a GUI session that unlocks the keychain the standard
+# way. This stays as the fallback for when that path is unavailable -- no
+# /etc/kcpassword yet, or the keychain was locked by hand.
+#
 # Guards:
 # - macOS only (caller passes isDarwin)
 # - SSH sessions only ($SSH_CONNECTION) -- never touches local GUI shells
@@ -11,6 +16,10 @@
 #   non-interactive calls like `ssh host cmd`, scp, or rsync on a prompt
 # - already-unlocked keychains are skipped silently (show-keychain-info
 #   succeeds only when unlocked), so re-sourcing never re-prompts
+#
+# On success the keychain timeout is cleared (set-keychain-settings with no -t)
+# so it stays unlocked for the rest of the boot instead of relocking mid-session
+# and prompting again.
 
 { isDarwin, lib }:
 
@@ -18,7 +27,13 @@ lib.optionalString isDarwin ''
   if [[ -n "''${SSH_CONNECTION:-}" ]] && [[ -o interactive ]]; then
     if ! security show-keychain-info ~/Library/Keychains/login.keychain-db &>/dev/null; then
       echo "🔐 SSH session: login keychain is locked, unlocking..." >&2
-      security unlock-keychain ~/Library/Keychains/login.keychain-db
+      if security unlock-keychain ~/Library/Keychains/login.keychain-db; then
+        # Drop the inactivity timeout so later sessions reuse this unlock.
+        security set-keychain-settings ~/Library/Keychains/login.keychain-db
+      else
+        echo "⚠️  Keychain unlock failed -- keychain-backed logins (e.g. Claude Code) will fail." >&2
+        echo "   Retry with: security unlock-keychain ~/Library/Keychains/login.keychain-db" >&2
+      fi
     fi
   fi
 ''


### PR DESCRIPTION
## 요약

헤드리스 재부팅 후 SSH 접속마다 login keychain unlock 프롬프트가 뜨는 문제를 해결합니다.

macOS는 GUI 로그인 과정에서 login keychain을 열어줍니다. GUI 로그인이 없는 헤드리스 재부팅에서는 아무도 열어주지 않아, 들어오는 SSH 세션마다 `zsh/keychain-unlock.nix`의 프롬프트를 만나게 됩니다.

`loginwindow.autoLoginUser`를 설정해 GUI 세션이 무인으로 올라오게 하고, keychain을 정상 경로로 열립니다. keychain 비밀번호를 리포지토리나 별도 파일에 저장하지 않습니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 버그 수정
- [x] 설정 변경

**`users/shared/darwin/default.nix`**
- `loginwindow.autoLoginUser = currentSystemUser` 추가

**`users/shared/programs/zsh/keychain-unlock.nix`** — SSH 폴백 경로의 버그 2건 수정 (자동 로그인이 불가할 때만 동작)
- unlock 실패가 조용히 넘어가던 문제: 사용자는 열렸다고 생각하지만 keychain 기반 로그인은 계속 실패했습니다. 실패 시 경고와 재시도 명령을 출력합니다.
- unlock 성공 후 inactivity timeout이 남아 세션 중간에 재잠금되어 다시 묻던 문제: `set-keychain-settings`로 해제합니다. `-t`를 주면 비대화형 세션에서 "User interaction is not allowed"로 실패하므로 의도적으로 생략했습니다.

## 테스트 계획

- [x] `make format` 통과 (0 changed)
- [x] `make test` 통과
- [x] `make build` 통과 (`nix build .#darwinConfigurations.kakaostyle-jito.system`)
- [x] `make switch` 적용 확인 — `defaults read /Library/Preferences/com.apple.loginwindow autoLoginUser` → `jito.hello`
- [x] 생성된 zshrc에 새 로직 반영 확인
- [ ] 재부팅 후 SSH 접속에서 프롬프트가 사라지는지 — 재부팅이 필요해 미검증

## 추가 정보

**적용에 수동 단계가 필요합니다.** nix-darwin은 plist 키만 쓰고 `/etc/kcpassword`는 만들지 않습니다(소스 전체에 해당 문자열 없음, `defaults write` 한 줄로 귀결). 그 파일이 없으면 이 설정은 무효이며 로그인 창이 그대로 뜹니다:

```bash
sudo sysadminctl -autologin set -userName <user>   # -password 생략 → 이력에 안 남음
```

**주의: 비밀번호 일치 조건.** GUI 로그인이 keychain을 열어주는 것은 계정 비밀번호와 keychain 비밀번호가 같을 때뿐입니다. kcpassword 자체가 keychain을 여는 것이 아닙니다. 어긋나면 자동 로그인이 켜져도 keychain은 잠긴 채 남습니다. 코드 주석에 복구법(`security set-keychain-password`)을 남겨뒀습니다.

**보안 트레이드오프.** `/etc/kcpassword`는 고정 11바이트 키 XOR 난독화로, 파일 접근 시 로그인 비밀번호가 평문 복구됩니다. FileVault가 꺼져 있어 디스크 물리 탈거 시 방어선이 없고, 부팅 후 화면이 잠금 없이 열립니다. 실질적 방어선은 물리적 접근 통제입니다. 이 트레이드오프를 인지하고 선택했습니다.

검토했으나 탈락한 대안: `fdesetup authrestart`(디스크 언락이지 keychain 언락이 아님 — Apple DTS 확인), CI 정석인 전용 keychain 분리(Claude Code에 keychain 경로 지정 옵션 없음), Touch ID 기반 unlock(`unlock-keychain`이 비밀번호만 지원, 공개 API 부재).

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함 (코드 내 주석)
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함 (없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic macOS login for the configured system user.
  * Added automatic SSH-session keychain unlocking for interactive macOS shells.

* **Bug Fixes**
  * Keychain unlocking now runs only when needed and remains active for the rest of the boot session.
  * Improved diagnostics and recovery guidance when unlocking fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->