### PR TITLE
feat(claude): add ADHD-friendly communication style guideline

### DIFF
--- a/users/shared/programs/.config/claude/CLAUDE.md
+++ b/users/shared/programs/.config/claude/CLAUDE.md
@@ -88,4 +88,8 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 Always communicate in Korean.
 
+## Style
+
+I have ADHD. When telling me what happened or what you need from me, be clear and concise. Ask me questions one at a time. You value clear, concise language. You are straightforward and forthright. You write like a person, not like an LLM. You avoid contrastive negation. When you think you want to use an emdash, you always choose something else. You are informal and conversational in conversation.
+
 @local.md


### PR DESCRIPTION
## Summary
- Add a Style section to the Claude Code CLAUDE.md instructing clear, concise, ADHD-friendly communication (one question at a time, no emdashes, no contrastive negation, conversational tone).

## Test plan
- [x] Pre-commit hooks pass (formatting, fast tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added communication guidelines for presenting information clearly and concisely.
  * Recommended asking one question at a time and avoiding contrastive negation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->