### PR TITLE
fix(ghostty): keep remote TERM on xterm-256color

### DIFF
--- a/tests/integration/ghostty-test.nix
+++ b/tests/integration/ghostty-test.nix
@@ -36,6 +36,9 @@ let
   # Helper function to check if a config line exists
   hasConfigLine = pattern: builtins.match ".*${pattern}.*" ghosttyConfigContent != null;
 
+  # Helper function to check if a config line does not exist
+  lacksConfigLine = pattern: builtins.match ".*${pattern}.*" ghosttyConfigContent == null;
+
   # Helper function to check if multiple config lines exist (all must match)
   hasAllConfigLines = patterns: builtins.all hasConfigLine patterns;
 
@@ -99,10 +102,10 @@ let
       "Ghostty should have shell-integration enabled"
     )
 
-    (helpers.assertTest "ghostty-shell-integration-features"
-      (hasConfigLine "shell-integration-features.*=.*cursor,sudo,title")
-      "Ghostty should have shell-integration-features set to cursor,sudo,title"
-    )
+    (helpers.assertTest "ghostty-shell-integration-features" (
+      hasConfigLine "shell-integration-features.*=.*no-cursor,sudo,title,ssh-env"
+      && lacksConfigLine "ssh-terminfo"
+    ) "Ghostty should use ssh-env without ssh-terminfo so remote TERM stays xterm-256color")
 
     (helpers.assertTest "ghostty-terminal-type-xterm-256color" (hasConfigLine "term.*=.*xterm-256color")
       "Ghostty should report xterm-256color for every shell"

--- a/users/shared/programs/.config/ghostty/config
+++ b/users/shared/programs/.config/ghostty/config
@@ -18,7 +18,7 @@ window-padding-y = 10
 
 # Shell Integration
 shell-integration = true
-shell-integration-features = no-cursor,sudo,title,ssh-env,ssh-terminfo
+shell-integration-features = no-cursor,sudo,title,ssh-env
 
 # Option key as Alt for terminal keybindings (opt+t for Claude Code think toggle)
 macos-option-as-alt=left

--- a/users/shared/programs/ssh.nix
+++ b/users/shared/programs/ssh.nix
@@ -2,7 +2,7 @@
 #
 # Manages ~/.ssh/config via home-manager so connection keepalive applies
 # uniformly to every host (including invocations through Ghostty's
-# ssh-terminfo wrapper). The OrbStack include is preserved at the top.
+# ssh-env wrapper). The OrbStack include is preserved at the top.
 
 {
   config,

--- a/users/shared/programs/zsh/functions.nix
+++ b/users/shared/programs/zsh/functions.nix
@@ -6,9 +6,9 @@
 # - assh: autossh alias for long-lived connections
 # - setup_ssh_agent_for_gui(): SSH agent for GUI apps
 #
-# Note: ssh() is intentionally NOT overridden. Ghostty's shell-integration
-# installs its own ssh() to upload xterm-ghostty terminfo to remote hosts;
-# wrapping ssh here would shadow that. Keepalive options live in ~/.ssh/config
+# Note: ssh() is intentionally NOT overridden. Ghostty's shell integration
+# installs its own ssh() to use xterm-256color for remote hosts; wrapping ssh
+# here would shadow that. Keepalive options live in ~/.ssh/config
 # (programs.ssh module).
 
 ''
@@ -36,7 +36,7 @@
 
   # autossh for long-lived connections that need auto-reconnect.
   # Plain `ssh` goes through Ghostty's shell-integration wrapper which
-  # uploads ghostty terminfo to the remote — don't shadow it.
+  # uses xterm-256color on the remote — don't shadow it.
   alias assh='AUTOSSH_POLL=60 AUTOSSH_FIRST_POLL=30 autossh -M 0 -o ServerAliveInterval=30 -o ServerAliveCountMax=3'
 
   # SSH agent setup for GUI applications


### PR DESCRIPTION
## 요약

Ghostty SSH 접속에서 TERM이 xterm-ghostty로 되돌아가 tmux가 실패하는 문제를 수정합니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정
- [x] 설정 변경

- ssh-terminfo 기능을 제거하고 ssh-env만 유지
- 원격 TERM이 xterm-256color로 유지되는 회귀 테스트 추가
- 관련 SSH 주석을 실제 동작에 맞게 수정

## 테스트 계획

- [x] Ghostty 임시 XDG 설정 파싱 확인
- [x] Ghostty 통합 테스트 derivation 빌드
- [x] make switch 통과
- [x] 활성 Ghostty 설정에서 term=xterm-256color 및 no-ssh-terminfo 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 주석을 업데이트함
- [x] 새로운 의존성 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Ghostty shell integration to use `no-cursor`, `sudo`, `title`, and `ssh-env`.
* **Bug Fixes**
  * Prevented the unsupported `ssh-terminfo` feature from being enabled.
  * Updated SSH and shell integration guidance to reflect Ghostty’s remote terminal behavior.
* **Documentation**
  * Clarified SSH integration and terminal compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->