### PR TITLE
fix(claude): sync CLAUDE.md on switch

### DIFF
--- a/tests/unit/claude-test.nix
+++ b/tests/unit/claude-test.nix
@@ -14,6 +14,7 @@ let
 
   # Path to Claude configuration
   claudeDir = ../../users/shared/programs/.config/claude;
+  claudeCodeModule = builtins.readFile ../../users/shared/programs/claude-code.nix;
 
   # Helper to safely read and parse JSON
   readJson =
@@ -53,6 +54,12 @@ let
     config-dir-exists =
       helpers.assertTest "config-dir-exists" (builtins.pathExists claudeDir)
         "Claude configuration directory does not exist";
+
+    # CLAUDE.md is the declarative instruction source and must refresh on every switch.
+    claude-md-refreshes-on-switch =
+      helpers.assertTest "claude-md-refreshes-on-switch"
+        (lib.hasInfix "run cp \${src}/CLAUDE.md ~/.claude/CLAUDE.md" claudeCodeModule)
+        "CLAUDE.md should overwrite the existing ~/.claude/CLAUDE.md during activation";
   };
 
 in

--- a/users/shared/programs/claude-code.nix
+++ b/users/shared/programs/claude-code.nix
@@ -5,12 +5,11 @@
 # NOTE: commands, agents, skills, and hooks are now managed via external plugin:
 # https://github.com/baleen37/claude-plugins
 #
-# These config files (CLAUDE.md, settings.json, statusline.sh, local.md) are
-# copied as real, writable files rather than read-only store symlinks, because
-# Claude Code mutates them at runtime (e.g. feedbackSurveyState, plugin toggles,
-# /remember). The copy only runs when the file is absent, so local edits and
-# runtime writes are preserved across rebuilds. To pull dotfiles updates into an
-# existing file, delete it and re-run switch.
+# CLAUDE.md is copied on every switch so its declarative guidance stays in sync.
+# The remaining files are real, writable files rather than read-only store
+# symlinks, because Claude Code mutates them at runtime (e.g.
+# feedbackSurveyState and plugin toggles). They are only copied when absent so
+# local edits and runtime writes are preserved across rebuilds.
 
 { config, lib, ... }:
 
@@ -24,7 +23,9 @@ in
   config = lib.mkIf cfg.enable {
     home.activation.claudeConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       run mkdir -p ~/.claude
-      for f in CLAUDE.md local.md settings.json statusline.sh setup-worktree.sh; do
+      run cp ${src}/CLAUDE.md ~/.claude/CLAUDE.md
+      run chmod u+w ~/.claude/CLAUDE.md
+      for f in local.md settings.json statusline.sh setup-worktree.sh; do
         if [ ! -f ~/.claude/"$f" ]; then
           run cp ${src}/"$f" ~/.claude/"$f"
           run chmod u+w ~/.claude/"$f"


### PR DESCRIPTION
## 요약

make switch가 이미 존재하는 ~/.claude/CLAUDE.md도 소스와 동기화하도록 수정합니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정

- CLAUDE.md만 매 Home Manager 활성화 시 덮어쓰기
- 런타임 변경 대상인 나머지 Claude 설정 파일은 기존의 조건부 복사 유지
- CLAUDE.md 갱신 회귀 테스트 추가

## 테스트 계획

- [x] nix build --impure .#checks.aarch64-darwin.unit-claude --no-link --print-build-logs
- [ ] make switch: Homebrew의 기존 KakaoTalk/Magnet 설치 실패로 최종 완료하지 못함

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 변경사항이 기존 기능을 손상시키지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Code guidance is now refreshed automatically on every configuration switch, ensuring the latest managed content is applied.
  * Other Claude Code configuration files continue to preserve local edits and runtime changes.
* **Tests**
  * Added coverage verifying that the guidance file is copied to the expected Claude Code configuration location during activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->