### PR TITLE
fix(ghostty): remove TERMINFO_DIRS override and use xterm-256color

### DIFF
--- a/tests/integration/ghostty-test.nix
+++ b/tests/integration/ghostty-test.nix
@@ -57,6 +57,11 @@ let
       && builtins.hasAttr "packages" ghosttyConfig.home
     ) "ghostty config should have home.packages")
 
+    (helpers.assertTest "ghostty-does-not-override-terminfo-dirs" (
+      ghosttyConfigUsable
+      && !(ghosttyConfig.home.sessionVariables or { } ? TERMINFO_DIRS)
+    ) "Ghostty should use the standard terminal database lookup path")
+
     # Test that home.file exists for config symlink
     (helpers.assertTest "ghostty-has-file-config" (
       ghosttyConfigUsable

--- a/tests/integration/ghostty-test.nix
+++ b/tests/integration/ghostty-test.nix
@@ -58,8 +58,7 @@ let
     ) "ghostty config should have home.packages")
 
     (helpers.assertTest "ghostty-does-not-override-terminfo-dirs" (
-      ghosttyConfigUsable
-      && !(ghosttyConfig.home.sessionVariables or { } ? TERMINFO_DIRS)
+      ghosttyConfigUsable && !(ghosttyConfig.home.sessionVariables or { } ? TERMINFO_DIRS)
     ) "Ghostty should use the standard terminal database lookup path")
 
     # Test that home.file exists for config symlink

--- a/users/shared/programs/ghostty.nix
+++ b/users/shared/programs/ghostty.nix
@@ -19,9 +19,7 @@ in
   config = lib.mkIf cfg.enable {
     # Install Ghostty from the official macOS binary package. Ghostty is configured
     # to use the standard xterm-256color terminal type.
-    home.packages =
-      with pkgs;
-      lib.optional isDarwin ghostty-bin;
+    home.packages = with pkgs; lib.optional isDarwin ghostty-bin;
 
     # Symlink Ghostty configuration
     # Pattern: XDG-compliant location (destination: ~/.config/ghostty/)

--- a/users/shared/programs/ghostty.nix
+++ b/users/shared/programs/ghostty.nix
@@ -17,28 +17,11 @@ in
   options.modules.programs.ghostty.enable = lib.mkEnableOption "Ghostty terminal configuration";
 
   config = lib.mkIf cfg.enable {
-    # Install Ghostty package
-    # Note: Using ghostty-bin (official binary) instead of ghostty (source build)
-    # because ghostty source build doesn't support macOS in nixpkgs.
-    #
-    # ghostty.terminfo (Linux) / ghostty-bin terminfo output (Darwin) is installed
-    # on all platforms so that tmux and other ncurses programs can resolve the
-    # xterm-ghostty TERM entry.  On Darwin, ghostty-bin already includes terminfo
-    # in its outputsToInstall; we also add ghostty.terminfo explicitly on Linux so
-    # that SSH sessions originating from Ghostty work correctly on remote hosts.
+    # Install Ghostty from the official macOS binary package. Ghostty is configured
+    # to use the standard xterm-256color terminal type.
     home.packages =
       with pkgs;
-      lib.optional isDarwin ghostty-bin ++ lib.optional (!isDarwin) ghostty.terminfo;
-
-    # Make xterm-ghostty terminfo visible to ncurses-based programs (tmux, vim, etc.).
-    # ncurses searches only a fixed set of paths by default:
-    #   ~/.terminfo, /etc/terminfo, /lib/terminfo, /usr/share/terminfo
-    # ~/.nix-profile/share/terminfo/ (where Nix package terminfo outputs land) is NOT
-    # included unless TERMINFO_DIRS is set.  Without this, `tmux a` from Ghostty fails
-    # with "missing or unsuitable terminal: xterm-ghostty".
-    home.sessionVariables = {
-      TERMINFO_DIRS = "$HOME/.nix-profile/share/terminfo";
-    };
+      lib.optional isDarwin ghostty-bin;
 
     # Symlink Ghostty configuration
     # Pattern: XDG-compliant location (destination: ~/.config/ghostty/)


### PR DESCRIPTION
## Summary

Ghostty가 원격 TERM으로 xterm-256color를 사용하므로 TERMINFO_DIRS override가 불필요합니다. 표준 ncurses 터미널 데이터베이스 조회 경로를 사용하도록 정리했습니다.

## Changes

- Remove TERMINFO_DIRS session variable override
- Remove unnecessary ghostty.terminfo on Linux (xterm-256color is standard)
- Simplify package configuration to just ghostty-bin on macOS
- Add test to verify TERMINFO_DIRS is not overridden

## Test Plan

- [x] ghostty-does-not-override-terminfo-dirs test verifies TERMINFO_DIRS is not set
- [x] Existing ghostty configuration tests still pass
- [x] macOS Ghostty terminal works with xterm-256color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal compatibility by preventing Ghostty from overriding the standard terminal database lookup path.
  * Updated package installation behavior across platforms to avoid adding unnecessary terminal database files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->