### PR TITLE
test(tmux): cover agent status edge cases

### DIFF
--- a/docs/superpowers/plans/2026-07-29-tmux-agent-status-rendering.md
+++ b/docs/superpowers/plans/2026-07-29-tmux-agent-status-rendering.md
@@ -24,11 +24,13 @@
 ### Task 1: Add semantic agent status rendering and aggregation
 
 **Files:**
+
 - Create: `users/shared/programs/tmux-agent-status-summary.sh`
 - Modify: `users/shared/programs/tmux.nix`
 - Modify: `tests/integration/tmux-functionality-test.nix`
 
 **Interfaces:**
+
 - Consumes: `tmux list-panes -a -F '#{@agent_status}'`.
 - Produces: a compact summary string and window-list glyphs.
 

--- a/docs/superpowers/plans/2026-07-29-tmux-agent-status-rendering.md
+++ b/docs/superpowers/plans/2026-07-29-tmux-agent-status-rendering.md
@@ -1,0 +1,172 @@
+# tmux Agent Status Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render bstack `me` plugin agent state in tmux window labels and a server-wide `status-right` summary without Herdr.
+
+**Architecture:** A small Bash program counts pane-local `@agent_status` values by querying tmux once. Home Manager packages that program and references its immutable path from the existing pre-Continuum `status-right`; tmux formats map the same semantic option to glyphs in window labels.
+
+**Tech Stack:** Nix, Home Manager, Bash, tmux formats
+
+## Global Constraints
+
+- Herdr and its Nix input/package/configuration must not be referenced.
+- The only state input is pane-local `@agent_status`.
+- State glyphs are exactly `running=●`, `needs_input=▲`, `ready=○`, `error=✕`.
+- Summary order is exactly `●N ▲N ○N ✕N`, omitting zero-count and unknown states.
+- The existing OSC `pane_title` and window-name fallback must remain intact.
+- The one `status-right` assignment must remain before Continuum loads and must retain `%d/%m` and `%H:%M`.
+- The summary must not inspect transcripts, processes, pane contents, titles, or state files.
+- Follow strict RED→GREEN TDD and touch only tmux configuration and its tests.
+
+---
+
+### Task 1: Add semantic agent status rendering and aggregation
+
+**Files:**
+- Create: `users/shared/programs/tmux-agent-status-summary.sh`
+- Modify: `users/shared/programs/tmux.nix`
+- Modify: `tests/integration/tmux-functionality-test.nix`
+
+**Interfaces:**
+- Consumes: `tmux list-panes -a -F '#{@agent_status}'`.
+- Produces: a compact summary string and window-list glyphs.
+
+- [ ] **Step 1: Write failing behavior and configuration tests**
+
+In `tests/integration/tmux-functionality-test.nix`, add:
+
+```nix
+agentStatusSummarySource =
+  toString ../../users/shared/programs + "/tmux-agent-status-summary.sh";
+fakeAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
+  if [ "$1" = "list-panes" ]; then
+    printf '%s\n' running ready running needs_input error unknown ""
+    exit 0
+  fi
+  exit 1
+'';
+```
+
+Add a `pkgs.runCommand` test that runs the real source with
+`PATH=${fakeAgentStatusTmux}/bin` and asserts its stdout is exactly:
+
+```text
+●2 ▲1 ○1 ✕1
+```
+
+Add a second fake tmux that exits 1 and assert the script exits 0 with empty
+stdout. Add config assertions proving:
+
+- both window status formats contain `#{@agent_status}`;
+- both still contain `#{pane_title}` and the `#W` fallback;
+- generated `status-right` contains `tmux-agent-status-summary`, `%d/%m`, and
+  `%H:%M`;
+- generated config contains exactly one `set -g status-right`;
+- that line remains before the `tmuxplugin-continuum` marker.
+
+- [ ] **Step 2: Run focused checks and verify RED**
+
+Run the new summary/config checks with:
+
+```bash
+env USER="$(id -un)" nix build \
+  '.#checks.aarch64-darwin.integration-tmux-functionality-tmux-agent-status-summary' \
+  '.#checks.aarch64-darwin.integration-tmux-functionality-tmux-agent-status-window-format' \
+  --impure --accept-flake-config
+```
+
+Expected: FAIL because the summary source and agent-status formats do not
+exist. Confirm the failures name those missing behaviors.
+
+- [ ] **Step 3: Implement the summary program**
+
+Create `users/shared/programs/tmux-agent-status-summary.sh` with:
+
+```bash
+set -euo pipefail
+
+command -v tmux >/dev/null 2>&1 || exit 0
+states="$(tmux list-panes -a -F '#{@agent_status}' 2>/dev/null)" || exit 0
+
+running=0
+needs_input=0
+ready=0
+error=0
+
+while IFS= read -r state; do
+    case "$state" in
+        running) ((running += 1)) ;;
+        needs_input) ((needs_input += 1)) ;;
+        ready) ((ready += 1)) ;;
+        error) ((error += 1)) ;;
+    esac
+done <<<"$states"
+
+parts=()
+((running > 0)) && parts+=("●$running")
+((needs_input > 0)) && parts+=("▲$needs_input")
+((ready > 0)) && parts+=("○$ready")
+((error > 0)) && parts+=("✕$error")
+
+if ((${#parts[@]} > 0)); then
+    printf '%s\n' "${parts[*]}"
+fi
+```
+
+- [ ] **Step 4: Package and render the status**
+
+In `users/shared/programs/tmux.nix`, extend the existing `let` with:
+
+```nix
+agentStatusSummary = pkgs.writeShellApplication {
+  name = "tmux-agent-status-summary";
+  runtimeInputs = [ pkgs.tmux ];
+  text = builtins.readFile ./tmux-agent-status-summary.sh;
+};
+agentStatusGlyph = "#{?#{==:#{@agent_status},running},●,#{?#{==:#{@agent_status},needs_input},▲,#{?#{==:#{@agent_status},ready},○,#{?#{==:#{@agent_status},error},✕,}}}}";
+```
+
+Prepend this command to the existing Continuum `status-right` value:
+
+```tmux
+#(${agentStatusSummary}/bin/tmux-agent-status-summary)
+```
+
+Keep the date/time styling in the same assignment. Insert
+`${agentStatusGlyph}` immediately after `#I` in both window status formats.
+Do not change their existing `pane_title` and `#W` conditional.
+
+- [ ] **Step 5: Run focused verification and verify GREEN**
+
+Run:
+
+```bash
+nix fmt
+env USER="$(id -un)" nix build \
+  '.#checks.aarch64-darwin.integration-tmux-functionality-tmux-agent-status-summary' \
+  '.#checks.aarch64-darwin.integration-tmux-functionality-tmux-agent-status-window-format' \
+  '.#checks.aarch64-darwin.integration-tmux-functionality-tmux-continuum-config-order' \
+  --impure --accept-flake-config
+```
+
+Expected: all derivations build and formatting produces no unrelated changes.
+
+- [ ] **Step 6: Run the full baseline-equivalent suite**
+
+Run:
+
+```bash
+env USER="$(id -un)" make test
+```
+
+Expected: validation completes successfully with exit code 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add users/shared/programs/tmux-agent-status-summary.sh \
+  users/shared/programs/tmux.nix \
+  tests/integration/tmux-functionality-test.nix
+git commit -m "feat(tmux): show coding agent status"
+```

--- a/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
@@ -18,13 +18,13 @@ bstack `me` 플러그인이 tmux pane option으로 기록한 agent 상태를 Her
 dotfiles는 pane-local tmux user option `@agent_status`만 소비한다. 허용 값은 다음
 다섯 가지다.
 
-| 값 | 표시 | 의미 |
-| --- | --- | --- |
-| `running` | `●` | agent가 turn을 처리 중 |
-| `needs_input` | `▲` | 권한 승인이나 사용자 입력 대기 |
-| `ready` | `○` | 다음 입력을 받을 수 있음 |
-| `error` | `✕` | provider가 보고한 실패 |
-| 값 없음 | 표시 없음 | agent 상태를 알 수 없음 |
+| 값            | 표시      | 의미                           |
+| ------------- | --------- | ------------------------------ |
+| `running`     | `●`       | agent가 turn을 처리 중         |
+| `needs_input` | `▲`       | 권한 승인이나 사용자 입력 대기 |
+| `ready`       | `○`       | 다음 입력을 받을 수 있음       |
+| `error`       | `✕`       | provider가 보고한 실패         |
+| 값 없음       | 표시 없음 | agent 상태를 알 수 없음        |
 
 이번 bstack 공용 hook은 Claude와 Codex가 함께 제공하는 이벤트만 사용하므로
 `error`를 아직 쓰지 않는다. dotfiles는 이후 provider adapter가 `error`를

--- a/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
@@ -54,7 +54,7 @@ Home Manager는 스크립트를 `pkgs.writeShellApplication`으로 패키징한�
 
 요약 command는 Continuum plugin의 `extraConfig` 안 기존 `status-right` 앞부분에
 추가한다. 이 설정은 Continuum이 로드되기 전에 존재해야 하며, 이후 Continuum이
-자신의 saver 정보를 append하는 기존 동작을 유지한다.
+기존 `status-right`를 확장하는 동작을 유지한다.
 
 ## 저장소 경계
 

--- a/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-29-tmux-agent-status-rendering-design.md
@@ -1,0 +1,82 @@
+# tmux Agent Status Rendering 설계
+
+## 목표
+
+bstack `me` 플러그인이 tmux pane option으로 기록한 agent 상태를 Herdr 없이
+기존 tmux UI에 표시한다.
+
+성공 조건:
+
+- 현재 window 목록에 agent 상태 glyph가 보인다.
+- `status-right`에 tmux server 전체의 상태별 agent 수가 보인다.
+- 기존 OSC 2 `pane_title` 표시는 상태가 없을 때 fallback으로 유지된다.
+- Continuum이 추가하는 `status-right` 내용과 기존 날짜/시간 표시가 유지된다.
+- `me` 플러그인이 없거나 agent가 tmux 밖에서 실행돼도 tmux는 정상 동작한다.
+
+## 외부 인터페이스
+
+dotfiles는 pane-local tmux user option `@agent_status`만 소비한다. 허용 값은 다음
+다섯 가지다.
+
+| 값 | 표시 | 의미 |
+| --- | --- | --- |
+| `running` | `●` | agent가 turn을 처리 중 |
+| `needs_input` | `▲` | 권한 승인이나 사용자 입력 대기 |
+| `ready` | `○` | 다음 입력을 받을 수 있음 |
+| `error` | `✕` | provider가 보고한 실패 |
+| 값 없음 | 표시 없음 | agent 상태를 알 수 없음 |
+
+이번 bstack 공용 hook은 Claude와 Codex가 함께 제공하는 이벤트만 사용하므로
+`error`를 아직 쓰지 않는다. dotfiles는 이후 provider adapter가 `error`를
+기록해도 설정 변경 없이 표시할 수 있게 렌더링만 지원한다.
+
+## 구성
+
+### 상태별 glyph
+
+`users/shared/programs/tmux.nix`에서 semantic state를 glyph로 바꾸는 tmux format을
+한 번 정의하고 현재/비현재 window format에서 재사용한다. 상태가 없으면 기존
+`pane_title != host` 조건과 window name fallback을 그대로 사용한다.
+
+### 전체 요약
+
+`users/shared/programs/tmux-agent-status-summary.sh`는
+`tmux list-panes -a -F '#{@agent_status}'` 결과만 읽는다. 알려진 상태의 개수를
+세고 0보다 큰 항목만 고정 순서 `●N ▲N ○N ✕N`으로 출력한다.
+
+스크립트는 transcript, process tree, `capture-pane`, Herdr 파일을 읽지 않는다.
+tmux server가 없거나 명령이 실패하면 빈 문자열과 성공 exit code를 반환한다.
+
+Home Manager는 스크립트를 `pkgs.writeShellApplication`으로 패키징한다. tmux
+설정은 store의 절대 실행 경로를 사용하므로 login shell PATH에 의존하지 않는다.
+
+### status-right 순서
+
+요약 command는 Continuum plugin의 `extraConfig` 안 기존 `status-right` 앞부분에
+추가한다. 이 설정은 Continuum이 로드되기 전에 존재해야 하며, 이후 Continuum이
+자신의 saver 정보를 append하는 기존 동작을 유지한다.
+
+## 저장소 경계
+
+- bstack `plugins/me`: lifecycle event를 `@agent_status`로 변환하고 pane option을
+  설정하거나 해제한다.
+- dotfiles: semantic state를 tmux UI로 렌더링하고 전체 개수를 집계한다.
+- Herdr: 의존하지 않으며 이 기능의 source of truth도 아니다.
+
+## 오류 처리
+
+- option 값이 없거나 알려지지 않았으면 glyph와 집계에서 제외한다.
+- tmux server 조회 실패는 status bar를 깨뜨리지 않고 빈 요약으로 끝낸다.
+- `SessionEnd`가 SIGKILL 등으로 누락되면 stale option이 남을 수 있다. 이번
+  최소 범위에서는 다음 lifecycle event나 pane 종료가 이를 정리한다.
+- prompt, cwd, assistant message 같은 외부 문자열은 status format에 넣지 않는다.
+
+## 검증
+
+- 실제 summary script를 fake tmux command와 함께 실행해 상태별 집계, 빈 상태,
+  조회 실패 동작을 검증한다.
+- 생성된 tmux 설정에서 window format이 `@agent_status`를 우선하고 기존
+  `pane_title` fallback을 보존하는지 검증한다.
+- 생성된 설정에서 agent summary가 Continuum load보다 먼저 설정되고 날짜/시간
+  표시가 유지되는지 검증한다.
+- focused integration checks, `make test`, formatter를 실행한다.

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -57,9 +57,17 @@ let
   generatedTmuxConfig = homeConfig.config.xdg.configFile."tmux/tmux.conf".text;
   generatedTmuxConfigFile = pkgs.writeText "tmux.conf" generatedTmuxConfig;
   agentStatusSummarySource = toString ../../users/shared/programs + "/tmux-agent-status-summary.sh";
+  expectedAgentStatusGlyph = "#{?#{==:#{@agent_status},running},●,#{?#{==:#{@agent_status},needs_input},▲,#{?#{==:#{@agent_status},ready},○,#{?#{==:#{@agent_status},error},✕,}}}}";
   fakeAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
     if [ "$1" = "list-panes" ]; then
       printf '%s\n' running ready running needs_input error unknown ""
+      exit 0
+    fi
+    exit 1
+  '';
+  emptyAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
+    if [ "$1" = "list-panes" ]; then
+      printf '%s\n' "" unknown ""
       exit 0
     fi
     exit 1
@@ -122,7 +130,7 @@ in
   ) "tmux continuum should restore saved sessions automatically";
 
   tmux-continuum-config-order = pkgs.runCommand "tmux-continuum-config-order" { } ''
-    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | cut -d: -f1)"
+    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | ${pkgs.coreutils}/bin/tail -n 1 | cut -d: -f1)"
     restore_line="$(${pkgs.gnugrep}/bin/grep -nF "set -g @continuum-restore 'on'" ${generatedTmuxConfigFile} | cut -d: -f1)"
     status_right_line="$(${pkgs.gnugrep}/bin/grep -nE '^set -g status-right ' ${generatedTmuxConfigFile} | cut -d: -f1)"
 
@@ -141,7 +149,13 @@ in
     output="$(PATH=${fakeAgentStatusTmux}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
     test "$output" = '●2 ▲1 ○1 ✕1'
 
+    output="$(PATH=${emptyAgentStatusTmux}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
+    test -z "$output"
+
     output="$(PATH=${failingAgentStatusTmux}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
+    test -z "$output"
+
+    output="$(PATH=${pkgs.coreutils}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
     test -z "$output"
 
     touch "$out"
@@ -150,11 +164,11 @@ in
   tmux-agent-status-window-format = pkgs.runCommand "tmux-agent-status-window-format" { } ''
     current_format="$(${pkgs.gnugrep}/bin/grep -F "window-status-current-format" ${generatedTmuxConfigFile})"
     inactive_format="$(${pkgs.gnugrep}/bin/grep -F "window-status-format" ${generatedTmuxConfigFile})"
-    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | cut -d: -f1)"
+    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | ${pkgs.coreutils}/bin/tail -n 1 | cut -d: -f1)"
     status_right_line="$(${pkgs.gnugrep}/bin/grep -nE '^set -g status-right ' ${generatedTmuxConfigFile} | cut -d: -f1)"
 
-    printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#{@agent_status}'
-    printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#{@agent_status}'
+    printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#I${expectedAgentStatusGlyph}'
+    printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#I${expectedAgentStatusGlyph}'
     printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#{pane_title}'
     printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#{pane_title}'
     printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#W'
@@ -164,6 +178,29 @@ in
     ${pkgs.gnugrep}/bin/grep -F '%H:%M' ${generatedTmuxConfigFile}
     test "$(${pkgs.gnugrep}/bin/grep -cE '^set -g status-right ' ${generatedTmuxConfigFile})" -eq 1
     test "$status_right_line" -lt "$continuum_load_line"
+
+    export HOME="$TMPDIR"
+    export LC_ALL=en_US.UTF-8
+    export TMUX_TMPDIR="$TMPDIR"
+    tmux_test() {
+      ${pkgs.tmux}/bin/tmux -f /dev/null -L agent-status-test "$@"
+    }
+    trap 'tmux_test kill-server 2>/dev/null || true' EXIT
+    tmux_test new-session -d -s agent-status-test '${pkgs.coreutils}/bin/sleep 60'
+    pane_id="$(tmux_test display-message -p '#{pane_id}')"
+    agent_status_glyph='${expectedAgentStatusGlyph}'
+
+    for mapping in running:● needs_input:▲ ready:○ error:✕ unknown:; do
+      state="''${mapping%%:*}"
+      expected="''${mapping#*:}"
+      tmux_test set-option -p -t "$pane_id" @agent_status "$state"
+      actual="$(tmux_test display-message -p -t "$pane_id" "$agent_status_glyph")"
+      test "$actual" = "$expected"
+    done
+
+    tmux_test set-option -pu -t "$pane_id" @agent_status
+    actual="$(tmux_test display-message -p -t "$pane_id" "$agent_status_glyph")"
+    test -z "$actual"
 
     touch "$out"
   '';

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -56,7 +56,7 @@ let
   };
   generatedTmuxConfig = homeConfig.config.xdg.configFile."tmux/tmux.conf".text;
   generatedTmuxConfigFile = pkgs.writeText "tmux.conf" generatedTmuxConfig;
-  agentStatusSummarySource = toString ../../users/shared/programs + "/tmux-agent-status-summary.sh";
+  agentStatusSummarySource = ../../users/shared/programs/tmux-agent-status-summary.sh;
   expectedAgentStatusGlyph = "#{?#{==:#{@agent_status},running},●,#{?#{==:#{@agent_status},needs_input},▲,#{?#{==:#{@agent_status},ready},○,#{?#{==:#{@agent_status},error},✕,}}}}";
   fakeAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
     if [ "$1" = "list-panes" ]; then

--- a/tests/integration/tmux-functionality-test.nix
+++ b/tests/integration/tmux-functionality-test.nix
@@ -56,6 +56,17 @@ let
   };
   generatedTmuxConfig = homeConfig.config.xdg.configFile."tmux/tmux.conf".text;
   generatedTmuxConfigFile = pkgs.writeText "tmux.conf" generatedTmuxConfig;
+  agentStatusSummarySource = toString ../../users/shared/programs + "/tmux-agent-status-summary.sh";
+  fakeAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
+    if [ "$1" = "list-panes" ]; then
+      printf '%s\n' running ready running needs_input error unknown ""
+      exit 0
+    fi
+    exit 1
+  '';
+  failingAgentStatusTmux = pkgs.writeShellScriptBin "tmux" ''
+    exit 1
+  '';
 
   # Helper function to check if config contains a string
   hasConfigString = str: pluginHelpers.hasConfigString tmuxConfig.extraConfig str;
@@ -111,17 +122,48 @@ in
   ) "tmux continuum should restore saved sessions automatically";
 
   tmux-continuum-config-order = pkgs.runCommand "tmux-continuum-config-order" { } ''
-    continuum_line="$(${pkgs.gnugrep}/bin/grep -nF 'tmuxplugin-continuum' ${generatedTmuxConfigFile} | ${pkgs.coreutils}/bin/tail -n 1 | cut -d: -f1)"
+    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | cut -d: -f1)"
     restore_line="$(${pkgs.gnugrep}/bin/grep -nF "set -g @continuum-restore 'on'" ${generatedTmuxConfigFile} | cut -d: -f1)"
-    status_right_line="$(${pkgs.gnugrep}/bin/grep -nF "set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M '" ${generatedTmuxConfigFile} | cut -d: -f1)"
+    status_right_line="$(${pkgs.gnugrep}/bin/grep -nE '^set -g status-right ' ${generatedTmuxConfigFile} | cut -d: -f1)"
 
-    echo "continuum-line=$continuum_line"
+    echo "continuum-load-line=$continuum_load_line"
     echo "continuum-restore-line=$restore_line"
     echo "status-right-line=$status_right_line"
     test "$(${pkgs.gnugrep}/bin/grep -cF "set -g @continuum-restore 'on'" ${generatedTmuxConfigFile})" -eq 1
-    test "$(${pkgs.gnugrep}/bin/grep -cF "set -g status-right " ${generatedTmuxConfigFile})" -eq 1
-    test "$restore_line" -lt "$continuum_line"
-    test "$status_right_line" -lt "$continuum_line"
+    test "$(${pkgs.gnugrep}/bin/grep -cE '^set -g status-right ' ${generatedTmuxConfigFile})" -eq 1
+    test "$restore_line" -lt "$continuum_load_line"
+    test "$status_right_line" -lt "$continuum_load_line"
+
+    touch "$out"
+  '';
+
+  tmux-agent-status-summary = pkgs.runCommand "tmux-agent-status-summary" { } ''
+    output="$(PATH=${fakeAgentStatusTmux}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
+    test "$output" = '●2 ▲1 ○1 ✕1'
+
+    output="$(PATH=${failingAgentStatusTmux}/bin ${pkgs.bash}/bin/bash ${agentStatusSummarySource})"
+    test -z "$output"
+
+    touch "$out"
+  '';
+
+  tmux-agent-status-window-format = pkgs.runCommand "tmux-agent-status-window-format" { } ''
+    current_format="$(${pkgs.gnugrep}/bin/grep -F "window-status-current-format" ${generatedTmuxConfigFile})"
+    inactive_format="$(${pkgs.gnugrep}/bin/grep -F "window-status-format" ${generatedTmuxConfigFile})"
+    continuum_load_line="$(${pkgs.gnugrep}/bin/grep -nF 'run-shell ' ${generatedTmuxConfigFile} | ${pkgs.gnugrep}/bin/grep -F 'tmuxplugin-continuum' | cut -d: -f1)"
+    status_right_line="$(${pkgs.gnugrep}/bin/grep -nE '^set -g status-right ' ${generatedTmuxConfigFile} | cut -d: -f1)"
+
+    printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#{@agent_status}'
+    printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#{@agent_status}'
+    printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#{pane_title}'
+    printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#{pane_title}'
+    printf '%s\n' "$current_format" | ${pkgs.gnugrep}/bin/grep -F '#W'
+    printf '%s\n' "$inactive_format" | ${pkgs.gnugrep}/bin/grep -F '#W'
+    ${pkgs.gnugrep}/bin/grep -F 'tmux-agent-status-summary' ${generatedTmuxConfigFile}
+    ${pkgs.gnugrep}/bin/grep -F '%d/%m' ${generatedTmuxConfigFile}
+    ${pkgs.gnugrep}/bin/grep -F '%H:%M' ${generatedTmuxConfigFile}
+    test "$(${pkgs.gnugrep}/bin/grep -cE '^set -g status-right ' ${generatedTmuxConfigFile})" -eq 1
+    test "$status_right_line" -lt "$continuum_load_line"
 
     touch "$out"
   '';

--- a/users/shared/programs/tmux-agent-status-summary.sh
+++ b/users/shared/programs/tmux-agent-status-summary.sh
@@ -1,0 +1,28 @@
+set -euo pipefail
+
+command -v tmux > /dev/null 2>&1 || exit 0
+states="$(tmux list-panes -a -F '#{@agent_status}' 2> /dev/null)" || exit 0
+
+running=0
+needs_input=0
+ready=0
+error=0
+
+while IFS= read -r state; do
+  case "$state" in
+    running) ((running += 1)) ;;
+    needs_input) ((needs_input += 1)) ;;
+    ready) ((ready += 1)) ;;
+    error) ((error += 1)) ;;
+  esac
+done <<< "$states"
+
+parts=()
+((running > 0)) && parts+=("●$running")
+((needs_input > 0)) && parts+=("▲$needs_input")
+((ready > 0)) && parts+=("○$ready")
+((error > 0)) && parts+=("✕$error")
+
+if ((${#parts[@]} > 0)); then
+  printf '%s\n' "${parts[*]}"
+fi

--- a/users/shared/programs/tmux.nix
+++ b/users/shared/programs/tmux.nix
@@ -38,6 +38,12 @@
 
 let
   cfg = config.modules.programs.tmux;
+  agentStatusSummary = pkgs.writeShellApplication {
+    name = "tmux-agent-status-summary";
+    runtimeInputs = [ pkgs.tmux ];
+    text = builtins.readFile ./tmux-agent-status-summary.sh;
+  };
+  agentStatusGlyph = "#{?#{==:#{@agent_status},running},●,#{?#{==:#{@agent_status},needs_input},▲,#{?#{==:#{@agent_status},ready},○,#{?#{==:#{@agent_status},error},✕,}}}}";
 in
 {
   options.modules.programs.tmux.enable = lib.mkEnableOption "Tmux multiplexer configuration";
@@ -58,7 +64,7 @@ in
           extraConfig = ''
             # Configure Continuum before it starts and extends status-right.
             set -g @continuum-restore 'on'
-            set -g status-right '#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M '
+            set -g status-right '#(${agentStatusSummary}/bin/tmux-agent-status-summary) #[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M '
           '';
         }
         vim-tmux-navigator
@@ -204,8 +210,8 @@ in
         # spinner = working, ✳ = waiting) when a program sets one via OSC 2;
         # falls back to the window name when the title is the default (#{host}).
         # Truncated to 30 chars to keep the window list readable.
-        setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour50]#F '
-        setw -g window-status-format ' #I#[fg=colour237]:#[fg=colour250]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour244]#F '
+        setw -g window-status-current-format ' #I${agentStatusGlyph}#[fg=colour250]:#[fg=colour255]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour50]#F '
+        setw -g window-status-format ' #I${agentStatusGlyph}#[fg=colour237]:#[fg=colour250]#{?#{!=:#{pane_title},#{host}},#{=/30/…:pane_title},#W}#[fg=colour244]#F '
 
         # ============================================================================
         # Misc


### PR DESCRIPTION
## 요약

tmux 창 목록과 status-right에서 코딩 agent 상태를 확인할 수 있게 합니다. Herdr 의존성은 없습니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

- pane-local @agent_status를 창 glyph로 렌더링
- 전체 pane의 running/needs_input/ready/error 개수를 status-right에 표시
- 기존 pane title fallback과 Continuum 설정 순서를 유지

## 테스트 계획

- [ ] `make lint` 통과
- [x] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

추가 검증: 세 tmux Nix check와 격리된 실제 tmux glyph 테스트 통과.

## 추가 정보

새 런타임 의존성은 tmux뿐이며 기존 패키지입니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tmux status indicators for agent activity, including running, input-needed, ready, and error states.
  * Displays aggregate agent counts in the tmux status bar.
  * Adds state glyphs to tmux window labels while preserving existing titles and time displays.
  * Gracefully hides indicators when no recognized agent status is available.

* **Documentation**
  * Added design and implementation documentation for the tmux agent-status display.

* **Tests**
  * Added integration coverage for status summaries, window glyphs, configuration ordering, and missing or failing tmux data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->