### PR TITLE
feat: add declarative herdr setup

### DIFF
--- a/docs/superpowers/plans/2026-07-28-herdr-setup.md
+++ b/docs/superpowers/plans/2026-07-28-herdr-setup.md
@@ -22,11 +22,13 @@
 ### Task 1: Declarative Herdr module
 
 **Files:**
+
 - Create: `tests/integration/herdr-test.nix`
 - Create: `users/shared/programs/herdr.nix`
 - Modify: `users/shared/home-manager.nix`
 
 **Interfaces:**
+
 - Consumes: `pkgs.herdr`, Home Manager's `home.packages` and `xdg.configFile` options.
 - Produces: `modules.programs.herdr.enable` and the managed `herdr/config.toml`.
 
@@ -63,6 +65,7 @@ let
 
   config = homeConfig.config;
   herdrConfig = config.xdg.configFile."herdr/config.toml".text;
+  parsedConfig = builtins.fromTOML herdrConfig;
   herdrConfigFile = pkgs.writeText "herdr-config.toml" herdrConfig;
 in
 {
@@ -71,10 +74,12 @@ in
   ) "Herdr should be installed through Home Manager";
 
   herdr-config-contains-tmux-bindings = helpers.assertTest "herdr-config-contains-tmux-bindings" (
-    lib.hasInfix ''prefix = "ctrl+a"'' herdrConfig
-    && lib.hasInfix ''detach = "prefix+d"'' herdrConfig
-    && lib.hasInfix ''split_vertical = "prefix+|"'' herdrConfig
-    && lib.hasInfix ''split_horizontal = "prefix+minus"'' herdrConfig
+    parsedConfig.keys == {
+      prefix = "ctrl+a";
+      detach = "prefix+d";
+      split_vertical = "prefix+|";
+      split_horizontal = "prefix+minus";
+    }
   ) "Herdr should use the selected tmux-compatible bindings";
 
   herdr-config-valid = pkgs.runCommand "herdr-config-valid" { } ''
@@ -92,7 +97,11 @@ Run:
 
 ```bash
 git add tests/integration/herdr-test.nix
-nix build '.#checks.aarch64-darwin.integration-herdr' --impure --accept-flake-config --show-trace
+nix build \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-package-installed' \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-config-contains-tmux-bindings' \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-config-valid' \
+  --impure --accept-flake-config --show-trace
 ```
 
 Staging the new test makes it visible to flake source filtering. Expected:
@@ -145,7 +154,11 @@ Run:
 
 ```bash
 nix fmt
-nix build '.#checks.aarch64-darwin.integration-herdr' --impure --accept-flake-config --show-trace
+nix build \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-package-installed' \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-config-contains-tmux-bindings' \
+  '.#checks.aarch64-darwin.integration-herdr-herdr-config-valid' \
+  --impure --accept-flake-config --show-trace
 git diff --check
 ```
 
@@ -162,10 +175,12 @@ git commit -m "feat(herdr): add tmux-compatible home-manager setup"
 ### Task 2: Build, apply, and migrate the current machine
 
 **Files:**
+
 - Verify only: `flake.nix`, `flake.lock`
 - Runtime target: `~/.config/herdr/config.toml`
 
 **Interfaces:**
+
 - Consumes: the Home Manager module from Task 1 and the `macbook-pro` nix-darwin configuration.
 - Produces: a Nix-managed `herdr` command on the current Mac with no Homebrew shadow copy.
 

--- a/docs/superpowers/plans/2026-07-28-herdr-setup.md
+++ b/docs/superpowers/plans/2026-07-28-herdr-setup.md
@@ -1,0 +1,235 @@
+# Herdr Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install Herdr through Home Manager, manage its minimal tmux-compatible configuration, and replace the older Homebrew binary on the current Mac.
+
+**Architecture:** A focused Home Manager module owns both `pkgs.herdr` and `~/.config/herdr/config.toml`. An integration test evaluates the real module and runs Herdr's own config validator; the machine migration applies the Nix configuration before removing the Homebrew formula.
+
+**Tech Stack:** Nix, Home Manager, nix-darwin, TOML, Herdr 0.7.5
+
+## Global Constraints
+
+- Use the pinned nixpkgs `pkgs.herdr`; do not add another flake input.
+- Manage Herdr through `modules.programs.herdr.enable`.
+- Set `Ctrl-a` as prefix, `prefix+d` as detach, and `prefix+|` / `prefix+minus` as pane splits.
+- Keep all other Herdr defaults unchanged.
+- Do not delete runtime state under `~/.config/herdr/`.
+- Do not stop a running Herdr server because that would terminate pane processes.
+
+---
+
+### Task 1: Declarative Herdr module
+
+**Files:**
+- Create: `tests/integration/herdr-test.nix`
+- Create: `users/shared/programs/herdr.nix`
+- Modify: `users/shared/home-manager.nix`
+
+**Interfaces:**
+- Consumes: `pkgs.herdr`, Home Manager's `home.packages` and `xdg.configFile` options.
+- Produces: `modules.programs.herdr.enable` and the managed `herdr/config.toml`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/integration/herdr-test.nix`:
+
+```nix
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  homeConfig = inputs.home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      ../../users/shared/programs/herdr.nix
+      {
+        modules.programs.herdr.enable = true;
+        home = {
+          username = "test";
+          homeDirectory = if pkgs.stdenv.isDarwin then "/Users/test" else "/home/test";
+          stateVersion = "24.11";
+        };
+      }
+    ];
+  };
+
+  config = homeConfig.config;
+  herdrConfig = config.xdg.configFile."herdr/config.toml".text;
+  herdrConfigFile = pkgs.writeText "herdr-config.toml" herdrConfig;
+in
+{
+  herdr-package-installed = helpers.assertTest "herdr-package-installed" (
+    builtins.elem pkgs.herdr config.home.packages
+  ) "Herdr should be installed through Home Manager";
+
+  herdr-config-contains-tmux-bindings = helpers.assertTest "herdr-config-contains-tmux-bindings" (
+    lib.hasInfix ''prefix = "ctrl+a"'' herdrConfig
+    && lib.hasInfix ''detach = "prefix+d"'' herdrConfig
+    && lib.hasInfix ''split_vertical = "prefix+|"'' herdrConfig
+    && lib.hasInfix ''split_horizontal = "prefix+minus"'' herdrConfig
+  ) "Herdr should use the selected tmux-compatible bindings";
+
+  herdr-config-valid = pkgs.runCommand "herdr-config-valid" { } ''
+    export HOME="$TMPDIR"
+    export HERDR_CONFIG_PATH=${herdrConfigFile}
+    ${pkgs.herdr}/bin/herdr config check
+    touch "$out"
+  '';
+}
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+git add tests/integration/herdr-test.nix
+nix build '.#checks.aarch64-darwin.integration-herdr' --impure --accept-flake-config --show-trace
+```
+
+Staging the new test makes it visible to flake source filtering. Expected:
+FAIL because `users/shared/programs/herdr.nix` does not exist.
+
+- [ ] **Step 3: Implement the minimal module**
+
+Create `users/shared/programs/herdr.nix`:
+
+```nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.modules.programs.herdr;
+in
+{
+  options.modules.programs.herdr.enable = lib.mkEnableOption "Herdr terminal workspace manager";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.herdr ];
+
+    xdg.configFile."herdr/config.toml".text = ''
+      onboarding = false
+
+      [update]
+      channel = "stable"
+      version_check = false
+
+      [keys]
+      prefix = "ctrl+a"
+      detach = "prefix+d"
+      split_vertical = "prefix+|"
+      split_horizontal = "prefix+minus"
+    '';
+  };
+}
+```
+
+Modify `users/shared/home-manager.nix` by adding `./programs/herdr.nix` beside
+`./programs/tmux.nix` and `herdr.enable = true;` beside `tmux.enable = true;`.
+
+- [ ] **Step 4: Run focused verification and verify GREEN**
+
+Run:
+
+```bash
+nix fmt
+nix build '.#checks.aarch64-darwin.integration-herdr' --impure --accept-flake-config --show-trace
+git diff --check
+```
+
+Expected: formatting completes, all three Herdr checks build, and the diff
+check prints no errors.
+
+- [ ] **Step 5: Commit the module**
+
+```bash
+git add tests/integration/herdr-test.nix users/shared/programs/herdr.nix users/shared/home-manager.nix
+git commit -m "feat(herdr): add tmux-compatible home-manager setup"
+```
+
+### Task 2: Build, apply, and migrate the current machine
+
+**Files:**
+- Verify only: `flake.nix`, `flake.lock`
+- Runtime target: `~/.config/herdr/config.toml`
+
+**Interfaces:**
+- Consumes: the Home Manager module from Task 1 and the `macbook-pro` nix-darwin configuration.
+- Produces: a Nix-managed `herdr` command on the current Mac with no Homebrew shadow copy.
+
+- [ ] **Step 1: Run repository-wide evaluation and the target build**
+
+Run:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 nix flake check --no-build --impure --accept-flake-config --show-trace
+NIXPKGS_ALLOW_UNFREE=1 nix build '.#darwinConfigurations.macbook-pro.system' --impure
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Apply the nix-darwin configuration**
+
+Run:
+
+```bash
+NIXPKGS_ALLOW_UNFREE=1 sudo -H /run/current-system/sw/bin/darwin-rebuild switch --flake '.#macbook-pro'
+```
+
+Expected: activation exits 0 and creates the Home Manager-managed Herdr config.
+
+- [ ] **Step 3: Verify the Nix package before removing Homebrew**
+
+Run:
+
+```bash
+test -x /etc/profiles/per-user/baleen/bin/herdr
+/etc/profiles/per-user/baleen/bin/herdr --version
+test -L "$HOME/.config/herdr/config.toml"
+```
+
+Expected: the executable exists, reports `herdr 0.7.5`, and the config is a
+Home Manager symlink.
+
+- [ ] **Step 4: Remove the inactive Homebrew formula**
+
+First run:
+
+```bash
+/opt/homebrew/bin/herdr status --json
+```
+
+Continue only when `.server.running` is `false`. Then run:
+
+```bash
+brew uninstall herdr
+```
+
+Expected: Homebrew removes Herdr 0.7.4 without deleting
+`~/.config/herdr/` runtime state. If the server is running, skip removal and
+report the migration cleanup as blocked instead of stopping it.
+
+- [ ] **Step 5: Run final runtime verification**
+
+Run in a fresh login-shell environment:
+
+```bash
+zsh -lic 'command -v herdr && herdr --version && herdr config check'
+brew list --versions herdr
+```
+
+Expected: `command -v` resolves to `/etc/profiles/per-user/baleen/bin/herdr`,
+the version is `herdr 0.7.5`, config validation succeeds, and
+`brew list --versions herdr` produces no package entry.

--- a/docs/superpowers/specs/2026-07-28-herdr-setup-design.md
+++ b/docs/superpowers/specs/2026-07-28-herdr-setup-design.md
@@ -1,0 +1,116 @@
+# Herdr Setup Design
+
+## Goal
+
+Install Herdr through the existing Nix/Home Manager configuration and give it
+the small set of tmux-compatible defaults the user explicitly selected.
+
+Success means:
+
+- `herdr` is provided by the pinned nixpkgs revision, currently version 0.7.5.
+- `~/.config/herdr/config.toml` is reproducible from this repository.
+- The prefix is `Ctrl-a`.
+- Detach and pane splitting use the same keys as the existing tmux setup.
+- The manually installed Homebrew copy no longer shadows the Nix binary.
+- The Nix configuration and Herdr configuration both validate.
+
+## Current State
+
+- Homebrew provides Herdr 0.7.4 at `/opt/homebrew/bin/herdr`.
+- The pinned nixpkgs exposes `pkgs.herdr` 0.7.5.
+- No Herdr config file exists.
+- No Herdr server is running, so replacing the binary will not terminate an
+  active Herdr session.
+- Shared programs are implemented as opt-in Home Manager modules under
+  `users/shared/programs/` and enabled in `users/shared/home-manager.nix`.
+
+## Approaches Considered
+
+### Minimal tmux-compatible module
+
+Add a dedicated Home Manager module that installs `pkgs.herdr` and declares
+only the settings that differ from useful Herdr defaults. This keeps the
+configuration small while making the selected tmux habits reproducible.
+
+This is the chosen approach.
+
+### Package and onboarding setting only
+
+Install the package and disable onboarding, leaving Herdr's `Ctrl-b` prefix and
+`prefix+q` detach binding unchanged. This is simpler but contradicts the
+selected `Ctrl-a` behavior.
+
+### Broad tmux keymap clone
+
+Override most Herdr bindings to mimic tmux. This adds configuration without a
+demonstrated need and risks hiding or conflicting with Herdr-specific workspace
+and agent controls.
+
+## Home Manager Structure
+
+Create `users/shared/programs/herdr.nix` with:
+
+- `modules.programs.herdr.enable`, following the existing shared-program module
+  pattern.
+- `home.packages = [ pkgs.herdr ];`.
+- A declarative `xdg.configFile."herdr/config.toml"` entry.
+
+Import the module and enable it in `users/shared/home-manager.nix`, next to the
+other terminal programs.
+
+No new flake input is needed because the pinned nixpkgs already contains the
+required stable package. Shell completions come from the nixpkgs package and do
+not need a separate generated file.
+
+## Herdr Configuration
+
+The managed TOML file contains only:
+
+```toml
+onboarding = false
+
+[update]
+channel = "stable"
+version_check = false
+
+[keys]
+prefix = "ctrl+a"
+detach = "prefix+d"
+split_vertical = "prefix+|"
+split_horizontal = "prefix+minus"
+```
+
+`version_check` is disabled because Nix, rather than Herdr's self-updater,
+owns upgrades. The stable channel remains explicit so Herdr's other
+channel-aware behavior does not opt into previews.
+
+Herdr's existing defaults already provide tmux-like new-tab, previous/next-tab,
+close-pane, and `h/j/k/l` pane navigation bindings. They will not be repeated.
+Theme, mouse behavior, notifications, agent integrations, and experimental
+features remain unchanged.
+
+## Migration
+
+Apply the Home Manager/nix-darwin configuration first and verify that the Nix
+profile contains Herdr 0.7.5. Then uninstall the Homebrew formula so
+`/opt/homebrew/bin/herdr` no longer wins earlier in `PATH`.
+
+Before removal, recheck that no Herdr server is running. If one has started in
+the meantime, do not stop it automatically because server shutdown terminates
+its pane processes; report that the migration cleanup must wait instead.
+
+The existing runtime logs, sockets, release notes, and session metadata under
+`~/.config/herdr/` are not deleted.
+
+## Verification
+
+1. Format and evaluate the Nix configuration.
+2. Build the target nix-darwin configuration.
+3. Apply it to the current machine.
+4. Validate the managed TOML with `herdr config check`.
+5. Confirm `herdr --version` reports 0.7.5 and `command -v herdr` resolves to
+   the Nix-managed profile rather than Homebrew.
+6. Confirm the Homebrew formula is absent.
+
+No interactive Herdr session is launched during verification because doing so
+would create runtime state and take over the current terminal.

--- a/tests/integration/herdr-test.nix
+++ b/tests/integration/herdr-test.nix
@@ -1,0 +1,52 @@
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  homeConfig = inputs.home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      ../../users/shared/programs/herdr.nix
+      {
+        modules.programs.herdr.enable = true;
+        home = {
+          username = "test";
+          homeDirectory = if pkgs.stdenv.isDarwin then "/Users/test" else "/home/test";
+          stateVersion = "24.11";
+        };
+      }
+    ];
+  };
+
+  inherit (homeConfig) config;
+  herdrConfig = config.xdg.configFile."herdr/config.toml".text;
+  parsedConfig = builtins.fromTOML herdrConfig;
+  herdrConfigFile = pkgs.writeText "herdr-config.toml" herdrConfig;
+in
+{
+  herdr-package-installed =
+    helpers.assertTest "herdr-package-installed" (builtins.elem pkgs.herdr config.home.packages)
+      "Herdr should be installed through Home Manager";
+
+  herdr-config-contains-tmux-bindings = helpers.assertTest "herdr-config-contains-tmux-bindings" (
+    parsedConfig.keys == {
+      prefix = "ctrl+a";
+      detach = "prefix+d";
+      split_vertical = "prefix+|";
+      split_horizontal = "prefix+minus";
+    }
+  ) "Herdr should use the selected tmux-compatible bindings";
+
+  herdr-config-valid = pkgs.runCommand "herdr-config-valid" { } ''
+    export HOME="$TMPDIR"
+    export HERDR_CONFIG_PATH=${herdrConfigFile}
+    ${pkgs.herdr}/bin/herdr config check
+    touch "$out"
+  '';
+}

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -14,6 +14,7 @@
     ./programs/starship.nix
     ./programs/tmux.nix
     ./programs/zellij.nix
+    ./programs/herdr.nix
     ./programs/claude-code.nix
     ./programs/codex.nix
     ./programs/opencode.nix
@@ -47,6 +48,7 @@
     zsh.enable = true;
     tmux.enable = true;
     zellij.enable = true;
+    herdr.enable = true;
     starship.enable = true;
     claude-code.enable = true;
     codex.enable = true;

--- a/users/shared/programs/herdr.nix
+++ b/users/shared/programs/herdr.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.modules.programs.herdr;
+in
+{
+  options.modules.programs.herdr.enable = lib.mkEnableOption "Herdr terminal workspace manager";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.herdr ];
+
+    xdg.configFile."herdr/config.toml".text = ''
+      onboarding = false
+
+      [update]
+      channel = "stable"
+      version_check = false
+
+      [keys]
+      prefix = "ctrl+a"
+      detach = "prefix+d"
+      split_vertical = "prefix+|"
+      split_horizontal = "prefix+minus"
+    '';
+  };
+}


### PR DESCRIPTION
## 변경 내용

- Home Manager에 declarative herdr 모듈 추가
- herdr 패키지와 설정 활성화
- herdr 통합 테스트 추가
- 설정 작업 계획 문서 갱신
- 기존 zellij 설정과 herdr 설정 병합 충돌 해결

## 원인

`users/shared/home-manager.nix`에 Git 충돌 마커가 남아 있어 `make switch`가 실패했습니다.

## 검증

- `make switch`
- `make test`
- pre-commit 전체 검사