### PR TITLE
feat(zellij): add zellij multiplexer module mirroring tmux config

### DIFF
--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -13,6 +13,7 @@
     ./programs/zsh
     ./programs/starship.nix
     ./programs/tmux.nix
+    ./programs/zellij.nix
     ./programs/claude-code.nix
     ./programs/codex.nix
     ./programs/opencode.nix
@@ -45,6 +46,7 @@
     vim.enable = true;
     zsh.enable = true;
     tmux.enable = true;
+    zellij.enable = true;
     starship.enable = true;
     claude-code.enable = true;
     codex.enable = true;

--- a/users/shared/programs/zellij.nix
+++ b/users/shared/programs/zellij.nix
@@ -1,0 +1,48 @@
+# Zellij Terminal Multiplexer Configuration
+#
+# tmux.nix parity: same prefix key, same split keys.
+#
+# Key Bindings:
+#   - Prefix: Ctrl+a (zellij's built-in "tmux" mode, rebound from Ctrl+b)
+#   - Split panes: Prefix+| (left/right), Prefix+- (top/bottom)
+#   - Navigate panes: Prefix+h/j/k/l
+#   - New tab (~window): Prefix+c
+#   - Next/Prev tab: Prefix+n/p
+#   - Rename tab: Prefix+,
+#   - Detach: Prefix+d
+
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.modules.programs.zellij;
+in
+{
+  options.modules.programs.zellij.enable = lib.mkEnableOption "Zellij multiplexer configuration";
+
+  config = lib.mkIf cfg.enable {
+    programs.zellij = {
+      enable = true;
+      enableZshIntegration = false;
+
+      extraConfig = ''
+        keybinds {
+          normal {
+            bind "Ctrl a" { SwitchToMode "Tmux"; }
+          }
+          tmux {
+            unbind "Ctrl b"
+            bind "Ctrl a" { Write 1; SwitchToMode "Normal"; }
+            unbind "%"
+            unbind "\""
+            bind "|" { NewPane "Right"; SwitchToMode "Normal"; }
+            bind "-" { NewPane "Down"; SwitchToMode "Normal"; }
+          }
+        }
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- tmux.nix와 동일한 module enable 패턴(`modules.programs.zellij.enable`)으로 zellij 모듈 추가
- tmux와 동일한 키바인딩: prefix `Ctrl+a` (zellij 기본 `Ctrl+b`에서 재바인딩), `|` 세로 분할, `-` 가로 분할, `hjkl` pane 이동

## Test plan
- [x] `nix flake check --impure` 통과 (기존에도 실패하던 `kakaostyle-jito-disables-hammerspoon` 테스트 제외, zellij와 무관)
- [ ] `make switch` 후 zellij 실행하여 prefix + `|`/`-` 분할, `hjkl` 이동 동작 확인