### PR TITLE
feat(worktree): use shared home worktree directory

### DIFF
--- a/tests/integration/herdr-test.nix
+++ b/tests/integration/herdr-test.nix
@@ -43,6 +43,11 @@ in
     }
   ) "Herdr should use the selected tmux-compatible bindings";
 
+  herdr-config-uses-shared-worktree-root =
+    helpers.assertTest "herdr-config-uses-shared-worktree-root"
+      (parsedConfig ? worktrees && parsedConfig.worktrees.directory == "~/worktrees")
+      "Herdr should create worktrees under ~/worktrees";
+
   herdr-config-valid = pkgs.runCommand "herdr-config-valid" { } ''
     export HOME="$TMPDIR"
     export HERDR_CONFIG_PATH=${herdrConfigFile}

--- a/tests/unit/claude-test.nix
+++ b/tests/unit/claude-test.nix
@@ -38,5 +38,10 @@ in
       (lib.hasInfix "run cp \${src}/CLAUDE.md ~/.claude/CLAUDE.md" claudeCodeModule)
       "claude-code.nix should overwrite ~/.claude/CLAUDE.md during activation"
     )
+
+    (helpers.assertTest "worktree-hook-refreshes-on-switch"
+      (lib.hasInfix "run cp \${src}/setup-worktree.sh ~/.claude/setup-worktree.sh" claudeCodeModule)
+      "claude-code.nix should refresh the declarative worktree hook during activation"
+    )
   ];
 }

--- a/tests/unit/wt-hook-consistency-test.nix
+++ b/tests/unit/wt-hook-consistency-test.nix
@@ -1,8 +1,7 @@
 # tests/unit/wt-hook-consistency-test.nix
 # The Claude Code WorktreeCreate hook runs under bash and cannot call the zsh
 # `wt` function, so the path rule is necessarily written twice. Pin both copies
-# to the same rule here — they drifted apart once already (the hook was still
-# on the old 00000- numbering after wt moved to YYMMDD-).
+# to the same rule here.
 {
   inputs,
   system,
@@ -20,21 +19,17 @@ in
 {
   platforms = [ "any" ];
   value = helpers.testSuite "wt-hook-consistency" [
-    (helpers.assertTest "hook-uses-worktrees-dir" (lib.hasInfix ".worktrees" hookScript)
-      "hook should place worktrees under .worktrees/"
+    (helpers.assertTest "hook-uses-shared-worktrees-dir" (lib.hasInfix "$HOME/worktrees" hookScript)
+      "hook should place worktrees under ~/worktrees/"
     )
 
-    (helpers.assertTest "hook-uses-date-prefix" (lib.hasInfix "date +%y%m%d" hookScript)
-      "hook should use the same YYMMDD prefix as wt"
+    (helpers.assertTest "hook-uses-repo-name" (lib.hasInfix "basename \"$REPO_ROOT\"" hookScript)
+      "hook should include the repository name in the worktree path"
     )
 
-    (helpers.assertTest "wt-uses-date-prefix" (lib.hasInfix "date +%y%m%d" wtScript)
-      "wt should use a YYMMDD prefix (the rule the hook mirrors)"
+    (helpers.assertTest "wt-uses-shared-worktrees-dir" (lib.hasInfix "\${HOME}/worktrees" wtScript)
+      "wt should use the same shared worktree root as the hook"
     )
-
-    (helpers.assertTest "hook-drops-numeric-prefix" (
-      !(lib.hasInfix "%05d" hookScript)
-    ) "hook should not use the old zero-padded numeric prefix")
 
     (helpers.assertTest "hook-resolves-main-root" (lib.hasInfix "worktree list" hookScript)
       "hook should resolve the main worktree root so it never nests worktrees"

--- a/tests/unit/wt-numbering-test.nix
+++ b/tests/unit/wt-numbering-test.nix
@@ -1,6 +1,5 @@
 # tests/unit/wt-numbering-test.nix
-# Verify wt _sanitize_branch prefixes worktree directories with today's YYMMDD
-# date instead of a monotonically increasing numeric counter.
+# Verify wt _sanitize_branch places worktrees in the shared home worktree root.
 {
   inputs,
   system,
@@ -16,18 +15,15 @@ let
 in
 {
   platforms = [ "any" ];
-  value = helpers.testSuite "wt-date-prefix" [
-    (helpers.assertTest "wt-uses-yymmdd-date-prefix" (lib.hasInfix "date +%y%m%d" wtScript)
-      "wt _sanitize_branch should prefix worktree directories with today's YYMMDD date"
-    )
+  value = helpers.testSuite "wt-worktree-path" [
+    (helpers.assertTest "wt-builds-shared-worktree-path" (
+      lib.hasInfix "worktrees/" wtScript
+      && lib.hasInfix "repo_name" wtScript
+      && lib.hasInfix "1//\\//-" wtScript
+    ) "wt _sanitize_branch should build ~/worktrees/<repo>/<branch> paths")
 
-    (helpers.assertTest "wt-builds-date-title-worktree-path"
-      (lib.hasInfix ''"''${repo_root}/.worktrees/''${date_prefix}-''${1//\//-}"'' wtScript)
-      "wt _sanitize_branch should build .worktrees/YYMMDD-title paths"
+    (helpers.assertTest "wt-derives-repo-name" (lib.hasInfix "basename \"$repo_root\"" wtScript)
+      "wt should use the main repository directory name in the worktree path"
     )
-
-    (helpers.assertTest "wt-does-not-scan-numeric-prefixes" (
-      !(lib.hasInfix "grep -oE '^[0-9]+'" wtScript)
-    ) "wt _sanitize_branch should not scan existing numeric prefixes")
   ];
 }

--- a/tests/unit/wt-subcommands-test.nix
+++ b/tests/unit/wt-subcommands-test.nix
@@ -31,6 +31,9 @@ in
       (lib.hasInfix "/nix/var/nix/gcroots/auto" wtScript)
       "wt ls should list worktrees machine-wide via nix-direnv gc-roots, not just the current repo"
     )
+    (helpers.assertTest "wt-ls-scans-shared-worktree-root" (lib.hasInfix (
+      ''"'' + "$HOME" + ''"/worktrees/*/*/.direnv/*''
+    ) wtScript) "wt ls should recognize worktrees under ~/worktrees/<repo>/<branch>")
     (helpers.assertTest "wt-rm-subcommand" (lib.hasInfix "rm)" wtScript)
       "wt should handle an rm subcommand"
     )

--- a/users/shared/programs/.config/claude/setup-worktree.sh
+++ b/users/shared/programs/.config/claude/setup-worktree.sh
@@ -2,7 +2,7 @@
 # WorktreeCreate hook: create the worktree where wt() would put it.
 #
 # Mirrors the path rule in users/shared/programs/zsh/wt.nix:
-#   <repo_root>/.worktrees/<YYMMDD>-<branch with / replaced by ->
+#   $HOME/worktrees/<repo>/<branch with / replaced by ->
 # The hook runs under bash and cannot call the zsh wt function, so the rule
 # lives in two places; tests/unit/wt-hook-consistency-test.nix pins them
 # together.
@@ -29,10 +29,10 @@ fi
 # nest a new one underneath it.
 REPO_ROOT=$(git -C "$CWD" worktree list --porcelain | sed -n 's/^worktree //p' | head -1)
 
-DATE_PREFIX=$(date +%y%m%d)
-DIR="$REPO_ROOT/.worktrees/${DATE_PREFIX}-${NAME//\//-}"
+REPO_NAME=$(basename "$REPO_ROOT")
+DIR="$HOME/worktrees/$REPO_NAME/${NAME//\//-}"
 
-mkdir -p "$REPO_ROOT/.worktrees"
+mkdir -p "$(dirname "$DIR")"
 
 if git -C "$CWD" rev-parse --verify main > /dev/null 2>&1; then
   BASE="main"

--- a/users/shared/programs/claude-code.nix
+++ b/users/shared/programs/claude-code.nix
@@ -6,10 +6,12 @@
 # https://github.com/baleen37/claude-plugins
 #
 # CLAUDE.md is copied on every switch so its declarative guidance stays in sync.
-# The remaining files are real, writable files rather than read-only store
+# Runtime-mutated files are real, writable files rather than read-only store
 # symlinks, because Claude Code mutates them at runtime (e.g.
 # feedbackSurveyState and plugin toggles). They are only copied when absent so
-# local edits and runtime writes are preserved across rebuilds.
+# local edits and runtime writes are preserved across rebuilds. The worktree
+# hook is declarative and is refreshed on every switch so its path rule stays
+# synchronized with wt.
 
 { config, lib, ... }:
 
@@ -25,12 +27,14 @@ in
       run mkdir -p ~/.claude
       run cp ${src}/CLAUDE.md ~/.claude/CLAUDE.md
       run chmod u+w ~/.claude/CLAUDE.md
-      for f in local.md settings.json statusline.sh setup-worktree.sh; do
+      for f in local.md settings.json statusline.sh; do
         if [ ! -f ~/.claude/"$f" ]; then
           run cp ${src}/"$f" ~/.claude/"$f"
           run chmod u+w ~/.claude/"$f"
         fi
       done
+      run cp ${src}/setup-worktree.sh ~/.claude/setup-worktree.sh
+      run chmod u+w ~/.claude/setup-worktree.sh
       run chmod +x ~/.claude/statusline.sh
       run chmod +x ~/.claude/setup-worktree.sh
     '';

--- a/users/shared/programs/herdr.nix
+++ b/users/shared/programs/herdr.nix
@@ -21,6 +21,9 @@ in
       channel = "stable"
       version_check = false
 
+      [worktrees]
+      directory = "~/worktrees"
+
       [keys]
       prefix = "ctrl+a"
       detach = "prefix+d"

--- a/users/shared/programs/zsh/wt.nix
+++ b/users/shared/programs/zsh/wt.nix
@@ -178,7 +178,7 @@
         # symlink takes ~5s with hundreds of roots.
         local _gc_target _wt_dir
         readlink /nix/var/nix/gcroots/auto/*(N@) 2>/dev/null | while IFS= read -r _gc_target; do
-          [[ "$_gc_target" == */.worktrees/*/.direnv/* ]] || continue
+          [[ "$_gc_target" == "$HOME"/worktrees/*/*/.direnv/* ]] || continue
           echo "''${_gc_target%/.direnv/*}"
         done | sort -u | while IFS= read -r _wt_dir; do
           if [[ -d "$_wt_dir" ]]; then
@@ -361,13 +361,13 @@
     }
 
     # Helper: Sanitize branch name for directory (replace / with -)
-    # Prefix with today's YYMMDD date for readable, chronological worktree names.
-    # Always returns an absolute path based on the main worktree root so wt works
-    # correctly from inside a worktree (flat, not nested).
+    # Place worktrees in a shared home directory, grouped by repository.
+    # Always resolve the repository name from the main worktree so wt works
+    # correctly from inside a worktree.
     local _sanitize_branch() {
       local repo_root=$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -1)
-      local date_prefix=$(date +%y%m%d)
-      echo "''${repo_root}/.worktrees/''${date_prefix}-''${1//\//-}"
+      local repo_name=$(basename "$repo_root")
+      echo "''${HOME}/worktrees/''${repo_name}/''${1//\//-}"
     }
 
     # Helper: Find base branch (main or master)
@@ -444,6 +444,7 @@
     local worktree_dir=$(_sanitize_branch "$branch_name")
 
     _check_worktree_exists "$worktree_dir" || return 1
+    mkdir -p "$(dirname "$worktree_dir")"
 
     local base_branch=$(_find_base_branch)
     if [[ -z "$base_branch" ]]; then


### PR DESCRIPTION
## 요약

worktree와 Herdr의 기본 worktree 위치를 ~/worktrees/<repo>/<branch>로 통일합니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

## 테스트 계획

- [x] nix flake check --impure
- [x] make switch-home
- [x] 임시 Git 저장소에서 wt feature-a, wt new 수동 검증
- [x] herdr config check

## 추가 정보

전체 make switch는 Homebrew App Store 설치 2건에서 비대화형 sudo가 필요해 실패했으며, Home Manager 설정은 make switch-home로 별도 적용했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktrees are now created consistently under `~/worktrees/<repository>/<branch>`.
  * Herdr configuration now uses `~/worktrees` as the shared worktree directory.
  * Worktree listings recognize the new shared directory structure.

* **Bug Fixes**
  * Claude Code’s worktree hook now refreshes correctly when configuration changes.
  * Worktree creation automatically creates required parent directories.
  * Branch names are sanitized consistently for worktree paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->