### PR TITLE
fix(wt): sync Herdr worktrees

### DIFF
--- a/tests/unit/wt-existing-worktree-test.nix
+++ b/tests/unit/wt-existing-worktree-test.nix
@@ -36,5 +36,27 @@ in
       (lib.hasInfix ''cd "$existing_worktree"'' wtScript)
       "wt should cd into the existing worktree instead of failing"
     )
+
+    (helpers.assertTest "wt-detects-herdr-pane" (lib.hasInfix ''[[ "''${HERDR_ENV:-}" == "1"'' wtScript)
+      "wt should detect a Herdr-managed pane before invoking Herdr"
+    )
+
+    (helpers.assertTest "wt-captures-herdr-workspace" (lib.hasInfix "HERDR_WORKSPACE_ID:-" wtScript)
+      "wt should capture the parent Herdr workspace id"
+    )
+
+    (helpers.assertTest "wt-opens-worktree-through-herdr" (lib.hasInfix "herdr worktree open" wtScript)
+      "wt should open the created worktree through Herdr"
+    )
+
+    (helpers.assertTest "wt-passes-parent-workspace"
+      (lib.hasInfix ''--workspace "$herdr_workspace"'' wtScript)
+      "wt should pass the parent workspace to Herdr"
+    )
+
+    (helpers.assertTest "wt-opens-herdr-before-cd"
+      (lib.hasInfix ''--path "$worktree_dir" --focus'' wtScript)
+      "wt should open the Herdr worktree before changing the shell directory"
+    )
   ];
 }

--- a/users/shared/programs/zsh/wt.nix
+++ b/users/shared/programs/zsh/wt.nix
@@ -15,6 +15,7 @@
   #                            Remove merged+clean worktrees (dry-run by default)
   wt() {
     local _wt_random=0
+    local herdr_workspace="''${HERDR_WORKSPACE_ID:-}"
 
     # Helper: Generate a random branch name like "snappy-greeting-bachman"
     local _random_branch_name() {
@@ -360,6 +361,14 @@
       return 1
     }
 
+    # Open a Git worktree in Herdr while the current workspace is still the
+    # parent repository workspace. Herdr's linked-worktree actions reject a
+    # request made after the shell has already cd-ed into the new checkout.
+    local _open_in_herdr() {
+      local worktree_dir="$1"
+      herdr worktree open --workspace "$herdr_workspace" --path "$worktree_dir" --focus >/dev/null 2>&1
+    }
+
     # Helper: Sanitize branch name for directory (replace / with -)
     # Place worktrees in a shared home directory, grouped by repository.
     # Always resolve the repository name from the main worktree so wt works
@@ -459,7 +468,11 @@
       if [[ -n "$existing_worktree" ]]; then
         _msg "$YELLOW" "Warning: branch '$branch_name' is already checked out at $existing_worktree"
         _msg "$BLUE" "Switching to existing worktree instead."
-        cd "$existing_worktree"
+        if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
+          _open_in_herdr "$existing_worktree" || return 1
+        else
+          cd "$existing_worktree"
+        fi
         return 0
       fi
 
@@ -481,7 +494,14 @@
     fi
 
     _msg "$GREEN" "Worktree created: $worktree_dir"
-    cd "$worktree_dir"
+    if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
+      _open_in_herdr "$worktree_dir" || {
+        _error "Failed to open worktree in Herdr"
+        return 1
+      }
+    else
+      cd "$worktree_dir"
+    fi
 
     # Opportunistic cleanup: reclaim store space left behind by previously
     # removed worktrees. Detached background run, so it never blocks the


### PR DESCRIPTION
## Summary
- Integrate wt with Herdr only inside Herdr-managed panes.
- Open the new or existing worktree through the parent Herdr workspace before changing directories.
- Preserve the existing Git fallback outside Herdr and add regression assertions.

## Tests
- Generated Zsh syntax check
- Focused and related wt Nix checks
- Real smoke test in a separate Herdr session
- pre-commit hooks and all tests passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated worktree navigation with Herdr-managed workspaces.
  * Automatically opens and focuses the selected or newly created worktree in Herdr before changing directories.
  * Preserves the current Herdr workspace when creating or opening worktrees.

* **Tests**
  * Added coverage for Herdr integration when handling existing worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->