### PR TITLE
chore(darwin): stop installing unused casks

### DIFF
--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -9,9 +9,7 @@ let
   # Homebrew Cask definitions (GUI applications)
   homebrew-casks = [
     # Development Tools
-    "datagrip" # Database IDE from JetBrains
     "ghostty" # GPU-accelerated terminal emulator
-    "utm" # Virtual machine manager for macOS
 
     # Fonts
     "font-jetbrains-mono" # JetBrains Mono font for terminal


### PR DESCRIPTION
## 요약

사용하지 않는 DataGrip과 UTM의 자동 설치를 중단합니다.

## 변경사항

- [ ] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경
- `users/shared/darwin/homebrew.nix`에서 `datagrip` cask 제거
- `users/shared/darwin/homebrew.nix`에서 `utm` cask 제거

## 테스트 계획

- [x] `make lint` 통과
- [x] `make test` 통과 (macOS validation mode)
- [ ] `make test-build` 통과
  - 기존 `kakaostyle-jito disables hammerspoon` assertion 실패로 중단됨
- [ ] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 설정 평가 완료

## 추가 정보

DataGrip과 UTM 앱은 로컬에서 제거했고, UTM VM 파일도 확인 후 제거했습니다. 이번 PR에서는 macOS Homebrew 자동 설치 선언만 제거하며, 별도 NixOS UTM VM 설정은 보존합니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [ ] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed DataGrip and UTM from the macOS Homebrew application list.
  * Retained Ghostty in the Development Tools section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->