### PR TITLE
fix(darwin): prevent mas app reinstalls when spotlight is disabled

### DIFF
--- a/tests/unit/darwin-test.nix
+++ b/tests/unit/darwin-test.nix
@@ -49,6 +49,8 @@ let
   # nixfmt reflows multi-line operator chains, and the threshold at which it joins
   # or splits them is not worth guessing at.
   homebrewCasks = darwinConfig.homebrew.casks;
+  preActivationText = (darwinConfig.system.activationScripts.preActivation or { text = ""; }).text;
+  homebrewExtraConfig = darwinConfig.homebrew.extraConfig;
   forceClick = customPrefs.NSGlobalDomain."com.apple.trackpad.forceClick";
   tapGesture = multitouch.TrackpadThreeFingerTapGesture;
   btTapGesture = bluetooth.TrackpadThreeFingerTapGesture;
@@ -75,6 +77,21 @@ in
       # silently uninstall all of them.
       (assertions.assertAttrEquals "homebrew-enabled" darwinConfig.homebrew "enable" true null)
       (assertions.assertListNotEmpty "homebrew-casks-not-empty" homebrewCasks null)
+
+      (helpers.assertTest "spotlight-indexing-for-mas" (
+        lib.hasInfix "/usr/bin/mdutil -E -i on /" preActivationText
+        && lib.hasInfix "/usr/bin/mdimport" preActivationText
+        && lib.hasInfix "/Applications/KakaoTalk.app" preActivationText
+        && lib.hasInfix "/Applications/Magnet.app" preActivationText
+      ) "Activation should enable Spotlight and index the configured MAS apps")
+
+      (helpers.assertTest "mas-existing-app-skip-configured" (
+        lib.hasInfix "HOMEBREW_BUNDLE_MAS_SKIP" homebrewExtraConfig
+        && lib.hasInfix "Applications/KakaoTalk.app" homebrewExtraConfig
+        && lib.hasInfix "Applications/Magnet.app" homebrewExtraConfig
+        && lib.hasInfix "869223134" homebrewExtraConfig
+        && lib.hasInfix "441258766" homebrewExtraConfig
+      ) "Existing App Store apps should be skipped while Spotlight is unavailable")
 
       # FileVault makes loginwindow.autoLoginUser a no-op, so it must stay unset
       # rather than be set to something misleading.

--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -83,6 +83,16 @@ in
       "KakaoTalk" = 869223134; # Communication platform (if needed)
     };
 
+    # mas discovers installed App Store apps through Spotlight. Keep existing
+    # apps out of `brew bundle` while Spotlight is being enabled or rebuilt.
+    extraConfig = ''
+      masSkip = [
+        ("869223134" if File.directory?("/Applications/KakaoTalk.app")),
+        ("441258766" if File.directory?("/Applications/Magnet.app")),
+      ].compact
+      ENV["HOMEBREW_BUNDLE_MAS_SKIP"] = [ENV["HOMEBREW_BUNDLE_MAS_SKIP"], *masSkip].compact.join(" ")
+    '';
+
     # Extended Package Repository Access
     # Additional Homebrew taps for specialized packages and development tools
     # Note: homebrew/cask is now built into Homebrew by default (since 2023)

--- a/users/shared/darwin/scripts.nix
+++ b/users/shared/darwin/scripts.nix
@@ -21,6 +21,26 @@
 _:
 
 {
+  # mas uses Spotlight metadata to find installed Mac App Store apps. Keep the
+  # index enabled for the root volume and import the configured apps when their
+  # Adam ID is not available yet.
+  system.activationScripts.preActivation.text = ''
+    spotlight_status=$(/usr/bin/mdutil -s / 2>/dev/null || true)
+    if echo "$spotlight_status" | grep -qi "disabled"; then
+      echo "Enabling Spotlight indexing for App Store app detection..." >&2
+      /usr/bin/mdutil -E -i on / >&2 || true
+    fi
+
+    for app in \
+      "/Applications/KakaoTalk.app" \
+      "/Applications/Magnet.app"; do
+      adam_id=$(/usr/bin/mdls -raw -name kMDItemAppStoreAdamID "$app" 2>/dev/null || true)
+      if [ -d "$app" ] && { [ -z "$adam_id" ] || [ "$adam_id" = "(null)" ]; }; then
+        /usr/bin/mdimport "$app" 2>/dev/null || true
+      fi
+    done
+  '';
+
   system.activationScripts.postActivation.text = ''
     # Remote Login (SSH)
     # Enables macOS Remote Login so the machine accepts incoming SSH connections.


### PR DESCRIPTION
## Summary
- Prevent Homebrew Bundle from reinstalling existing KakaoTalk and Magnet apps when Spotlight metadata is unavailable
- Attempt to enable and import Spotlight metadata during darwin activation
- Preserve installation on machines where the apps are absent

## Verification
- `make switch` completed successfully
- Homebrew output confirmed `Skipping KakaoTalk` and `Skipping Magnet`
- Darwin unit tests passed
- treefmt check passed
- flake check passed
- darwin system build passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved macOS setup handling for Homebrew-managed App Store applications.
  - Spotlight indexing is automatically enabled or refreshed when needed.
  - App Store applications such as KakaoTalk and Magnet are detected and imported when their identifiers are unavailable.
  - Homebrew now skips already installed applications during bundle installation, helping activation complete more reliably while Spotlight is unavailable or rebuilding.

- **Tests**
  - Added coverage confirming Spotlight and Homebrew skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->