### PR TITLE
fix(wt): resolve Herdr parent workspace

### DIFF
--- a/tests/unit/wt-existing-worktree-test.nix
+++ b/tests/unit/wt-existing-worktree-test.nix
@@ -58,5 +58,25 @@ in
       (lib.hasInfix ''--path "$worktree_dir" --focus'' wtScript)
       "wt should open the Herdr worktree before changing the shell directory"
     )
+
+    (helpers.assertTest "wt-resolves-herdr-source-workspace" (
+      lib.hasInfix ''herdr worktree list --workspace "$herdr_workspace"'' wtScript
+      && lib.hasInfix "source_workspace_id" wtScript
+    ) "wt should resolve the repository parent workspace from Herdr's worktree source")
+
+    (helpers.assertTest "wt-resolves-herdr-before-creation"
+      (lib.hasInfix "_resolve_herdr_workspace || return 1" wtScript)
+      "wt should resolve the Herdr parent before creating a Git worktree"
+    )
+
+    (helpers.assertTest "wt-rolls-back-checkout-after-herdr-failure"
+      (lib.hasInfix ''git worktree remove --force "$worktree_dir"'' wtScript)
+      "wt should remove a newly created checkout when Herdr open fails"
+    )
+
+    (helpers.assertTest "wt-rolls-back-new-branch-after-herdr-failure"
+      (lib.hasInfix ''git branch -D "$branch_name"'' wtScript)
+      "wt should remove a newly created branch when Herdr open fails"
+    )
   ];
 }

--- a/users/shared/programs/zsh/wt.nix
+++ b/users/shared/programs/zsh/wt.nix
@@ -341,6 +341,11 @@
       done
     fi
 
+    local branch_existed=0
+    if git rev-parse --verify "refs/heads/$branch_name" >/dev/null 2>&1; then
+      branch_existed=1
+    fi
+
     # ANSI color codes
     local RED='\033[0;31m'
     local GREEN='\033[0;32m'
@@ -359,6 +364,19 @@
     local _error() {
       _msg "$RED" "$@"
       return 1
+    }
+
+    # Resolve the repository parent workspace. Herdr panes expose the current
+    # workspace ID, which is a linked-worktree workspace when wt runs there.
+    local _resolve_herdr_workspace() {
+      local source_workspace
+      source_workspace=$(herdr worktree list --workspace "$herdr_workspace" 2>/dev/null |
+        sed -n 's/.*"source_workspace_id":"\([^"]*\)".*/\1/p')
+      if [[ -z "$source_workspace" ]]; then
+        _error "Failed to resolve Herdr parent workspace"
+        return 1
+      fi
+      herdr_workspace="$source_workspace"
     }
 
     # Open a Git worktree in Herdr while the current workspace is still the
@@ -450,6 +468,10 @@
       return 1
     fi
 
+    if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
+      _resolve_herdr_workspace || return 1
+    fi
+
     local worktree_dir=$(_sanitize_branch "$branch_name")
 
     _check_worktree_exists "$worktree_dir" || return 1
@@ -479,6 +501,8 @@
       # Try to handle hierarchical ref conflict
       local resolved_branch=$(_handle_ref_conflict "$branch_name" "$create_error")
       if [[ -n "$resolved_branch" ]]; then
+        branch_name="$resolved_branch"
+        branch_existed=1
         worktree_dir=$(_sanitize_branch "$resolved_branch")
         _check_worktree_exists "$worktree_dir" || return 1
 
@@ -496,6 +520,10 @@
     _msg "$GREEN" "Worktree created: $worktree_dir"
     if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
       _open_in_herdr "$worktree_dir" || {
+        git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+        if [[ "$branch_existed" -eq 0 ]]; then
+          git branch -D "$branch_name" >/dev/null 2>&1 || true
+        fi
         _error "Failed to open worktree in Herdr"
         return 1
       }


### PR DESCRIPTION
## 요약

Herdr linked worktree 안에서 `wt new`가 부모 workspace를 사용하도록 수정했습니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정

- `HERDR_WORKSPACE_ID`의 `source_workspace_id`를 조회해 repository parent workspace로 변환
- Herdr open 실패 시 새 checkout과 새 branch 롤백

## 테스트 계획

- [x] 관련 `wt` unit checks 통과
- [x] 생성된 zsh script 문법 검사 통과
- [x] live Herdr runtime에서 신규 worktree 생성 검증
- [x] 기존 branch 전환 검증
- [x] Herdr open 실패 롤백 검증
- [x] `nix flake check --no-build` 통과

## 추가 정보

전체 flake build는 clean 기준에서도 실패하는 기존 `kakaostyle-jito` Hammerspoon host assertion과 별개입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree creation reliability by resolving the parent workspace before creating a new worktree.
  * If opening the worktree in Herdr fails, the newly created worktree and branch are now cleaned up automatically.
  * Improved branch-conflict handling to preserve existing branches and prevent accidental deletion during recovery.
* **Tests**
  * Added coverage for workspace resolution, pre-creation checks, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->