### PR TITLE
chore(codex): disable knowledge-base plugin

### DIFF
--- a/users/shared/programs/.config/codex/config.toml
+++ b/users/shared/programs/.config/codex/config.toml
@@ -54,3 +54,6 @@ enabled_tools = ["search_journal", "read_journal", "list_journal", "write_journa
 
 [plugins."slack@openai-curated-remote"]
 enabled = false
+
+[plugins."knowledge-base@baleen-marketplace"]
+enabled = false


### PR DESCRIPTION
## 요약

Codex 초기 설정에서 `knowledge-base` 플러그인이 전역 활성화되지 않도록 명시적으로 비활성화합니다.

## 변경사항

- [ ] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경

## 테스트 계획

- [x] pre-commit 검사 통과
- [x] 원격 push 시 전체 테스트 통과
- [x] TOML 설정 diff 확인

## 추가 정보

기존 사용자의 `~/.codex/config.toml`은 최초 설치 이후 자동 덮어쓰지 않으므로, 현재 환경의 전역 설정은 별도로 `enabled = false`로 조정되어 있습니다. 이 변경은 신규 초기화 환경에도 같은 정책을 적용합니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a disabled knowledge-base plugin configuration entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->