### PR TITLE
chore(codex): slim default MCP context

### DIFF
--- a/users/shared/programs/.config/codex/config.toml
+++ b/users/shared/programs/.config/codex/config.toml
@@ -8,6 +8,9 @@ model_reasoning_effort = "high"
 [sandbox_workspace_write]
 network_access = true
 
+[features]
+tool_search_always_defer_mcp_tools = true
+
 [projects."/Users/jito.hello/dev/wooto/infra"]
 trust_level = "trusted"
 
@@ -42,3 +45,12 @@ status_line = [
     "git-branch",
     "context-remaining",
 ]
+
+[plugins."private-journal-mcp@baleen-marketplace"]
+enabled = true
+
+[plugins."private-journal-mcp@baleen-marketplace".mcp_servers.private-journal]
+enabled_tools = ["search_journal", "read_journal", "list_journal", "write_journal"]
+
+[plugins."slack@openai-curated-remote"]
+enabled = false


### PR DESCRIPTION
## 요약

Codex 기본 MCP context 부담을 줄이고 private-journal 기능은 유지합니다.

## 변경사항

- [x] 설정 변경
- `[features].tool_search_always_defer_mcp_tools = true` 추가
- private-journal MCP 도구 4개만 allowlist에 유지
- `slack@openai-curated-remote` 비활성화

## 테스트 계획

- [x] TOML 파싱 확인
- [x] `git diff --check`
- [x] `nix flake check --no-build`
- [x] pre-commit 및 pre-push 전체 검사

## 추가 정보

Home Manager의 기존 설정 보존 동작은 유지했습니다.

## 체크리스트

- [x] 자체 검토를 완료함
- [x] 변경사항이 기존 기능을 손상시키지 않음