### PR TITLE
feat(darwin): install Amphetamine for closed-lid wake

### DIFF
--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -81,6 +81,7 @@ in
     masApps = {
       "Magnet" = 441258766; # Window management tool with multi-monitor support
       "KakaoTalk" = 869223134; # Communication platform (if needed)
+      "Amphetamine" = 937984704; # Keeps the machine awake with the lid closed
     };
 
     # mas discovers installed App Store apps through Spotlight. Keep existing
@@ -89,6 +90,7 @@ in
       masSkip = [
         ("869223134" if File.directory?("/Applications/KakaoTalk.app")),
         ("441258766" if File.directory?("/Applications/Magnet.app")),
+        ("937984704" if File.directory?("/Applications/Amphetamine.app")),
       ].compact
       ENV["HOMEBREW_BUNDLE_MAS_SKIP"] = [ENV["HOMEBREW_BUNDLE_MAS_SKIP"], *masSkip].compact.join(" ")
     '';


### PR DESCRIPTION
## 요약

맥북 뚜껑을 닫아도 슬립되지 않게 하려고 Mac App Store 앱 Amphetamine을 `masApps`에 추가했습니다.

`pmset disablesleep`은 `pmset -g`의 System-wide power settings(`SleepDisabled`)에 들어가는 전역 설정이라 AC/배터리로 분기할 수 없고, nix-darwin의 `power.sleep.*`은 `systemsetup` 유휴 타이머만 다루므로 뚜껑 닫힘을 막지 못합니다. `caffeinate`도 뚜껑 닫힘은 막지 못합니다. Amphetamine은 전원 연결 여부를 조건으로 걸 수 있는 트리거와 closed-display mode를 제공해서, 전원 연결 시에만 깨어있게 두는 요구에 맞습니다.

## 변경사항

- `users/shared/darwin/homebrew.nix`
  - `masApps`에 `"Amphetamine" = 937984704` 추가 (Amphetamine은 homebrew cask가 없고 App Store 전용)
  - 기존 `masSkip` 컨벤션대로 `/Applications/Amphetamine.app` 존재 시 `brew bundle`이 건너뛰도록 한 줄 추가

Darwin 호스트 3개(`macbook-pro`, `baleen-macbook`, `kakaostyle-jito`)가 이 파일을 공유하므로 모두 적용됩니다. `pmset`이나 activation script는 건드리지 않았습니다.

- [x] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [x] 설정 변경

## 테스트 계획

- [x] pre-commit 훅 통과 (deadnix, Fast Tests 포함)
- [x] `nix eval '.#darwinConfigurations.macbook-pro.config.homebrew.masApps'` → `{ Amphetamine = 937984704; KakaoTalk = 869223134; Magnet = 441258766; }`
- [ ] `make switch` 후 실제 설치 확인 (App Store 로그인 필요, 아직 미실행)
- [ ] 뚜껑 닫고 깨어있는지 수동 확인 (아래 수동 설정 후)

기존 테스트 중 `masApps`를 검증하는 것은 없습니다 (`tests/unit/darwin-test.nix`는 `homebrew.casks`가 비어있지 않은지만 확인). 새 테스트는 추가하지 않았습니다.

## 추가 정보

앱 설치는 선언적이지만 **동작에 필요한 설정은 GUI라 dotfiles로 관리되지 않습니다.** `make switch` 후 수동으로:

1. App Store 로그인 상태 확인 (`mas install`에 필요)
2. Amphetamine 실행 → closed-display mode 허용 활성화
3. "전원 연결 시 세션 시작" 트리거 설정
4. Apple Silicon 맥북에서는 전원 연결/분리 시 세션이 꼬이는 이슈가 있어 Amphetamine 5.3+ 의 **Power Protect** 스크립트와 설정 파일을 앱에서 별도로 설치해야 합니다

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [ ] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Amphetamine to the managed Mac App Store applications.
  * Prevented unnecessary Homebrew Bundle actions when Amphetamine is already installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->