### PR TITLE
feat(darwin): keep the lid-closed Mac awake on AC power

### DIFF
--- a/tests/unit/darwin-lid-awake-test.nix
+++ b/tests/unit/darwin-lid-awake-test.nix
@@ -1,0 +1,45 @@
+# Guards the closed-lid-on-AC daemon in users/shared/darwin/power.nix.
+#
+# Every part of it fails silently: a daemon with no RunAtLoad is installed but
+# never runs, and a script that stops gating on the power source
+# keeps the machine awake on battery -- the failure mode being a MacBook cooking
+# itself in a bag. Nothing here surfaces at switch time, so assert on the
+# rendered daemon.
+{
+  pkgs,
+  lib,
+  self,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  daemons = self.darwinConfigurations.kakaostyle-jito.config.launchd.daemons;
+  daemon = daemons.lid-awake-on-ac or null;
+  script = if daemon == null then "" else daemon.script;
+in
+{
+  platforms = [ "darwin" ];
+  value = {
+    daemon-declared = helpers.assertTest "lid awake daemon declared" (
+      daemon != null
+    ) "launchd.daemons.lid-awake-on-ac is what keeps the lid-closed machine awake on AC";
+
+    toggles-disablesleep =
+      helpers.assertTest "toggles pmset disablesleep" (lib.hasInfix "pmset -a disablesleep" script)
+        "disablesleep is the only setting that suppresses clamshell sleep; nothing else in pmset substitutes for it";
+
+    gated-on-ac-power =
+      helpers.assertTest "gated on AC power" (lib.hasInfix "AC Power" script)
+        "without the power-source check the machine also stays awake on battery with the lid shut";
+
+    actually-runs =
+      helpers.assertTest "runs at load and stays running"
+        (daemon != null && daemon.serviceConfig.RunAtLoad == true && daemon.serviceConfig.KeepAlive == true)
+        "without RunAtLoad the daemon never starts, and without KeepAlive a dead pslog stream is never restarted";
+
+    event-driven =
+      helpers.assertTest "waits on power source events" (lib.hasInfix "pmset -g pslog" script)
+        "the daemon is meant to block on the pslog stream; falling back to polling wakes the CPU on a timer forever";
+  };
+}

--- a/users/shared/darwin/default.nix
+++ b/users/shared/darwin/default.nix
@@ -4,6 +4,7 @@
 # - Performance optimizations (UI, input, memory)
 # - Developer-friendly interface (Dock, Finder, Trackpad)
 # - Homebrew integration for GUI apps (homebrew.nix)
+# - Closed-lid wake while on AC power (power.nix)
 # - Automated app cleanup and keyboard config (scripts.nix)
 # - Korean keyboard support with cmd+shift+space
 
@@ -22,6 +23,7 @@ in
 {
   imports = [
     ./homebrew.nix
+    ./power.nix
     ./scripts.nix
   ];
 

--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -81,7 +81,6 @@ in
     masApps = {
       "Magnet" = 441258766; # Window management tool with multi-monitor support
       "KakaoTalk" = 869223134; # Communication platform (if needed)
-      "Amphetamine" = 937984704; # Keeps the machine awake with the lid closed
     };
 
     # mas discovers installed App Store apps through Spotlight. Keep existing
@@ -90,7 +89,6 @@ in
       masSkip = [
         ("869223134" if File.directory?("/Applications/KakaoTalk.app")),
         ("441258766" if File.directory?("/Applications/Magnet.app")),
-        ("937984704" if File.directory?("/Applications/Amphetamine.app")),
       ].compact
       ENV["HOMEBREW_BUNDLE_MAS_SKIP"] = [ENV["HOMEBREW_BUNDLE_MAS_SKIP"], *masSkip].compact.join(" ")
     '';

--- a/users/shared/darwin/power.nix
+++ b/users/shared/darwin/power.nix
@@ -1,0 +1,56 @@
+# macOS Power Management
+#
+# Keeps the machine awake with the lid closed while the power adapter is
+# connected, and lets it sleep normally on battery.
+#
+# The only knob that suppresses clamshell sleep is pmset's undocumented
+# `disablesleep`, and it is system-wide: `pmset -c disablesleep 1` stores
+# `SleepDisabled` under `SystemPowerSettings` in
+# /Library/Preferences/com.apple.PowerManagement.plist, so the -c/-b/-a
+# power-source flag is ignored. A single declarative value therefore cannot mean
+# "AC only" -- something has to follow the power source and toggle it, which is
+# what this daemon does.
+#
+# `pmset -g pslog` blocks until the power source changes and flushes per line
+# even when piped, so the daemon sits idle on a read instead of polling, and
+# reacts in about a second rather than within a poll window. It also prints the
+# current state right after registering, which is what performs the initial
+# reconcile at load.
+
+_:
+
+{
+  launchd.daemons.lid-awake-on-ac = {
+    script = ''
+      reconcile() {
+        if /usr/bin/pmset -g ps | /usr/bin/grep -q "AC Power"; then
+          want=1
+        else
+          want=0
+        fi
+
+        # Absent from `pmset -g` until it has been set once; treat that as 0.
+        current=$(/usr/bin/pmset -g | /usr/bin/awk '/SleepDisabled/ { print $2 }')
+        [ -n "$current" ] || current=0
+
+        if [ "$current" != "$want" ]; then
+          /usr/bin/pmset -a disablesleep "$want"
+        fi
+      }
+
+      # Reconcile on every line rather than only on "Now drawing from": the
+      # toggle is idempotent, so an extra check costs two pmset reads, while a
+      # missed transition leaves the machine awake on battery.
+      /usr/bin/pmset -g pslog | while IFS= read -r _; do
+        reconcile
+      done
+    '';
+
+    serviceConfig = {
+      RunAtLoad = true;
+      # The daemon is the pslog stream; if pmset ever exits, restart it.
+      KeepAlive = true;
+      StandardErrorPath = "/var/log/lid-awake-on-ac.log";
+    };
+  };
+}


### PR DESCRIPTION
## 요약

맥북 뚜껑을 닫아도 전원 어댑터가 연결돼 있는 동안은 깨어 있게 만듭니다. 배터리로 돌아가면 평소처럼 잠듭니다. Amphetamine 앱 설치(#1382) 대신 launchd 데몬으로 처리합니다.

클램셸 sleep을 막는 유일한 수단은 pmset의 비공개 설정 `disablesleep`이고, 이건 **전역** 설정입니다. `pmset -c disablesleep 1`을 실행해도 값이 `/Library/Preferences/com.apple.PowerManagement.plist`의 `SystemPowerSettings`에 저장되며 `-c`/`-b`/`-a` 플래그는 무시됩니다(실기 확인). 즉 "AC일 때만"은 선언적 값 하나로 표현할 수 없어서, 전원 소스를 따라가며 토글하는 주체가 필요합니다.

데몬은 `pmset -g pslog`에 블록해서 대기합니다. pslog는 파이프로 넘겨도 라인 단위로 flush 되므로 폴링 없이 이벤트가 오는 즉시(약 1초) 반응하고, 대기 중에는 비용이 없습니다.

## 변경사항

- [x] 기능 추가/수정
- [x] 테스트 추가/수정

- `users/shared/darwin/power.nix` (신규): `launchd.daemons.lid-awake-on-ac` — AC면 `disablesleep 1`, 배터리면 `0`. `RunAtLoad` + `KeepAlive`
- `users/shared/darwin/default.nix`: import 추가
- `users/shared/darwin/homebrew.nix`: Amphetamine masApp 제거 (어느 머신에도 설치된 적 없음)
- `tests/unit/darwin-lid-awake-test.nix` (신규): 데몬 선언, AC 게이트, `disablesleep` 토글, `RunAtLoad`+`KeepAlive`, pslog 이벤트 대기 — 5개 어서션

## 테스트 계획

- [x] `nix build .#darwinConfigurations.kakaostyle-jito.system` 통과, plist 생성 확인
- [x] 신규 unit 어서션 5개 모두 PASS
- [x] pre-commit 훅 통과
- [x] 로컬에서 수동 테스트 완료

수동 검증:

- 배터리 상태에서 `SleepDisabled=1`로 만든 뒤 생성된 스크립트 실행 → `0`으로 복귀, 재실행도 no-op (idempotent)
- pmset 스텁으로 AC 상태 시뮬레이션 → `pmset -a disablesleep 1` 호출 확인
- `make switch` 후 라이브: 데몬이 PID를 가진 채 `pmset -g pslog`에 대기 중, AC 연결 상태에서 `SleepDisabled 1`

## 추가 정보

폴링(`StartInterval`) 버전으로 먼저 만들었다가, pslog가 파이프에서도 라인 단위로 flush 된다는 걸 실측하고 이벤트 기반으로 교체했습니다.

남은 검증: 어댑터를 실제로 뽑았을 때 `SleepDisabled`가 `0`으로 떨어지는지 라이브 확인 (스크립트 로직 자체는 위에서 검증됨).