### PR TITLE
feat(wt): use repository-local worktree paths

### DIFF
--- a/tests/integration/herdr-test.nix
+++ b/tests/integration/herdr-test.nix
@@ -43,10 +43,9 @@ in
     }
   ) "Herdr should use the selected tmux-compatible bindings";
 
-  herdr-config-uses-shared-worktree-root =
-    helpers.assertTest "herdr-config-uses-shared-worktree-root"
-      (parsedConfig ? worktrees && parsedConfig.worktrees.directory == "~/worktrees")
-      "Herdr should create worktrees under ~/worktrees";
+  herdr-config-does-not-set-worktree-root =
+    helpers.assertTest "herdr-config-does-not-set-worktree-root" (!(parsedConfig ? worktrees))
+      "Herdr config should not maintain a global worktree root";
 
   herdr-config-valid = pkgs.runCommand "herdr-config-valid" { } ''
     export HOME="$TMPDIR"

--- a/tests/unit/wt-existing-worktree-test.nix
+++ b/tests/unit/wt-existing-worktree-test.nix
@@ -45,18 +45,25 @@ in
       "wt should capture the parent Herdr workspace id"
     )
 
-    (helpers.assertTest "wt-opens-worktree-through-herdr" (lib.hasInfix "herdr worktree open" wtScript)
-      "wt should open the created worktree through Herdr"
+    (helpers.assertTest "wt-opens-existing-worktree-through-herdr"
+      (lib.hasInfix "herdr worktree open" wtScript)
+      "wt should open an already existing worktree through Herdr"
     )
+
+    (helpers.assertTest "wt-creates-worktree-through-herdr" (
+      lib.hasInfix "herdr worktree create" wtScript
+      && lib.hasInfix ''--branch "$branch"'' wtScript
+      && lib.hasInfix ''--base "$base_branch"'' wtScript
+    ) "wt should create a new worktree through Herdr when running in a Herdr pane")
 
     (helpers.assertTest "wt-passes-parent-workspace"
       (lib.hasInfix ''--workspace "$herdr_workspace"'' wtScript)
       "wt should pass the parent workspace to Herdr"
     )
 
-    (helpers.assertTest "wt-opens-herdr-before-cd"
+    (helpers.assertTest "wt-passes-path-to-herdr-create"
       (lib.hasInfix ''--path "$worktree_dir" --focus'' wtScript)
-      "wt should open the Herdr worktree before changing the shell directory"
+      "wt should pass the explicit worktree path to Herdr"
     )
 
     (helpers.assertTest "wt-resolves-herdr-source-workspace" (

--- a/tests/unit/wt-hook-consistency-test.nix
+++ b/tests/unit/wt-hook-consistency-test.nix
@@ -19,16 +19,13 @@ in
 {
   platforms = [ "any" ];
   value = helpers.testSuite "wt-hook-consistency" [
-    (helpers.assertTest "hook-uses-shared-worktrees-dir" (lib.hasInfix "$HOME/worktrees" hookScript)
-      "hook should place worktrees under ~/worktrees/"
+    (helpers.assertTest "hook-uses-repository-worktrees-dir"
+      (lib.hasInfix "$REPO_ROOT/.worktrees/" hookScript)
+      "hook should place worktrees under <repo>/.worktrees/"
     )
 
-    (helpers.assertTest "hook-uses-repo-name" (lib.hasInfix "basename \"$REPO_ROOT\"" hookScript)
-      "hook should include the repository name in the worktree path"
-    )
-
-    (helpers.assertTest "wt-uses-shared-worktrees-dir" (lib.hasInfix "\${HOME}/worktrees" wtScript)
-      "wt should use the same shared worktree root as the hook"
+    (helpers.assertTest "wt-uses-repository-worktrees-dir" (lib.hasInfix ".worktrees/" wtScript)
+      "wt should use the same repository-local worktree root as the hook"
     )
 
     (helpers.assertTest "hook-resolves-main-root" (lib.hasInfix "worktree list" hookScript)

--- a/tests/unit/wt-numbering-test.nix
+++ b/tests/unit/wt-numbering-test.nix
@@ -1,5 +1,5 @@
 # tests/unit/wt-numbering-test.nix
-# Verify wt _sanitize_branch places worktrees in the shared home worktree root.
+# Verify wt _sanitize_branch places worktrees in the repository-local .worktrees root.
 {
   inputs,
   system,
@@ -16,14 +16,15 @@ in
 {
   platforms = [ "any" ];
   value = helpers.testSuite "wt-worktree-path" [
-    (helpers.assertTest "wt-builds-shared-worktree-path" (
-      lib.hasInfix "worktrees/" wtScript
-      && lib.hasInfix "repo_name" wtScript
+    (helpers.assertTest "wt-builds-repository-worktree-path" (
+      lib.hasInfix ".worktrees/" wtScript
+      && lib.hasInfix "repo_root" wtScript
       && lib.hasInfix "1//\\//-" wtScript
-    ) "wt _sanitize_branch should build ~/worktrees/<repo>/<branch> paths")
+    ) "wt _sanitize_branch should build <repo>/.worktrees/<branch> paths")
 
-    (helpers.assertTest "wt-derives-repo-name" (lib.hasInfix "basename \"$repo_root\"" wtScript)
-      "wt should use the main repository directory name in the worktree path"
+    (helpers.assertTest "wt-resolves-main-repository-root"
+      (lib.hasInfix "git worktree list --porcelain" wtScript)
+      "wt should use the main repository root in the worktree path"
     )
   ];
 }

--- a/tests/unit/wt-subcommands-test.nix
+++ b/tests/unit/wt-subcommands-test.nix
@@ -31,9 +31,10 @@ in
       (lib.hasInfix "/nix/var/nix/gcroots/auto" wtScript)
       "wt ls should list worktrees machine-wide via nix-direnv gc-roots, not just the current repo"
     )
-    (helpers.assertTest "wt-ls-scans-shared-worktree-root" (lib.hasInfix (
-      ''"'' + "$HOME" + ''"/worktrees/*/*/.direnv/*''
-    ) wtScript) "wt ls should recognize worktrees under ~/worktrees/<repo>/<branch>")
+    (helpers.assertTest "wt-ls-scans-repository-worktree-roots"
+      (lib.hasInfix ''"$_gc_target" == */.worktrees/*/.direnv/*'' wtScript)
+      "wt ls should recognize worktrees under any repository's .worktrees directory"
+    )
     (helpers.assertTest "wt-rm-subcommand" (lib.hasInfix "rm)" wtScript)
       "wt should handle an rm subcommand"
     )

--- a/users/shared/programs/.config/claude/setup-worktree.sh
+++ b/users/shared/programs/.config/claude/setup-worktree.sh
@@ -2,7 +2,7 @@
 # WorktreeCreate hook: create the worktree where wt() would put it.
 #
 # Mirrors the path rule in users/shared/programs/zsh/wt.nix:
-#   $HOME/worktrees/<repo>/<branch with / replaced by ->
+#   <repo_root>/.worktrees/<branch with / replaced by ->
 # The hook runs under bash and cannot call the zsh wt function, so the rule
 # lives in two places; tests/unit/wt-hook-consistency-test.nix pins them
 # together.
@@ -29,10 +29,9 @@ fi
 # nest a new one underneath it.
 REPO_ROOT=$(git -C "$CWD" worktree list --porcelain | sed -n 's/^worktree //p' | head -1)
 
-REPO_NAME=$(basename "$REPO_ROOT")
-DIR="$HOME/worktrees/$REPO_NAME/${NAME//\//-}"
+DIR="$REPO_ROOT/.worktrees/${NAME//\//-}"
 
-mkdir -p "$(dirname "$DIR")"
+mkdir -p "$REPO_ROOT/.worktrees"
 
 if git -C "$CWD" rev-parse --verify main > /dev/null 2>&1; then
   BASE="main"

--- a/users/shared/programs/herdr.nix
+++ b/users/shared/programs/herdr.nix
@@ -21,9 +21,6 @@ in
       channel = "stable"
       version_check = false
 
-      [worktrees]
-      directory = "~/worktrees"
-
       [keys]
       prefix = "ctrl+a"
       detach = "prefix+d"

--- a/users/shared/programs/zsh/wt.nix
+++ b/users/shared/programs/zsh/wt.nix
@@ -179,7 +179,7 @@
         # symlink takes ~5s with hundreds of roots.
         local _gc_target _wt_dir
         readlink /nix/var/nix/gcroots/auto/*(N@) 2>/dev/null | while IFS= read -r _gc_target; do
-          [[ "$_gc_target" == "$HOME"/worktrees/*/*/.direnv/* ]] || continue
+          [[ "$_gc_target" == */.worktrees/*/.direnv/* ]] || continue
           echo "''${_gc_target%/.direnv/*}"
         done | sort -u | while IFS= read -r _wt_dir; do
           if [[ -d "$_wt_dir" ]]; then
@@ -379,22 +379,21 @@
       herdr_workspace="$source_workspace"
     }
 
-    # Open a Git worktree in Herdr while the current workspace is still the
-    # parent repository workspace. Herdr's linked-worktree actions reject a
-    # request made after the shell has already cd-ed into the new checkout.
+    # Open an existing Git worktree in Herdr while the current workspace is
+    # still the parent repository workspace. Herdr's linked-worktree actions
+    # reject a request made after the shell has already cd-ed into the checkout.
     local _open_in_herdr() {
       local worktree_dir="$1"
       herdr worktree open --workspace "$herdr_workspace" --path "$worktree_dir" --focus >/dev/null 2>&1
     }
 
     # Helper: Sanitize branch name for directory (replace / with -)
-    # Place worktrees in a shared home directory, grouped by repository.
-    # Always resolve the repository name from the main worktree so wt works
-    # correctly from inside a worktree.
+    # Place worktrees in the repository-local .worktrees directory.
+    # Always resolve the main worktree so wt works correctly from inside a
+    # linked worktree without nesting another .worktrees directory.
     local _sanitize_branch() {
       local repo_root=$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -1)
-      local repo_name=$(basename "$repo_root")
-      echo "''${HOME}/worktrees/''${repo_name}/''${1//\//-}"
+      echo "''${repo_root}/.worktrees/''${1//\//-}"
     }
 
     # Helper: Find base branch (main or master)
@@ -461,7 +460,20 @@
       local worktree_dir="$2"
       local base_branch="$3"
 
-      if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+      if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
+        if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+          _msg "$BLUE" "Branch '$branch' already exists. Using existing branch through Herdr."
+        else
+          _msg "$GREEN" "Creating new branch '$branch' through Herdr (base: $base_branch)"
+        fi
+        herdr worktree create \
+          --workspace "$herdr_workspace" \
+          --branch "$branch" \
+          --base "$base_branch" \
+          --path "$worktree_dir" \
+          --focus \
+          2>&1
+      elif git rev-parse --verify "$branch" >/dev/null 2>&1; then
         _msg "$BLUE" "Branch '$branch' already exists. Using existing branch."
         git worktree add "$worktree_dir" "$branch" 2>&1
       else
@@ -546,11 +558,17 @@
         worktree_dir=$(_sanitize_branch "$resolved_branch")
         _check_worktree_exists "$worktree_dir" || return 1
 
-        if ! git worktree add "$worktree_dir" "$resolved_branch" >/dev/null 2>&1; then
+        local resolved_error
+        if ! resolved_error=$(_create_worktree "$resolved_branch" "$worktree_dir" "$base_branch"); then
           _error "Failed to create worktree"
+          echo "$resolved_error" >&2
           return 1
         fi
       else
+        if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" && "$branch_existed" -eq 0 && "$create_error" == *'"code":"worktree_open_failed"'* ]]; then
+          git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
+          git branch -D "$branch_name" >/dev/null 2>&1 || true
+        fi
         _error "Failed to create worktree"
         echo "$create_error" >&2
         return 1
@@ -559,14 +577,7 @@
 
     _msg "$GREEN" "Worktree created: $worktree_dir"
     if [[ "''${HERDR_ENV:-}" == "1" && -n "$herdr_workspace" ]]; then
-      _open_in_herdr "$worktree_dir" || {
-        git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || true
-        if [[ "$branch_existed" -eq 0 ]]; then
-          git branch -D "$branch_name" >/dev/null 2>&1 || true
-        fi
-        _error "Failed to open worktree in Herdr"
-        return 1
-      }
+      :
     else
       cd "$worktree_dir"
     fi


### PR DESCRIPTION
## Summary

- create wt and Claude worktrees under each repository's `.worktrees` directory
- route Herdr-created worktrees through an explicit `--path`
- remove the global Herdr worktree directory setting

## Validation

- focused wt and Herdr checks passed
- Herdr config check passed
- formatter, shellcheck, diff check, and pre-commit hooks passed
- push-time All Tests hook passed
- `make test-build` is blocked by the unrelated existing kakaostyle-jito hammerspoon assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktrees are now created and recognized in each repository’s local `.worktrees/` directory.
  * Worktree creation integrates more consistently with Herdr workspaces, including branch and base-branch handling.
  * Worktree listings now detect repository-local worktrees across repositories.

* **Bug Fixes**
  * Improved handling of failed worktree openings, including cleanup of newly created worktrees and branches.
  * Improved branch-conflict retries and creation error reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->