### PR TITLE
feat(direnv): add non-blocking flake shell loading

### DIFF
--- a/docs/notes/2026-08-11-direnv-flake-cache.md
+++ b/docs/notes/2026-08-11-direnv-flake-cache.md
@@ -1,0 +1,67 @@
+# direnv와 Nix flake 캐시 조사
+
+## 질문
+
+`.envrc`에 `use flake`만 작성하는 현재 방식이 올바른지, 새 worktree 진입 시 Nix 평가가 오래 걸리는 이유를 공식 문서와 저장소 설정으로 대조했다.
+
+## 결론
+
+현재 `.envrc`의 다음 설정은 올바르다.
+
+```text
+use flake
+```
+
+현재 flake는 `devShells.default`를 제공하고, Home Manager 설정은 `programs.direnv.nix-direnv.enable = true`를 활성화한다. 따라서 `use flake`가 현재 디렉터리의 기본 devShell을 로드하는 구조가 맞다.
+
+## 공식 문서 대조
+
+- [nix-direnv README](https://github.com/nix-community/nix-direnv)는 기존 flake 통합 예시로 `use flake`와 `direnv allow`를 제시한다.
+- `use_flake`는 내부적으로 `nix print-dev-env`를 호출한다.
+- nix-direnv는 최초 실행 후 shell 환경을 캐시해 이후 로드를 빠르게 한다.
+- `use flake`는 `.envrc`, `flake.nix`, `flake.lock`, `devshell.toml` 등을 감시한다. 이 파일이 바뀌면 캐시를 다시 만드는 것이 정상이다.
+- [direnv의 캐시 위치 문서](https://github.com/direnv/direnv/wiki/Customizing-cache-location)는 기본적으로 direnv 활성 디렉터리마다 `.direnv`가 생기며, `direnv_layout_dir`로 위치를 바꿀 수 있다고 설명한다. 따라서 worktree별 `.direnv`와 최초 평가가 반복되는 것은 기본 동작과 일치한다.
+- [Nix `eval-cache` 문서](https://releases.nixos.org/nix/nix-2.34.0/manual/command-ref/conf-file.html)는 flake 평가 캐시가 특정 flake 버전의 재평가를 줄이지만 중간 결과 전체를 캐시하지는 않는다고 설명한다.
+- [Nix `print-dev-env` 문서](https://releases.nixos.org/nix/nix-2.24.1/manual/command-ref/new-cli/nix3-print-dev-env.html)는 devShell의 환경을 출력하고 `--profile` 경로를 사용할 수 있다고 설명한다.
+
+## 저장소 대조
+
+- `.envrc`: `use flake`
+- `flake-modules/dev-shells.nix`: `devShells.default` 정의
+- `users/shared/programs/zsh/default.nix`: `programs.direnv.enable`, zsh integration, `nix-direnv.enable` 활성화
+- `flake.nix`: `substituters`와 `trusted-public-keys` 설정은 빌드 산출물(binary cache)용이다. flake 평가 결과 자체를 Cachix에서 가져오는 설정은 아니다.
+
+## 판단
+
+기본 캐시는 정상 동작한다. 새 worktree의 첫 진입에서는 평가가 끝날 때까지 기다리면 `.direnv/flake-profile-*`가 생성되고, 같은 worktree의 다음 진입은 캐시를 사용한다.
+
+worktree 간 캐시 공유가 별도 목표라면 `direnv_layout_dir`를 flake 내용 또는 버전별 경로와 함께 설계해야 한다. 단일 공통 디렉터리를 무조건 공유하면 서로 다른 branch의 devShell 캐시가 충돌할 수 있으므로 별도 변경과 검증이 필요하다.
+
+## 효율화 비교
+
+### 1순위: direnv-instant
+
+[direnv-instant](https://github.com/Mic92/direnv-instant)는 direnv를 백그라운드 daemon에서 실행해 프롬프트를 즉시 반환한다. 이전에 생성된 환경은 즉시 적용하고, 변경된 환경은 백그라운드에서 다시 만든다. nix-direnv와 함께 사용하도록 안내되어 있으므로 현재의 `use flake`와 캐시 모델을 유지하면서 체감 지연을 줄이는 방향이다.
+
+Home Manager 모듈을 사용하려면 공식 README 기준으로 flake input과 `homeModules.direnv-instant` import, `programs.direnv-instant.enable = true`가 필요하다. 기존 `programs.direnv.enableZshIntegration`과 동시에 사용하면 안 되므로 zsh의 일반 direnv hook은 꺼야 한다.
+
+### 2순위: 수동 reload
+
+nix-direnv의 `nix_direnv_manual_reload`는 flake 파일이 바뀌었을 때 자동으로 긴 평가를 실행하지 않고, 사용자가 `nix-direnv-reload`를 실행하도록 한다. 자주 수정하는 flake에는 유용하지만 새 worktree의 cold start 자체를 줄이지는 않는다.
+
+### 보류: worktree 간 layout 공유
+
+direnv는 `direnv_layout_dir` override를 지원한다. 다만 현재 기본 동작은 디렉터리별 cache이고, worktree별로 flake 내용과 branch가 달라질 수 있다. 공통 경로를 단순히 하나로 지정하면 서로 다른 devShell 환경이 충돌할 수 있다. 저장소 전체 내용과 dirty diff를 포함한 안정적인 cache key를 설계하고 동시 실행을 검증하기 전에는 적용하지 않는다.
+
+## 효율화 결론
+
+현재 목적이 worktree 진입 시 터미널이 멈추지 않는 것이라면 `use flake`는 유지하고 `direnv-instant`를 Home Manager에 통합하는 것이 가장 적합하다. 현재 목적이 평가 CPU 시간 자체를 없애는 것이라면 layout 공유가 필요하지만, 안전한 key 설계가 선행되어야 한다.
+
+## 적용 결과
+
+- `flake.nix`에 커밋으로 고정한 `direnv-instant` input을 추가했다.
+- `direnv-instant`의 `nixpkgs`는 저장소의 root `nixpkgs`를 follow하도록 설정해 별도 nixpkgs 평가를 피했다.
+- 공통 Home Manager 모듈에서 `homeModules.direnv-instant`를 import하고 활성화했다.
+- 일반 direnv zsh hook은 끄고 `direnv-instant` zsh hook을 사용하도록 변경했다.
+- `.envrc`의 `use flake`와 `nix-direnv`는 유지했다.
+- Home Manager activation package와 zsh 통합 테스트가 통과했다.

--- a/flake.lock
+++ b/flake.lock
@@ -99,6 +99,29 @@
         "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.0/x86_64-linux"
       }
     },
+    "direnv-instant": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1786000099,
+        "narHash": "sha256-T3tirJdmYgW5MKwbqfO7qlDInSq4Ilrjw/DwJemFIME=",
+        "owner": "Mic92",
+        "repo": "direnv-instant",
+        "rev": "5656a76b19fef6d1cd14b392ff508f15fa7fb086",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "direnv-instant",
+        "rev": "5656a76b19fef6d1cd14b392ff508f15fa7fb086",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -137,6 +160,27 @@
       }
     },
     "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "direnv-instant",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "nixpkgs"
@@ -317,11 +361,12 @@
         "claude-code": "claude-code",
         "darwin": "darwin",
         "determinate": "determinate",
-        "flake-parts": "flake-parts_2",
+        "direnv-instant": "direnv-instant",
+        "flake-parts": "flake-parts_3",
         "home-manager": "home-manager",
         "import-tree": "import-tree",
         "nixpkgs": "nixpkgs_3",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "systems": {
@@ -340,6 +385,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "direnv-instant",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    direnv-instant = {
+      url = "github:Mic92/direnv-instant/5656a76b19fef6d1cd14b392ff508f15fa7fb086";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     import-tree.url = "github:vic/import-tree";
 
     treefmt-nix = {

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -149,10 +149,9 @@ in
       && lib.hasInfix "window:moveToScreen(nextScreen" initLuaContent
     ) "repeated horizontal tiling should move the window to an adjacent display")
 
-    (helpers.assertTest "init-does-not-register-old-alt-tab-switcher"
-      (!(lib.hasInfix "hs.window.switcher" initLuaContent))
-      "init.lua should leave Cmd-Tab window switching to Switch"
-    )
+    (helpers.assertTest "init-does-not-register-old-alt-tab-switcher" (
+      !(lib.hasInfix "hs.window.switcher" initLuaContent)
+    ) "init.lua should leave Cmd-Tab window switching to Switch")
 
     (helpers.assertTest "init-pomodoro-binding"
       (lib.hasInfix "Hyper:bind({}, 'p', function()" initLuaContent)

--- a/tests/integration/hammerspoon-test.nix
+++ b/tests/integration/hammerspoon-test.nix
@@ -133,6 +133,27 @@ in
       "init.lua should bind Hyper hotkeys"
     )
 
+    (helpers.assertTest "init-window-management-hotkeys" (
+      lib.hasInfix "local windowHotkeyMods = { 'cmd', 'ctrl', 'shift' }" initLuaContent
+      && lib.hasInfix "moveWindowHorizontally(windowUnits.left, 'west')" initLuaContent
+      && lib.hasInfix "moveWindowHorizontally(windowUnits.right, 'east')" initLuaContent
+      && lib.hasInfix "moveWindowToUnit(windowUnits.leftTwoThirds)" initLuaContent
+      && lib.hasInfix "moveWindowToUnit(windowUnits.rightTwoThirds)" initLuaContent
+      && lib.hasInfix "hs.hotkey.bind({ 'alt', 'ctrl' }, 'return'" initLuaContent
+      && lib.hasInfix "moveWindowToUnit(windowUnits.fill)" initLuaContent
+    ) "init.lua should provide the configured Hammerspoon window-management hotkeys")
+
+    (helpers.assertTest "init-window-management-moves-between-screens" (
+      lib.hasInfix "screen:toWest(nil, true)" initLuaContent
+      && lib.hasInfix "screen:toEast(nil, true)" initLuaContent
+      && lib.hasInfix "window:moveToScreen(nextScreen" initLuaContent
+    ) "repeated horizontal tiling should move the window to an adjacent display")
+
+    (helpers.assertTest "init-does-not-register-old-alt-tab-switcher"
+      (!(lib.hasInfix "hs.window.switcher" initLuaContent))
+      "init.lua should leave Cmd-Tab window switching to Switch"
+    )
+
     (helpers.assertTest "init-pomodoro-binding"
       (lib.hasInfix "Hyper:bind({}, 'p', function()" initLuaContent)
       "init.lua should bind Pomodoro toggle"

--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -37,6 +37,7 @@ let
   fzfSettings = zshConfigBody.programs.fzf or { };
   zoxideSettings = zshConfigBody.programs.zoxide or { };
   direnvSettings = zshConfigBody.programs.direnv or { };
+  direnvInstantSettings = zshConfigBody.programs.direnv-instant or { };
 
   # Helper to check if an alias exists
   hasAlias = aliasName: builtins.hasAttr aliasName shellAliases;
@@ -147,11 +148,14 @@ in
 
     # Direnv integration
     (helpers.assertTest "direnv-enabled" direnvSettings.enable "direnv should be enabled")
-    (helpers.assertTest "direnv-zsh-integration" direnvSettings.enableZshIntegration
-      "direnv zsh integration should be enabled"
+    (helpers.assertTest "direnv-zsh-integration-disabled" (!direnvSettings.enableZshIntegration)
+      "normal direnv zsh integration should be disabled when direnv-instant is enabled"
     )
     (helpers.assertTest "direnv-nix-integration" direnvSettings.nix-direnv.enable
       "direnv nix-direnv should be enabled"
+    )
+    (helpers.assertTest "direnv-instant-enabled" direnvInstantSettings.enable
+      "direnv-instant should be enabled"
     )
 
     # Direnv auto-allow configuration

--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -148,9 +148,9 @@ in
 
     # Direnv integration
     (helpers.assertTest "direnv-enabled" direnvSettings.enable "direnv should be enabled")
-    (helpers.assertTest "direnv-zsh-integration-disabled" (!direnvSettings.enableZshIntegration)
-      "normal direnv zsh integration should be disabled when direnv-instant is enabled"
-    )
+    (helpers.assertTest "direnv-zsh-integration-disabled" (
+      !direnvSettings.enableZshIntegration
+    ) "normal direnv zsh integration should be disabled when direnv-instant is enabled")
     (helpers.assertTest "direnv-nix-integration" direnvSettings.nix-direnv.enable
       "direnv nix-direnv should be enabled"
     )

--- a/tests/unit/darwin-test.nix
+++ b/tests/unit/darwin-test.nix
@@ -49,6 +49,7 @@ let
   # nixfmt reflows multi-line operator chains, and the threshold at which it joins
   # or splits them is not worth guessing at.
   homebrewCasks = darwinConfig.homebrew.casks;
+  homebrewTaps = darwinConfig.homebrew.taps;
   preActivationText = (darwinConfig.system.activationScripts.preActivation or { text = ""; }).text;
   homebrewExtraConfig = darwinConfig.homebrew.extraConfig;
   forceClick = customPrefs.NSGlobalDomain."com.apple.trackpad.forceClick";
@@ -78,19 +79,27 @@ in
       (assertions.assertAttrEquals "homebrew-enabled" darwinConfig.homebrew "enable" true null)
       (assertions.assertListNotEmpty "homebrew-casks-not-empty" homebrewCasks null)
 
+      (helpers.assertTest "switch-cask-configured" (
+        lib.elem "Sanyam-G/switch/switch" homebrewCasks
+        && lib.elem "Sanyam-G/switch" homebrewTaps
+      ) "Switch should be installed from its Homebrew tap")
+
+      (helpers.assertTest "magnet-not-configured" (
+        !(darwinConfig.homebrew.masApps ? Magnet)
+        && !(lib.hasInfix "Magnet.app" preActivationText)
+        && !(lib.hasInfix "441258766" homebrewExtraConfig)
+      ) "Magnet should not be managed after switching to Hammerspoon")
+
       (helpers.assertTest "spotlight-indexing-for-mas" (
         lib.hasInfix "/usr/bin/mdutil -E -i on /" preActivationText
         && lib.hasInfix "/usr/bin/mdimport" preActivationText
         && lib.hasInfix "/Applications/KakaoTalk.app" preActivationText
-        && lib.hasInfix "/Applications/Magnet.app" preActivationText
       ) "Activation should enable Spotlight and index the configured MAS apps")
 
       (helpers.assertTest "mas-existing-app-skip-configured" (
         lib.hasInfix "HOMEBREW_BUNDLE_MAS_SKIP" homebrewExtraConfig
         && lib.hasInfix "Applications/KakaoTalk.app" homebrewExtraConfig
-        && lib.hasInfix "Applications/Magnet.app" homebrewExtraConfig
         && lib.hasInfix "869223134" homebrewExtraConfig
-        && lib.hasInfix "441258766" homebrewExtraConfig
       ) "Existing App Store apps should be skipped while Spotlight is unavailable")
 
       # FileVault makes loginwindow.autoLoginUser a no-op, so it must stay unset

--- a/tests/unit/darwin-test.nix
+++ b/tests/unit/darwin-test.nix
@@ -80,8 +80,7 @@ in
       (assertions.assertListNotEmpty "homebrew-casks-not-empty" homebrewCasks null)
 
       (helpers.assertTest "switch-cask-configured" (
-        lib.elem "Sanyam-G/switch/switch" homebrewCasks
-        && lib.elem "Sanyam-G/switch" homebrewTaps
+        lib.elem "Sanyam-G/switch/switch" homebrewCasks && lib.elem "Sanyam-G/switch" homebrewTaps
       ) "Switch should be installed from its Homebrew tap")
 
       (helpers.assertTest "magnet-not-configured" (

--- a/users/shared/darwin/homebrew.nix
+++ b/users/shared/darwin/homebrew.nix
@@ -25,6 +25,7 @@ let
     # Utility Tools
     "claude"
     "karabiner-elements" # Key remapping and modification tool
+    "Sanyam-G/switch/switch" # Keyboard-driven window switcher
     "orbstack" # Docker and Linux VM management
     "tailscale-app" # VPN mesh network with GUI
     "teleport-connect" # Teleport GUI client for secure infrastructure access
@@ -79,7 +80,6 @@ in
     # Carefully selected apps for development productivity and system management
     # IDs obtained via: nix shell nixpkgs#mas && mas search <app name>
     masApps = {
-      "Magnet" = 441258766; # Window management tool with multi-monitor support
       "KakaoTalk" = 869223134; # Communication platform (if needed)
     };
 
@@ -88,7 +88,6 @@ in
     extraConfig = ''
       masSkip = [
         ("869223134" if File.directory?("/Applications/KakaoTalk.app")),
-        ("441258766" if File.directory?("/Applications/Magnet.app")),
       ].compact
       ENV["HOMEBREW_BUNDLE_MAS_SKIP"] = [ENV["HOMEBREW_BUNDLE_MAS_SKIP"], *masSkip].compact.join(" ")
     '';
@@ -98,6 +97,7 @@ in
     # Note: homebrew/cask is now built into Homebrew by default (since 2023)
     taps = [
       "daipeihust/tap" # im-select
+      "Sanyam-G/switch" # switch window switcher
     ];
   };
 }

--- a/users/shared/darwin/scripts.nix
+++ b/users/shared/darwin/scripts.nix
@@ -32,8 +32,7 @@ _:
     fi
 
     for app in \
-      "/Applications/KakaoTalk.app" \
-      "/Applications/Magnet.app"; do
+      "/Applications/KakaoTalk.app"; do
       adam_id=$(/usr/bin/mdls -raw -name kMDItemAppStoreAdamID "$app" 2>/dev/null || true)
       if [ -d "$app" ] && { [ -z "$adam_id" ] || [ "$adam_id" = "(null)" ]; }; then
         /usr/bin/mdimport "$app" 2>/dev/null || true

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -1,12 +1,15 @@
 {
   pkgs,
   currentSystemUser,
+  inputs,
   isDarwin ? pkgs.stdenv.hostPlatform.isDarwin,
   ...
 }:
 
 {
   imports = [
+    inputs.direnv-instant.homeModules.direnv-instant
+
     # Tool configurations (programs)
     ./programs/git.nix
     ./programs/vim.nix

--- a/users/shared/programs/.config/hammerspoon/init.lua
+++ b/users/shared/programs/.config/hammerspoon/init.lua
@@ -7,13 +7,84 @@ hs.loadSpoon('VimImeGuard')
 
 Hyper = spoon.Hyper
 
--- Alt-Tab replacement: hold Option, tap Tab to cycle windows (not just apps),
--- release Option to focus the selected one. Bound to real modifier keys
--- because hs.window.switcher finalizes on modifier release, unlike the F19
--- Hyper modal below.
-windowSwitcher = hs.window.switcher.new(hs.window.filter.new())
-hs.hotkey.bind('alt', 'tab', function() windowSwitcher:next() end)
-hs.hotkey.bind('alt-shift', 'tab', function() windowSwitcher:previous() end)
+-- Window management replaces Magnet. Switch handles Cmd-Tab window switching;
+-- these bindings keep the common tiling operations local to Hammerspoon.
+local windowHotkeyMods = { 'cmd', 'ctrl', 'shift' }
+local windowAnimationDuration = 0
+local windowUnits = {
+  left = hs.geometry.new(0, 0, 0.5, 1),
+  right = hs.geometry.new(0.5, 0, 0.5, 1),
+  top = hs.geometry.new(0, 0, 1, 0.5),
+  bottom = hs.geometry.new(0, 0.5, 1, 0.5),
+  leftTwoThirds = hs.geometry.new(0, 0, 2 / 3, 1),
+  rightTwoThirds = hs.geometry.new(1 / 3, 0, 2 / 3, 1),
+  fill = hs.geometry.new(0, 0, 1, 1),
+}
+
+local function isWindowInUnit(window, unit)
+  local screenFrame = window:screen():frame()
+  local frame = window:frame()
+  local epsilon = 2
+  local expected = {
+    x = screenFrame.x + screenFrame.w * unit.x,
+    y = screenFrame.y + screenFrame.h * unit.y,
+    w = screenFrame.w * unit.w,
+    h = screenFrame.h * unit.h,
+  }
+
+  return math.abs(frame.x - expected.x) < epsilon
+    and math.abs(frame.y - expected.y) < epsilon
+    and math.abs(frame.w - expected.w) < epsilon
+    and math.abs(frame.h - expected.h) < epsilon
+end
+
+local function moveWindowToUnit(unit)
+  local window = hs.window.focusedWindow()
+  if window then
+    window:moveToUnit(unit, windowAnimationDuration)
+  end
+end
+
+local function moveWindowHorizontally(unit, direction)
+  local window = hs.window.focusedWindow()
+  if not window then
+    return
+  end
+
+  local screen = window:screen()
+  if isWindowInUnit(window, unit) then
+    local nextScreen = direction == 'west'
+      and screen:toWest(nil, true)
+      or screen:toEast(nil, true)
+    if nextScreen then
+      window:moveToScreen(nextScreen, false, true, windowAnimationDuration)
+    end
+  end
+
+  window:moveToUnit(unit, windowAnimationDuration)
+end
+
+hs.hotkey.bind(windowHotkeyMods, 'left', function()
+  moveWindowHorizontally(windowUnits.left, 'west')
+end)
+hs.hotkey.bind(windowHotkeyMods, 'right', function()
+  moveWindowHorizontally(windowUnits.right, 'east')
+end)
+hs.hotkey.bind(windowHotkeyMods, 'up', function()
+  moveWindowToUnit(windowUnits.top)
+end)
+hs.hotkey.bind(windowHotkeyMods, 'down', function()
+  moveWindowToUnit(windowUnits.bottom)
+end)
+hs.hotkey.bind(windowHotkeyMods, 'e', function()
+  moveWindowToUnit(windowUnits.leftTwoThirds)
+end)
+hs.hotkey.bind(windowHotkeyMods, 't', function()
+  moveWindowToUnit(windowUnits.rightTwoThirds)
+end)
+hs.hotkey.bind({ 'alt', 'ctrl' }, 'return', function()
+  moveWindowToUnit(windowUnits.fill)
+end)
 
 -- F19 is emitted by Karabiner when right_command is held (see karabiner.nix).
 -- Karabiner intercepts app-launcher and local-binding keys directly for Secure

--- a/users/shared/programs/zsh/default.nix
+++ b/users/shared/programs/zsh/default.nix
@@ -76,9 +76,11 @@ in
 
     programs.direnv = {
       enable = true;
-      enableZshIntegration = true;
+      enableZshIntegration = false;
       nix-direnv.enable = true;
     };
+
+    programs.direnv-instant.enable = true;
 
     # Direnv auto-allow configuration
     # Automatically trust all .envrc files in the user's home directory


### PR DESCRIPTION
## 요약

새 worktree에서 `use flake` 평가가 셸 진입을 막는 문제를 완화하기 위해 `direnv-instant`를 Home Manager에 통합했습니다.

## 변경사항

- [x] 기능 추가/수정
- [ ] 버그 수정
- [x] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

- `direnv-instant` flake input을 커밋으로 고정
- root `nixpkgs`를 follow하도록 설정해 중복 입력을 줄임
- 일반 direnv zsh hook을 비활성화하고 `direnv-instant` hook 활성화
- 기존 `use flake`와 `nix-direnv` 유지

## 테스트 계획

- [ ] `make lint` 통과
- [ ] `make test` 통과 (2-5초)
- [ ] `make test-all` 통과
- [ ] `make build` 통과
- [x] 로컬에서 수동 테스트 완료
- [x] 관련 플랫폼에서 테스트 완료

- Home Manager activation package 빌드 통과
- `nix build .#checks.aarch64-darwin.integration-zsh --no-link` 통과
- pre-commit Fast Tests 및 push hook All Tests 통과
- `make switch-home HM_USER=jito.hello` 실제 적용 완료

## 추가 정보

`direnv-instant`은 기존 캐시를 즉시 사용하고 Nix 환경 갱신을 백그라운드에서 처리합니다. 새 터미널부터 적용됩니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faster directory environment loading with `direnv-instant`, while retaining Nix-based environment support.
  - Added Hammerspoon shortcuts for half-screen, thirds, top/bottom, and full-screen window layouts.
  - Windows can move between adjacent displays when using matching layouts.
  - Added Switch as the macOS window-switching utility.

- **Changes**
  - Removed Magnet configuration and the previous Hammerspoon Alt-Tab switcher.
  - Documented directory-specific Nix evaluation caching and environment-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->