### PR TITLE
fix(darwin): avoid single-item activation loop

### DIFF
--- a/tests/unit/darwin-test.nix
+++ b/tests/unit/darwin-test.nix
@@ -95,6 +95,10 @@ in
         && lib.hasInfix "/Applications/KakaoTalk.app" preActivationText
       ) "Activation should enable Spotlight and index the configured MAS apps")
 
+      (helpers.assertTest "spotlight-single-app-has-no-loop" (
+        !(lib.hasInfix "for app in" preActivationText)
+      ) "A single configured MAS app should not use a single-iteration loop")
+
       (helpers.assertTest "mas-existing-app-skip-configured" (
         lib.hasInfix "HOMEBREW_BUNDLE_MAS_SKIP" homebrewExtraConfig
         && lib.hasInfix "Applications/KakaoTalk.app" homebrewExtraConfig

--- a/users/shared/darwin/scripts.nix
+++ b/users/shared/darwin/scripts.nix
@@ -31,13 +31,11 @@ _:
       /usr/bin/mdutil -E -i on / >&2 || true
     fi
 
-    for app in \
-      "/Applications/KakaoTalk.app"; do
-      adam_id=$(/usr/bin/mdls -raw -name kMDItemAppStoreAdamID "$app" 2>/dev/null || true)
-      if [ -d "$app" ] && { [ -z "$adam_id" ] || [ "$adam_id" = "(null)" ]; }; then
-        /usr/bin/mdimport "$app" 2>/dev/null || true
-      fi
-    done
+    app="/Applications/KakaoTalk.app"
+    adam_id=$(/usr/bin/mdls -raw -name kMDItemAppStoreAdamID "$app" 2>/dev/null || true)
+    if [ -d "$app" ] && { [ -z "$adam_id" ] || [ "$adam_id" = "(null)" ]; }; then
+      /usr/bin/mdimport "$app" 2>/dev/null || true
+    fi
   '';
 
   system.activationScripts.postActivation.text = ''


### PR DESCRIPTION
## 요약

KakaoTalk 단일 앱 Spotlight 처리 루프가 ShellCheck SC2043 경고를 빌드 실패로 만들어 `darwin-rebuild switch`를 중단시키는 문제를 수정합니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정
- [x] 설정 변경
- KakaoTalk 경로를 단일 앱 직접 처리로 변경
- 단일 항목 반복문이 다시 추가되지 않도록 Darwin assertion 추가

## 테스트 계획

- [x] 커밋 pre-commit hooks 통과
- [x] `nix build .#checks.aarch64-darwin.unit-darwin`
- [x] `nix build .#darwinConfigurations.macbook-pro.system`
- [x] 실제 `darwin-rebuild switch` 적용
- [x] treefmt 및 `git diff --check`
- [ ] `make test-all`

## 추가 정보

전체 `all-assertions`는 이번 변경과 무관한 기존 `kakaostyle-jito disables hammerspoon` assertion에서 실패했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS App Store metadata handling for KakaoTalk.
  - Spotlight activation now works correctly when only one App Store application is configured.
  - Missing application metadata continues to be handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->