### PR TITLE
test: assert VS Code stays a nix package on Linux

### DIFF
--- a/tests/unit/vscode-linux-source-test.nix
+++ b/tests/unit/vscode-linux-source-test.nix
@@ -1,0 +1,44 @@
+# On Linux, VS Code stays a nix package.
+#
+# The Darwin half of this invariant lives in vscode-source-test.nix, which can
+# only run on Darwin because it reads `self.darwinConfigurations`. Platform
+# gating keys off the system the check runs on, so the Linux half has to be its
+# own file: `users/shared/packages/dev.nix` branches on
+# `stdenv.hostPlatform.isDarwin`, and dropping `vscode` from the non-Darwin
+# branch would otherwise be caught by nothing.
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  homeOptionsModule = {
+    options.home.packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+    };
+  };
+
+  devPackages =
+    (lib.evalModules {
+      modules = [
+        homeOptionsModule
+        (import ../../users/shared/packages/dev.nix)
+        { _module.args = { inherit pkgs; }; }
+        { config.modules.packages.dev.enable = true; }
+      ];
+    }).config.home.packages;
+
+  devPackageNames = map (pkg: pkg.pname or pkg.name or "") devPackages;
+in
+{
+  platforms = [ "linux" ];
+  value = helpers.assertTest "vscode from nix on linux" (builtins.any (name: name == "vscode")
+    devPackageNames
+  ) "VS Code should stay in home.packages on Linux: only Darwin moves it to Homebrew";
+}


### PR DESCRIPTION
## 요약

[#1403 의 CodeRabbit 리뷰 지적](https://github.com/baleen37/dotfiles/pull/1403#discussion_r2600000000) 대응입니다.

#1403 은 Darwin 에서 VS Code 를 Homebrew 로 옮기고 그것을 단정했지만, `users/shared/packages/dev.nix` 의 **Linux 분기에는 검증이 없었습니다.** non-Darwin 분기에서 `vscode` 가 빠져도 아무 테스트가 잡지 못하는 상태였습니다.

## 변경사항

- [x] 테스트 추가/수정

- `tests/unit/vscode-linux-source-test.nix` 신규 — Linux 에서 `vscode` 가 `home.packages` 에 있는지 단정

### 왜 별 파일인가

`platforms` 게이팅은 **체크가 실행되는 시스템**을 기준으로 동작합니다 (`tests/lib/platform-helpers.nix`). 기존 `vscode-source-test.nix` 는 `self.darwinConfigurations` 를 읽어 `platforms = [ "darwin" ]` 이 고정이므로, 같은 파일에 Linux 단정을 넣으면 Darwin 에서만 평가되어 무의미합니다. Linux 에서 발견되려면 `platforms = [ "linux" ]` 인 별 파일이어야 합니다.

## 테스트 계획

- [x] `make lint` 통과
- [x] 플랫폼 게이팅 확인 — Darwin 체크 목록에는 없고, Linux 에만 등록됨:
  ```
  aarch64-darwin: unit-vscode-source-vscode-from-homebrew-cask
                  unit-vscode-source-vscode-not-from-nix-store
  x86_64-linux:   unit-vscode-linux-source
  ```
- [x] 두 Linux 아키텍처 모두 통과 (`test-vscode-from-nix-on-linux-pass`)
- [x] **역검증** — `dev.nix` 의 Linux 분기에서 `vscode` 를 빼면 `test-vscode-from-nix-on-linux-fail` 로 바뀜을 확인. 잡으려던 회귀를 실제로 잡습니다

`dev.nix` 는 역검증 후 원복했고 `main` 과 차이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)