### PR TITLE
test: build the homeModules override from a probe host

### DIFF
--- a/tests/unit/host-overrides-test.nix
+++ b/tests/unit/host-overrides-test.nix
@@ -2,44 +2,57 @@
 #
 # Verifies that a host's `homeModules` attribute actually overrides
 # `modules.programs.*.enable` in the resulting darwin configuration.
+#
+# The override is exercised through a throwaway host built here rather than
+# through an entry in flake-modules/hosts.nix. An earlier version of this test
+# asserted that kakaostyle-jito had hammerspoon disabled; #1273 deliberately
+# re-enabled it and dropped the override, leaving the test failing on a stale
+# expectation. Building the host locally keeps the feature covered without
+# pinning any real host's configuration.
 
 {
+  inputs,
   pkgs,
   lib,
-  self,
   ...
 }:
 
 let
   helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
 
-  # The kakaostyle-jito host should have hammerspoon disabled via homeModules.
-  jitoCfg = self.darwinConfigurations.kakaostyle-jito.config;
+  overlays = import ../../lib/overlays.nix { inherit inputs; };
 
-  hammerspoonEnabledOnJito =
-    jitoCfg.home-manager.users."jito.hello".modules.programs.hammerspoon.enable;
+  # `self` is only used for flake-level references that this configuration does
+  # not reach, so the probe host does not need one.
+  mkSystem = import ../../lib/mksystem.nix {
+    inherit inputs overlays;
+    self = null;
+  };
 
-  # By contrast, macbook-pro (no override) should keep the module-level default
-  # (`pkgs.stdenv.hostPlatform.isDarwin` == true on aarch64-darwin).
-  # Note: macbook-pro resolves to the current USER (jito.hello in this env).
-  proCfg = self.darwinConfigurations.macbook-pro.config;
+  probeUser = "probeuser";
 
-  macbookProUsers = builtins.attrNames proCfg.home-manager.users;
-  macbookProUser = builtins.head macbookProUsers;
+  hammerspoonEnabledWith =
+    homeModules:
+    (mkSystem "host-overrides-probe" {
+      system = "aarch64-darwin";
+      user = probeUser;
+      darwin = true;
+      inherit homeModules;
+      machineModules = [ ../../machines/darwin/common.nix ];
+    }).config.home-manager.users.${probeUser}.modules.programs.hammerspoon.enable;
 
-  hammerspoonEnabledOnPro =
-    proCfg.home-manager.users.${macbookProUser}.modules.programs.hammerspoon.enable;
-
+  overridden = hammerspoonEnabledWith { modules.programs.hammerspoon.enable = false; };
+  default = hammerspoonEnabledWith { };
 in
 {
   platforms = [ "darwin" ];
   value = {
-    override-disables-hammerspoon = helpers.assertTest "kakaostyle-jito disables hammerspoon" (
-      hammerspoonEnabledOnJito == false
-    ) "host.homeModules must override modules.programs.hammerspoon.enable to false on kakaostyle-jito";
+    home-modules-override-reaches-config = helpers.assertTest "homeModules override reaches config" (
+      overridden == false
+    ) "host.homeModules must override modules.programs.hammerspoon.enable to false";
 
-    default-keeps-hammerspoon = helpers.assertTest "macbook-pro keeps hammerspoon default" (
-      hammerspoonEnabledOnPro == true
-    ) "macbook-pro (no override) must keep hammerspoon default=true (Darwin)";
+    no-override-keeps-module-default =
+      helpers.assertTest "no override keeps module default" (default == true)
+        "a host without homeModules must keep the module default (hammerspoon defaults to true on Darwin)";
   };
 }


### PR DESCRIPTION
## 요약

`main` 에서 상시 실패하던 `unit-host-overrides-override-disables-hammerspoon` 을 고칩니다. 이 하나 때문에 `make test-build` 전체가 막혀 있었습니다.

### 원인

테스트는 `kakaostyle-jito` 가 `homeModules` 로 hammerspoon 을 끈 상태라고 단정했습니다. 이 단정과 `homeModules` 기능은 #1271 에서 같이 들어왔습니다.

그런데 #1273 이 **의도적으로** 이 호스트의 hammerspoon/karabiner 를 다시 켜면서 오버라이드를 지웠습니다. 커밋 메시지 그대로입니다:

> `feat(hosts): enable hammerspoon/karabiner on kakaostyle-jito`
> hyper+s Slack 바인딩이 이 머신에서도 동작하도록 비활성화 해제

설정 변경은 맞고, 테스트만 낡은 기대를 붙들고 남았습니다. **설정이 옳고 테스트가 틀린 경우입니다.**

### 왜 이렇게 고쳤나

지금 `homeModules` 를 쓰는 호스트가 하나도 없습니다. 특정 호스트의 값에 테스트를 묶어둔 게 애초에 썩은 원인이라, 같은 방식으로 다시 묶으면 또 같은 일이 납니다.

테스트 안에서 일회용 호스트를 `mksystem` 으로 직접 만들어 양방향을 단정합니다:

- `homeModules` 로 오버라이드하면 config 에 반영됨 → `false`
- `homeModules` 가 없으면 모듈 기본값 유지 → `true`

생산 호스트 설정에 의존하지 않으므로, `hosts.nix` 를 누가 어떻게 바꿔도 이 테스트는 깨지지 않고 `homeModules` 기능이 망가질 때만 실패합니다.

## 변경사항

- [x] 버그 수정
- [x] 테스트 추가/수정

- `tests/unit/host-overrides-test.nix` — 생산 호스트 단정 → 일회용 probe 호스트로 기능 검증

프로덕션 코드 변경 없음. 테스트 파일 1개만 수정했습니다.

## 테스트 계획

- [x] `make lint` 통과
- [x] `make test` 통과
- [x] **`make test-build` 통과 — `✅ 114 assertion checks passed`** (이 PR 전에는 이 테스트 때문에 실패)
- [x] 신규 단정 2개 통과:
  ```
  ✅ homeModules override reaches config: PASS
  ✅ no override keeps module default: PASS
  ```
- [x] **역검증** — `lib/mksystem.nix` 에서 `homeModules` 전달을 제거하면 `test-homeModules-override-reaches-config-fail` 로 바뀜을 확인. 잡으려던 회귀를 실제로 잡습니다. `mksystem.nix` 는 원복했고 `main` 과 차이 없습니다

## 추가 정보

`self = null` 로 probe 호스트를 만듭니다. `self` 는 이 설정이 도달하지 않는 flake 수준 참조에만 쓰여서 평가에 문제가 없고, 주석으로 남겨뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved host override test coverage using a temporary Darwin host configuration.
  - Verified that custom `homeModules` overrides can disable Hammerspoon.
  - Confirmed that an empty override preserves the default Hammerspoon module.
  - Removed outdated host configuration lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->