### PR TITLE
chore: replace gemini-cli with antigravity-cli

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1787111413,
-        "narHash": "sha256-sFosWtq21eHGJRnTc/hvf4M1obRgLEUMNm/IzllkHMA=",
+        "lastModified": 1787172299,
+        "narHash": "sha256-PShzS87awOlE5XWkxUGBd/58/F+AtE2ZMgFffKj4r8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afe3d8ac4395617bdcdac9f188ac8717a062e014",
+        "rev": "07e1d92cdc0ed416cfa11ff3ca40d17e61cfba7a",
         "type": "github"
       },
       "original": {

--- a/users/shared/packages/ai.nix
+++ b/users/shared/packages/ai.nix
@@ -14,7 +14,7 @@ in
     home.packages = with pkgs; [
       claude-code
       opencode
-      gemini-cli
+      antigravity-cli
     ];
   };
 }


### PR DESCRIPTION
## Why

nixpkgs marked `gemini-cli` with `meta.problems.removal`, so evaluating it now fails:

> Package 'gemini-cli-0.47.0' ... has the following problem: removal: Unpaid tier and Google AI Pro/Ultra users: Gemini CLI was replaced by Antigravity CLI.

Google is [transitioning Gemini CLI to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).

## What

- `users/shared/packages/ai.nix`: `gemini-cli` → `antigravity-cli` (1.1.13)
- `flake.lock`: bump nixpkgs (the pinned rev predated the removal marker)

`antigravity-cli` supports all three configured systems: `aarch64-darwin`, `x86_64-linux`, `aarch64-linux`.

## Heads up

The binary is now **`agy`**, not `gemini`. Nothing in the repo aliased the old name, so no other changes were needed, but the muscle-memory command changes.

## Verification

- `darwin-rebuild switch` applied on `kakaostyle-jito`; `agy --version` → `1.1.13`, `gemini` no longer on PATH
- home-manager profile has `bin/agy`, no `bin/gemini`
- `checks.aarch64-darwin.all-assertions`: 118 assertion checks passed
- `checks.aarch64-darwin.treefmt`: 211 files, 0 changed
- pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the Gemini CLI with the Antigravity CLI in the available AI tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->