### PR TITLE
fix(darwin): repair VS Code LaunchServices ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ build-switch: switch
 switch:
 ifeq ($(UNAME), Darwin)
 	$(NIX_ENV) sudo -H $(DARWIN_REBUILD) switch --flake ".#$(NIXNAME)"
+	$(MAKE) audit-darwin-vscode
 else ifeq ($(IS_NIXOS), true)
 	$(NIX_ENV_FULL) $(SUDO_NIX) run "nixpkgs#nixos-rebuild" -- switch --flake ".#${NIXNAME}"
 else
@@ -49,13 +50,25 @@ else
 endif
 
 # Rebuild only Home Manager configuration (faster for user config changes)
+# This target does not install Homebrew casks; full `make switch` owns that path.
 # Usage: make switch-home
 switch-home:
 	@echo "Rebuilding Home Manager configuration for $(HM_USER)..."
 ifeq ($(UNAME), Darwin)
 	$(NIX_ENV) $(NIX) run 'github:nix-community/home-manager' -- switch --flake ".#$(HM_USER)"
+	$(MAKE) audit-darwin-vscode
 else
 	$(NIX_ENV_FULL) $(NIX) run 'github:nix-community/home-manager' -- switch --flake ".#$(HM_USER)"
+endif
+
+# Inspect the LaunchServices owner of the Homebrew-managed VS Code app without
+# changing app bundles, Home Manager generations, or Nix profiles.
+audit-darwin-vscode:
+ifeq ($(UNAME), Darwin)
+	@/bin/sh "$(MAKEFILE_DIR)/users/shared/darwin/vscode-launchservices.sh" audit
+else
+	@echo "audit-darwin-vscode is only supported on Darwin" >&2
+	@exit 1
 endif
 
 test:
@@ -240,7 +253,7 @@ wsl:
 	 nix build ".#nixosConfigurations.wsl.config.system.build.installer"
 
 # Phony targets
-.PHONY: build-switch switch switch-home test test-build test-all test-containers fmt-diff format cache vm/bootstrap0 vm/bootstrap vm/copy vm/switch vm/secrets secrets/backup secrets/restore install-hooks lint update
+.PHONY: build-switch switch switch-home audit-darwin-vscode test test-build test-all test-containers fmt-diff format cache vm/bootstrap0 vm/bootstrap vm/copy vm/switch vm/secrets secrets/backup secrets/restore install-hooks lint update
 
 install-hooks:
 	pre-commit install --hook-type pre-commit --hook-type pre-push

--- a/tests/integration/home-manager-test.nix
+++ b/tests/integration/home-manager-test.nix
@@ -43,6 +43,7 @@ let
     lib.any (path: lib.hasSuffix suffix path) importedPaths;
 
   expectedModules = [
+    "darwin/vscode-launchservices.nix"
     "programs/git.nix"
     "programs/vim.nix"
     "programs/zsh"

--- a/tests/integration/vscode-launchservices-test.nix
+++ b/tests/integration/vscode-launchservices-test.nix
@@ -1,0 +1,144 @@
+# LaunchServices repair is tested with fake tools so the check never mutates the
+# host's LaunchServices database or installed applications.
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+  scriptPath = ../../users/shared/darwin/vscode-launchservices.sh;
+  scriptExists = builtins.pathExists scriptPath;
+
+  behaviorTest =
+    if !scriptExists then
+      helpers.assertTest "vscode-launchservices-script-exists" false
+        "users/shared/darwin/vscode-launchservices.sh must exist"
+    else
+      pkgs.runCommand "test-vscode-launchservices-behavior"
+        {
+          nativeBuildInputs = [ pkgs.bash ];
+        }
+        ''
+          set -euo pipefail
+
+          test_root="$TMPDIR/vscode-launchservices"
+          app="$test_root/Applications/Visual Studio Code.app"
+          profile="$test_root/profile"
+          state="$test_root/launchservices-state"
+          log="$test_root/launchservices.log"
+          fake_bin="$test_root/bin"
+          mkdir -p "$app/Contents" "$fake_bin" "$profile"
+
+          cat > "$app/Contents/Info.plist" <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.microsoft.VSCode</string>
+          </dict>
+          </plist>
+          EOF
+
+          {
+            printf '%s\n' '/nix/store/fake-vscode/Applications/Visual Studio Code.app'
+            printf '%s\n' "$app"
+          } > "$state"
+
+          cat > "$fake_bin/lsregister" <<'EOF'
+          #!/bin/sh
+          set -eu
+          state="$VSCODE_TEST_STATE"
+          log="$VSCODE_TEST_LOG"
+          case "$1" in
+            -dump)
+              while IFS= read -r path; do
+                printf 'path: %s\nidentifier: com.microsoft.VSCode\n' "$path"
+              done < "$state"
+              ;;
+            -u)
+              printf 'unregister %s\n' "$2" >> "$log"
+              grep -Fvx "$2" "$state" > "$state.tmp" || true
+              mv "$state.tmp" "$state"
+              ;;
+            -f)
+              printf 'register %s\n' "$2" >> "$log"
+              if ! grep -Fqx "$2" "$state"; then
+                printf '%s\n' "$2" >> "$state"
+              fi
+              ;;
+            *)
+              echo "unexpected lsregister args: $*" >&2
+              exit 2
+              ;;
+          esac
+          EOF
+          chmod +x "$fake_bin/lsregister"
+
+          cat > "$fake_bin/mdimport" <<'EOF'
+          #!/bin/sh
+          set -eu
+          printf 'mdimport %s\n' "$2" >> "$VSCODE_TEST_LOG"
+          EOF
+          chmod +x "$fake_bin/mdimport"
+
+          cat > "$fake_bin/osascript" <<'EOF'
+          #!/bin/sh
+          set -eu
+          first_path="$(sed -n '1p' "$VSCODE_TEST_STATE")"
+          printf '%s\n' "$first_path"
+          EOF
+          chmod +x "$fake_bin/osascript"
+
+          export VSCODE_TEST_STATE="$state"
+          export VSCODE_TEST_LOG="$log"
+          export VSCODE_LSREGISTER="$fake_bin/lsregister"
+          export VSCODE_MDIMPORT="$fake_bin/mdimport"
+          export VSCODE_OSASCRIPT="$fake_bin/osascript"
+          export VSCODE_CANONICAL_APP="$app"
+
+          ${pkgs.bash}/bin/bash ${scriptPath} audit > "$test_root/audit-before" || test "$?" -eq 1
+          grep -Fq 'representative=/nix/store/fake-vscode/Applications/Visual Studio Code.app' \
+            "$test_root/audit-before"
+          grep -Fq 'nix_registered=/nix/store/fake-vscode/Applications/Visual Studio Code.app' \
+            "$test_root/audit-before"
+
+          ${pkgs.bash}/bin/bash ${scriptPath} repair
+          test -d "$app"
+          test -d "$profile"
+          ! grep -Fq '/nix/store/fake-vscode/Applications/Visual Studio Code.app' "$state"
+          grep -Fqx "$app" "$state"
+          grep -Fqx "unregister /nix/store/fake-vscode/Applications/Visual Studio Code.app" "$log"
+          grep -Fqx "register $app" "$log"
+          grep -Fqx "mdimport $app" "$log"
+
+          cp "$state" "$test_root/state-after-first-repair"
+          ${pkgs.bash}/bin/bash ${scriptPath} repair
+          cmp -s "$test_root/state-after-first-repair" "$state"
+          test "$(grep -Fc 'unregister /nix/store/fake-vscode/Applications/Visual Studio Code.app' "$log")" -eq 1
+
+          ${pkgs.bash}/bin/bash ${scriptPath} audit > "$test_root/audit-after"
+          grep -Fq "representative=$app" "$test_root/audit-after"
+          grep -Fq 'nix_registered=none' "$test_root/audit-after"
+          test -e "$app/Contents/Info.plist"
+          test -e "$profile"
+
+          sed 's/com.microsoft.VSCode/com.example.Wrong/' "$app/Contents/Info.plist" \
+            > "$app/Contents/Info.plist.wrong"
+          mv "$app/Contents/Info.plist.wrong" "$app/Contents/Info.plist"
+          if ${pkgs.bash}/bin/bash ${scriptPath} repair > "$test_root/wrong-bundle.log" 2>&1; then
+            echo "repair unexpectedly accepted a non-VS Code bundle ID" >&2
+            exit 1
+          fi
+          grep -Fq 'expected com.microsoft.VSCode' "$test_root/wrong-bundle.log"
+          test -e "$app/Contents/Info.plist"
+          test -e "$profile"
+          touch "$out"
+        '';
+in
+{
+  platforms = [ "darwin" ];
+  value = behaviorTest;
+}

--- a/tests/unit/darwin-activation-test.nix
+++ b/tests/unit/darwin-activation-test.nix
@@ -32,6 +32,11 @@ in
       helpers.assertTest "app cleanup script runs" (lib.hasInfix "GarageBand.app" activation.script.text)
         "App cleanup should be spliced into the assembled activation script";
 
+    vscode-launchservices-repair-runs =
+      helpers.assertTest "VS Code LaunchServices repair runs"
+        (lib.hasInfix "vscode-launchservices.sh" activation.script.text)
+        "Darwin activation should run the shared VS Code LaunchServices repair adapter";
+
     # The regression itself: a segment name nix-darwin does not know about.
     no-orphaned-custom-segments = helpers.assertTest "no orphaned custom activation segments" (
       !(activation ? enableRemoteLogin)

--- a/tests/unit/makefile-switch-commands-test.nix
+++ b/tests/unit/makefile-switch-commands-test.nix
@@ -70,6 +70,15 @@ pkgs.runCommand "makefile-switch-commands-test"
     echo "$switchHome" | grep -q '\.#\$(HM_USER)' \
       || fail "switch-home must select Home Manager profiles with HM_USER"
 
+    echo "$switchHome" | grep -q 'Homebrew' \
+      || fail "switch-home must document that Homebrew is handled only by make switch"
+    if echo "$switchHome" | grep -Eiq '(^|[[:space:]])brew([[:space:]]|$)|darwin-rebuild'; then
+      fail "switch-home must not install Homebrew or run Darwin system activation"
+    fi
+
+    echo "$darwinSwitch" | grep -q 'audit-darwin-vscode' \
+      || fail "make switch must audit VS Code LaunchServices after Darwin activation"
+
     if grep -q -- '--impure' "$makefileSource"; then
       fail "Makefile must evaluate flakes purely"
     fi

--- a/tests/unit/vscode-source-test.nix
+++ b/tests/unit/vscode-source-test.nix
@@ -39,6 +39,16 @@ let
   devPackageNames = map (pkg: pkg.pname or pkg.name or "") devPackages;
   hasNixVscode = builtins.any (name: name == "vscode") devPackageNames;
 
+  darwinSystemPackages =
+    self.darwinConfigurations.kakaostyle-jito.config.home-manager.users."jito.hello".home.packages;
+  darwinSystemPackageNames = map (pkg: pkg.pname or pkg.name or "") darwinSystemPackages;
+  standaloneHomePackages = self.homeConfigurations."jito.hello".config.home.packages;
+  standaloneHomePackageNames = map (pkg: pkg.pname or pkg.name or "") standaloneHomePackages;
+  hasDarwinSystemVscode = builtins.any (name: name == "vscode") darwinSystemPackageNames;
+  hasStandaloneHomeVscode = builtins.any (name: name == "vscode") standaloneHomePackageNames;
+  standaloneActivation =
+    self.homeConfigurations."jito.hello".config.home.activation.vscodeLaunchServices;
+
   # nix-darwin normalises `homebrew.casks` entries into attrsets, so compare names.
   caskNames = map (cask: cask.name) self.darwinConfigurations.kakaostyle-jito.config.homebrew.casks;
 in
@@ -52,5 +62,21 @@ in
     vscode-from-homebrew-cask =
       helpers.assertTest "vscode from homebrew cask" (builtins.elem "visual-studio-code" caskNames)
         "VS Code should be installed via the visual-studio-code Homebrew cask on Darwin";
+
+    vscode-not-in-darwin-system-home-packages =
+      helpers.assertTest "vscode not in Darwin system Home Manager packages" (!hasDarwinSystemVscode)
+        "Darwin system Home Manager must not add VS Code from the nix store";
+
+    vscode-not-in-standalone-home-packages =
+      helpers.assertTest "vscode not in standalone Home Manager packages" (!hasStandaloneHomeVscode)
+        "standalone make switch-home Home Manager must not add VS Code from the nix store";
+
+    vscode-launchservices-standalone-activation =
+      helpers.assertTest "VS Code LaunchServices repair in standalone activation"
+        (
+          lib.hasInfix "vscode-launchservices.sh" standaloneActivation.data
+          && lib.hasInfix "repair" standaloneActivation.data
+        )
+        "standalone Home Manager activation must run the shared VS Code LaunchServices repair adapter";
   };
 }

--- a/users/shared/darwin/scripts.nix
+++ b/users/shared/darwin/scripts.nix
@@ -39,6 +39,10 @@ _:
   '';
 
   system.activationScripts.postActivation.text = ''
+    # Homebrew runs before postActivation. Reconcile LaunchServices after the
+    # cask has installed the canonical app in /Applications.
+    /bin/sh ${./vscode-launchservices.sh} repair
+
     # Remote Login (SSH)
     # Enables macOS Remote Login so the machine accepts incoming SSH connections.
     # nix-darwin has no dedicated option for this, so we toggle it via systemsetup.

--- a/users/shared/darwin/vscode-launchservices.nix
+++ b/users/shared/darwin/vscode-launchservices.nix
@@ -1,0 +1,14 @@
+{
+  isDarwin ? pkgs.stdenv.hostPlatform.isDarwin,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  config = lib.mkIf isDarwin {
+    home.activation.vscodeLaunchServices = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      ${pkgs.bash}/bin/bash ${./vscode-launchservices.sh} repair
+    '';
+  };
+}

--- a/users/shared/darwin/vscode-launchservices.sh
+++ b/users/shared/darwin/vscode-launchservices.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+set -eu
+
+bundle_id='com.microsoft.VSCode'
+canonical_app="${VSCODE_CANONICAL_APP:-/Applications/Visual Studio Code.app}"
+lsregister="${VSCODE_LSREGISTER:-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister}"
+mdimport="${VSCODE_MDIMPORT:-/usr/bin/mdimport}"
+osascript="${VSCODE_OSASCRIPT:-/usr/bin/osascript}"
+plutil="${VSCODE_PLUTIL:-/usr/bin/plutil}"
+
+fail() {
+  echo "vscode-launchservices: $*" >&2
+  exit 1
+}
+
+canonical_bundle_id() {
+  "$plutil" -extract CFBundleIdentifier raw "$canonical_app/Contents/Info.plist"
+}
+
+validate_canonical_app() {
+  [ -d "$canonical_app" ] || fail "canonical app is missing: $canonical_app"
+  [ -f "$canonical_app/Contents/Info.plist" ] \
+    || fail "canonical app has no Info.plist: $canonical_app"
+
+  actual_bundle_id="$(canonical_bundle_id)" \
+    || fail "cannot read canonical app bundle ID: $canonical_app"
+  [ "$actual_bundle_id" = "$bundle_id" ] \
+    || fail "canonical app bundle ID is $actual_bundle_id, expected $bundle_id: $canonical_app"
+}
+
+bundle_paths() {
+  launchservices_dump="$("$lsregister" -dump 2> /dev/null)" \
+    || fail "cannot read LaunchServices database"
+
+  printf '%s\n' "$launchservices_dump" | awk -v expected_id="$bundle_id" '
+    /^path:[[:space:]]+/ {
+      path = $0
+      sub(/^[^:]*:[[:space:]]*/, "", path)
+      sub(/[[:space:]]+\(0x[[:xdigit:]]+\)$/, "", path)
+      next
+    }
+
+    /^identifier:[[:space:]]+/ {
+      identifier = $0
+      sub(/^[^:]*:[[:space:]]*/, "", identifier)
+      if (identifier == expected_id && path != "") print path
+      path = ""
+    }
+  '
+}
+
+nix_bundle_paths_from() {
+  printf '%s\n' "$1" | awk '/^\/nix\/store\/.*\/Visual Studio Code[.]app$/ { print }'
+}
+
+nix_bundle_paths() {
+  paths="$(bundle_paths)" || return 1
+  nix_bundle_paths_from "$paths"
+}
+
+representative_app() {
+  "$osascript" -e 'POSIX path of (path to application id "com.microsoft.VSCode")' 2> /dev/null || true
+}
+
+audit() {
+  validate_canonical_app
+
+  representative="$(representative_app)"
+  representative="${representative%/}"
+  paths="$(bundle_paths)"
+  nix_paths="$(nix_bundle_paths_from "$paths")"
+
+  if printf '%s\n' "$paths" | grep -Fqx "$canonical_app"; then
+    canonical_registered=yes
+  else
+    canonical_registered=no
+  fi
+
+  printf 'canonical=%s\n' "$canonical_app"
+  printf 'canonical_bundle_id=%s\n' "$bundle_id"
+  printf 'canonical_registered=%s\n' "$canonical_registered"
+  if [ -n "$representative" ]; then
+    printf 'representative=%s\n' "$representative"
+  else
+    printf 'representative=none\n'
+  fi
+  if [ -n "$nix_paths" ]; then
+    printf '%s\n' "$nix_paths" | sed 's/^/nix_registered=/'
+  else
+    printf 'nix_registered=none\n'
+  fi
+
+  [ "$representative" = "$canonical_app" ] \
+    || fail "LaunchServices representative is not the canonical app"
+  [ "$canonical_registered" = yes ] \
+    || fail "canonical app is not registered with LaunchServices"
+  [ -z "$nix_paths" ] \
+    || fail "Nix-store VS Code registrations remain"
+}
+
+repair() {
+  validate_canonical_app
+
+  nix_paths="$(nix_bundle_paths)"
+  if [ -n "$nix_paths" ]; then
+    printf '%s\n' "$nix_paths" | while IFS= read -r path; do
+      echo "vscode-launchservices: unregistering $path" >&2
+      "$lsregister" -u "$path"
+    done
+  fi
+
+  echo "vscode-launchservices: registering $canonical_app" >&2
+  "$lsregister" -f "$canonical_app"
+  echo "vscode-launchservices: refreshing Spotlight metadata for $canonical_app" >&2
+  "$mdimport" -i "$canonical_app"
+
+  audit
+}
+
+case "${1:-}" in
+  audit)
+    audit
+    ;;
+  repair)
+    repair
+    ;;
+  *)
+    fail "usage: $0 {audit|repair}"
+    ;;
+esac

--- a/users/shared/home-manager.nix
+++ b/users/shared/home-manager.nix
@@ -10,6 +10,9 @@
   imports = [
     inputs.direnv-instant.homeModules.direnv-instant
 
+    # Darwin GUI ownership and LaunchServices repair.
+    ./darwin/vscode-launchservices.nix
+
     # Tool configurations (programs)
     ./programs/git.nix
     ./programs/vim.nix


### PR DESCRIPTION
## 요약\n\nDarwin에서 Nix store의 VS Code가 LaunchServices 대표 앱으로 남아 Alfred 검색 결과를 가로채는 문제를 방지합니다.\n\n## 변경사항\n\n- Darwin Home Manager 패키지에서는 VS Code를 제외하고 Homebrew cask 소유권을 테스트\n- LaunchServices audit/repair 어댑터 추가\n- /nix/store/.../Visual Studio Code.app 등록만 해제하고 /Applications/Visual Studio Code.app를 재등록\n- Darwin system activation과 standalone Home Manager activation에 동일한 repair 경로 연결\n- make audit-darwin-vscode 추가\n- fake LaunchServices integration test로 반복 실행, bundle ID 검증, 파일/profile 보존을 검증\n\n## 테스트\n\n- pre-commit hooks 및 push hooks 전체 통과\n- git diff --check\n- sh -n, ShellCheck\n- Darwin focused Nix assertions\n- LaunchServices fake-tool integration test\n- Home Manager/source invariant tests\n- Darwin treefmt\n- 실제 Mac make audit-darwin-vscode 통과: 대표 경로 /Applications/Visual Studio Code.app, Nix 등록 없음\n\n## 참고\n\n전체 all-systems 평가에서는 현재 로컬 Nix store의 기존 zsh runtime drv 누락과 Darwin 환경의 Linux builder 부재로 aggregate 검증이 제한되어, 변경 범위의 Darwin focused checks를 기준으로 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic macOS VS Code registration repair during Home Manager activation.
  * Cleans up stale VS Code registrations and ensures the installed application is correctly registered.
  * Added commands to audit or repair VS Code LaunchServices registration manually.

* **Bug Fixes**
  * macOS switching now verifies VS Code registration after rebuilding, helping prevent launch and application-discovery issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->