### PR TITLE
fix(zsh): reset mouse tracking after ssh disconnect

### DIFF
--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -217,6 +217,17 @@ in
       "SSH_AUTH_SOCK should be configured for 1Password"
     )
 
+    # Recover terminal mouse tracking after an ungraceful SSH disconnect.
+    (helpers.assertTest "ssh-disconnect-mouse-reset" (initContentHasAll [
+      "_reset_terminal_mouse_tracking"
+      "add-zsh-hook precmd _reset_terminal_mouse_tracking"
+      "1000l"
+      "1002l"
+      "1003l"
+      "1006l"
+      "1015l"
+    ]) "zsh should clear terminal mouse tracking before showing a prompt")
+
     # Shell functions
     (helpers.assertTest "function-shell-exists" (initContentHas "shell()")
       "shell() function for nix-shell should exist"

--- a/users/shared/programs/zsh/functions.nix
+++ b/users/shared/programs/zsh/functions.nix
@@ -14,6 +14,16 @@
 # (programs.ssh module).
 
 ''
+  # Clear mouse-tracking modes left behind when a remote full-screen app exits
+  # without cleanup (for example, after an SSH connection reset).
+  _reset_terminal_mouse_tracking() {
+    [[ -t 1 ]] || return 0
+    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1015l'
+  }
+
+  autoload -Uz add-zsh-hook
+  add-zsh-hook precmd _reset_terminal_mouse_tracking
+
   # nix shortcuts
   shell() {
       nix-shell '<nixpkgs>' -A "$1"


### PR DESCRIPTION
## 요약
비정상적인 SSH 종료 뒤 로컬 Ghostty/zsh에 마우스 좌표 escape sequence가 출력되는 문제를 복구합니다.

## 변경사항
- zsh `precmd`에서 남은 마우스 추적 모드만 해제
- 기존 zsh 통합 테스트에 회귀 검증 추가

## 테스트
- `pre-commit run --all-files`
- `make test`
- `nix build '.#checks.aarch64-darwin.integration-zsh' --accept-flake-config --print-build-logs --no-link`
- 실제 새 zsh에서 hook 동작 확인

## 배포/롤백
- merge 후 `make switch-home HM_USER=jito.hello`
- 문제 시 Home Manager 이전 generation으로 rollback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Zsh now automatically resets terminal mouse-tracking modes before displaying a prompt, helping restore normal terminal behavior after interrupted remote full-screen applications.

- **Bug Fixes**
  - Prevents terminal mouse tracking from remaining enabled after an ungraceful SSH disconnect.

- **Tests**
  - Added integration coverage verifying terminal mouse-tracking modes are reset correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->