### PR TITLE
chore: remove VS Code audit make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ build-switch: switch
 switch:
 ifeq ($(UNAME), Darwin)
 	$(NIX_ENV) sudo -H $(DARWIN_REBUILD) switch --flake ".#$(NIXNAME)"
-	$(MAKE) audit-darwin-vscode
 else ifeq ($(IS_NIXOS), true)
 	$(NIX_ENV_FULL) $(SUDO_NIX) run "nixpkgs#nixos-rebuild" -- switch --flake ".#${NIXNAME}"
 else
@@ -56,19 +55,8 @@ switch-home:
 	@echo "Rebuilding Home Manager configuration for $(HM_USER)..."
 ifeq ($(UNAME), Darwin)
 	$(NIX_ENV) $(NIX) run 'github:nix-community/home-manager' -- switch --flake ".#$(HM_USER)"
-	$(MAKE) audit-darwin-vscode
 else
 	$(NIX_ENV_FULL) $(NIX) run 'github:nix-community/home-manager' -- switch --flake ".#$(HM_USER)"
-endif
-
-# Inspect the LaunchServices owner of the Homebrew-managed VS Code app without
-# changing app bundles, Home Manager generations, or Nix profiles.
-audit-darwin-vscode:
-ifeq ($(UNAME), Darwin)
-	@/bin/sh "$(MAKEFILE_DIR)/users/shared/darwin/vscode-launchservices.sh" audit
-else
-	@echo "audit-darwin-vscode is only supported on Darwin" >&2
-	@exit 1
 endif
 
 test:
@@ -253,7 +241,7 @@ wsl:
 	 nix build ".#nixosConfigurations.wsl.config.system.build.installer"
 
 # Phony targets
-.PHONY: build-switch switch switch-home audit-darwin-vscode test test-build test-all test-containers fmt-diff format cache vm/bootstrap0 vm/bootstrap vm/copy vm/switch vm/secrets secrets/backup secrets/restore install-hooks lint update
+.PHONY: build-switch switch switch-home test test-build test-all test-containers fmt-diff format cache vm/bootstrap0 vm/bootstrap vm/copy vm/switch vm/secrets secrets/backup secrets/restore install-hooks lint update
 
 install-hooks:
 	pre-commit install --hook-type pre-commit --hook-type pre-push

--- a/tests/unit/makefile-switch-commands-test.nix
+++ b/tests/unit/makefile-switch-commands-test.nix
@@ -70,14 +70,21 @@ pkgs.runCommand "makefile-switch-commands-test"
     echo "$switchHome" | grep -q '\.#\$(HM_USER)' \
       || fail "switch-home must select Home Manager profiles with HM_USER"
 
-    echo "$switchHome" | grep -q 'Homebrew' \
+    grep -q '^# This target does not install Homebrew casks; full `make switch` owns that path\.$' "$makefileSource" \
       || fail "switch-home must document that Homebrew is handled only by make switch"
     if echo "$switchHome" | grep -Eiq '(^|[[:space:]])brew([[:space:]]|$)|darwin-rebuild'; then
       fail "switch-home must not install Homebrew or run Darwin system activation"
     fi
 
-    echo "$darwinSwitch" | grep -q 'audit-darwin-vscode' \
-      || fail "make switch must audit VS Code LaunchServices after Darwin activation"
+    if echo "$darwinSwitch" | grep -q 'audit-darwin-vscode'; then
+      fail "make switch must not run a separate VS Code audit target"
+    fi
+    if echo "$switchHome" | grep -q 'audit-darwin-vscode'; then
+      fail "switch-home must not run a separate VS Code audit target"
+    fi
+    if grep -q '^audit-darwin-vscode:' "$makefileSource"; then
+      fail "Makefile must not define a separate VS Code audit target"
+    fi
 
     if grep -q -- '--impure' "$makefileSource"; then
       fail "Makefile must evaluate flakes purely"


### PR DESCRIPTION
## 변경 내용
- `make switch`와 `make switch-home`의 불필요한 VS Code audit 호출 제거
- `audit-darwin-vscode` Make 타깃과 `.PHONY` 등록 제거
- Make 동작 테스트 갱신

## 검증
- `nix build .#checks.aarch64-darwin.unit-makefile-switch-commands --accept-flake-config --show-trace`
- pre-commit Fast Tests 통과
- pre-push All Tests 통과