### PR TITLE
fix(darwin): stop Bluetooth peripherals from waking a closed lid

### DIFF
--- a/tests/unit/darwin-activation-test.nix
+++ b/tests/unit/darwin-activation-test.nix
@@ -37,6 +37,11 @@ in
         (lib.hasInfix "vscode-launchservices.sh" activation.script.text)
         "Darwin activation should run the shared VS Code LaunchServices repair adapter";
 
+    bluetooth-remote-wake-disabled-runs =
+      helpers.assertTest "bluetooth remote wake disable runs"
+        (lib.hasInfix "RemoteWakeEnabled" activation.script.text)
+        "Bluetooth remote wake must be disabled during activation, or paired input devices wake the machine from clamshell sleep on battery";
+
     # The regression itself: a segment name nix-darwin does not know about.
     no-orphaned-custom-segments = helpers.assertTest "no orphaned custom activation segments" (
       !(activation ? enableRemoteLogin)

--- a/users/shared/darwin/power.nix
+++ b/users/shared/darwin/power.nix
@@ -16,6 +16,13 @@
 # reacts in about a second rather than within a poll window. It also prints the
 # current state right after registering, which is what performs the initial
 # reconcile at load.
+#
+# Separately, Bluetooth input devices wake the machine from clamshell sleep on
+# battery. A paired trackpad nudged in a bag produced a 45s-wake / 10s-sleep
+# DarkWake loop ("due to ... wifibt ... bluetooth-pcie" in `pmset -g log`),
+# which drains the battery while the lid is shut. `RemoteWakeEnabled` is the
+# system-wide switch behind Settings > General > Sharing > Advanced, and
+# nix-darwin has no option for it, so it is written directly below.
 
 _:
 
@@ -53,4 +60,21 @@ _:
       StandardErrorPath = "/var/log/lid-awake-on-ac.log";
     };
   };
+
+  # Stop Bluetooth peripherals from waking the machine with the lid closed.
+  # The key is absent until it has been written once, so `read` failing is the
+  # unset case and is treated as "not yet disabled".
+  system.activationScripts.postActivation.text = ''
+    echo "Disabling Bluetooth remote wake..." >&2
+
+    bt_plist=/Library/Preferences/com.apple.Bluetooth
+    bt_wake=$(/usr/bin/defaults read "$bt_plist" RemoteWakeEnabled 2>/dev/null || echo 1)
+
+    if [ "$bt_wake" = "0" ]; then
+      echo "  ✓  Bluetooth remote wake already disabled" >&2
+    else
+      /usr/bin/defaults write "$bt_plist" RemoteWakeEnabled -bool false >&2 || true
+      echo "  Bluetooth remote wake disabled" >&2
+    fi
+  '';
 }


### PR DESCRIPTION
## 요약

맥북 뚜껑을 닫아도 계속 깨어나는 문제를 고칩니다. 원인은 페어링된 Bluetooth 입력 기기였습니다.

배터리 상태에서 `pmset -g log`를 보면 45초 깨고 10초 자는 DarkWake 루프가 반복됩니다:

```
DarkWake from Deep Idle [CDNP] : due to smc.70070000 wifibt SMC.OutboxNotEmpty bluetooth-pcie/ Using BATT
Entering Sleep state due to 'Maintenance Sleep' ... 9 secs
DarkWake from Deep Idle [CDNP] : due to smc.70070000 wifibt SMC.OutboxNotEmpty bluetooth-pcie/ Using BATT
```

가방 안에서 트랙패드가 눌릴 때마다 깨어나면서 뚜껑을 닫아도 배터리가 닳습니다.

`RemoteWakeEnabled`는 시스템 설정 > 일반 > 공유 > 고급의 "Bluetooth 기기가 컴퓨터를 깨우도록 허용" 뒤에 있는 시스템 전역 스위치입니다. nix-darwin에 해당 옵션이 없어서 `postActivation`에서 직접 씁니다.

기존 `lid-awake-on-ac` 데몬(AC 전원에서 의도적으로 clamshell sleep을 막는 기능)과는 무관하며, 그 동작은 그대로입니다.

## 변경사항

- `users/shared/darwin/power.nix`: `postActivation`에서 `RemoteWakeEnabled`를 false로 설정. 이미 꺼져 있으면 no-op이 되도록 가드
- `tests/unit/darwin-activation-test.nix`: 해당 설정이 실제 활성화 스크립트에 spliced 되는지 검증하는 assertion 추가

- [ ] 기능 추가/수정
- [x] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [x] 테스트 추가/수정
- [x] 설정 변경

## 테스트 계획

- [x] `nix build .#darwinConfigurations.kakaostyle-jito.system` 통과
- [x] `nix build .#checks.aarch64-darwin.all-assertions` 통과
- [x] `nix fmt` — 변경 없음 (0 changed)
- [x] pre-commit 훅 전체 통과
- [x] 빌드된 `activate` 스크립트에 신규 세그먼트와 기존 `scripts.nix` 세그먼트가 모두 병합됨을 확인
- [x] 신규 테스트의 검증력 확인 — 설정을 일시 제거하니 FAIL, 복원하니 PASS

`make test` / `make test-all`은 실행하지 않았습니다. 컨테이너 테스트는 Linux + KVM이 필요해 macOS에서는 검증 모드로 degrade되므로, 대신 assertion을 실제로 빌드하는 `all-assertions`를 돌렸습니다.

## 추가 정보

**Bluetooth 설정은 재부팅해야 완전히 반영됩니다.**

이 PR은 Bluetooth 깨움만 다룹니다. 로그에는 Power Nap으로 인한 `rtc/SleepService` 깨움도 보이지만 범위 밖이라 손대지 않았습니다. Bluetooth만으로 부족하면 별도로 다루면 됩니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS power management now disables Bluetooth remote wake during system activation, helping prevent Bluetooth devices from waking a sleeping Mac while running on battery.
  - The setting is applied only when needed and remains effective across activations.

- **Tests**
  - Added coverage to verify the generated macOS activation script includes the Bluetooth remote-wake safeguard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->