### PR TITLE
feat(codex): install Codex CLI via Home Manager

### DIFF
--- a/tests/integration/codex-test.nix
+++ b/tests/integration/codex-test.nix
@@ -1,0 +1,35 @@
+# tests/integration/codex-test.nix
+
+{
+  inputs,
+  system,
+  pkgs ? import inputs.nixpkgs { inherit system; },
+  lib ? pkgs.lib,
+  ...
+}:
+
+let
+  helpers = import ../lib/test-helpers.nix { inherit pkgs lib; };
+
+  homeConfig = inputs.home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      ../../users/shared/programs/codex.nix
+      {
+        modules.programs.codex.enable = true;
+        home = {
+          username = "test";
+          homeDirectory = if pkgs.stdenv.isDarwin then "/Users/test" else "/home/test";
+          stateVersion = "24.11";
+        };
+      }
+    ];
+  };
+
+  inherit (homeConfig) config;
+in
+{
+  codex-package-installed =
+    helpers.assertTest "codex-package-installed" (builtins.elem pkgs.codex config.home.packages)
+      "Codex should be installed through Home Manager";
+}

--- a/users/shared/programs/codex.nix
+++ b/users/shared/programs/codex.nix
@@ -4,6 +4,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -14,6 +15,8 @@ in
   options.modules.programs.codex.enable = lib.mkEnableOption "Codex CLI configuration";
 
   config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.codex ];
+
     # Share Claude's instruction file: AGENTS.md -> live ~/.claude/CLAUDE.md
     # (the writable copy managed by claude-code.nix), so both tools read the
     # same file and edits to either propagate. force overrides the symlink the


### PR DESCRIPTION
## 요약

Home Manager에서 OpenAI Codex CLI를 Nix 패키지로 설치하도록 설정합니다.

## 변경사항

- [x] 설정 변경
- [x] 테스트 추가/수정
- modules.programs.codex.enable 활성화 시 pkgs.codex를 home.packages에 추가
- Codex 패키지 설치 회귀 테스트 추가

## 테스트 계획

- [x] Codex 패키지 설치 회귀 테스트
- [x] 전체 assertion 테스트
- [x] treefmt 검사
- [x] Git diff 검사
- [ ] Home Manager activation 패키지 빌드

## 추가 정보

Home Manager activation 패키지 빌드는 로컬 /nix 디스크 공간 부족으로 중단됐습니다. 관련 설정 평가는 전체 assertion 테스트에서 통과했습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따름
- [x] 자체 검토를 완료함
- [x] 필요한 경우 문서를 업데이트함
- [x] 변경사항이 기존 기능을 손상시키지 않음
- [x] 새로운 의존성이 필요한 경우 사전에 논의함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Codex to be installed automatically when its Home Manager module is enabled.

* **Tests**
  * Added integration coverage verifying Codex is included in the user’s installed packages on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->