### PR TITLE
fix(ghostty): report real terminfo so keyboard state tears down cleanly

### DIFF
--- a/tests/integration/ghostty-test.nix
+++ b/tests/integration/ghostty-test.nix
@@ -106,14 +106,20 @@ let
       "Ghostty should have shell-integration enabled"
     )
 
-    (helpers.assertTest "ghostty-shell-integration-features" (
-      hasConfigLine "shell-integration-features.*=.*no-cursor,sudo,title,ssh-env"
-      && lacksConfigLine "ssh-terminfo"
-    ) "Ghostty should use ssh-env without ssh-terminfo so remote TERM stays xterm-256color")
-
-    (helpers.assertTest "ghostty-terminal-type-xterm-256color" (hasConfigLine "term.*=.*xterm-256color")
-      "Ghostty should report xterm-256color for every shell"
+    (helpers.assertTest "ghostty-shell-integration-features"
+      (hasConfigLine "shell-integration-features.*=.*no-cursor,sudo,title,ssh-env,ssh-terminfo")
+      "Ghostty must keep ssh-terminfo so remote hosts get the xterm-ghostty entry that term= advertises"
     )
+
+    # term must match Ghostty's real terminfo. Advertising xterm-256color made
+    # applications read terminfo and conclude CSI u was unsupported while
+    # Ghostty still answered runtime capability queries affirmatively; setup and
+    # teardown disagreed, so an abnormally terminated remote TUI left keyboard
+    # protocol state behind. tmux.nix also keys terminal-features off
+    # xterm-ghostty, and those settings go dead under any other value.
+    (helpers.assertTest "ghostty-terminal-type-xterm-ghostty" (
+      hasConfigLine "term.*=.*xterm-ghostty" && lacksConfigLine "term = xterm-256color"
+    ) "Ghostty must report its real terminfo so capability negotiation and teardown agree")
 
     # macOS-specific keybinding test (Option key as Alt)
     (helpers.assertTest "ghostty-macos-option-as-alt" (hasConfigLine "macos-option-as-alt.*=.*left")

--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -217,16 +217,26 @@ in
       "SSH_AUTH_SOCK should be configured for 1Password"
     )
 
-    # Recover terminal mouse tracking after an ungraceful SSH disconnect.
-    (helpers.assertTest "ssh-disconnect-mouse-reset" (initContentHasAll [
-      "_reset_terminal_mouse_tracking"
-      "add-zsh-hook precmd _reset_terminal_mouse_tracking"
+    # Recover terminal input modes after an ungraceful SSH disconnect. A remote
+    # TUI killed by a dropped connection never runs its teardown, so the local
+    # terminal stays in whatever mode it left behind. Mouse tracking leaks click
+    # escapes; the kitty keyboard protocol leaks key reports, which surface as
+    # stray `1;1:3u` while typing.
+    (helpers.assertTest "ssh-disconnect-input-mode-reset" (initContentHasAll [
+      "_reset_terminal_input_modes"
+      "add-zsh-hook precmd _reset_terminal_input_modes"
       "1000l"
       "1002l"
       "1003l"
       "1006l"
       "1015l"
-    ]) "zsh should clear terminal mouse tracking before showing a prompt")
+      # Kitty keyboard protocol: pop the stack, then reset flags outright
+      # (mode 3) since a crashed program may never have pushed.
+      "[<u"
+      "[0;3u"
+      # Bracketed paste
+      "2004l"
+    ]) "zsh should clear mouse tracking and keyboard protocol state before showing a prompt")
 
     # Shell functions
     (helpers.assertTest "function-shell-exists" (initContentHas "shell()")

--- a/tests/integration/zsh-test.nix
+++ b/tests/integration/zsh-test.nix
@@ -230,10 +230,11 @@ in
       "1003l"
       "1006l"
       "1015l"
-      # Kitty keyboard protocol: pop the stack, then reset flags outright
-      # (mode 3) since a crashed program may never have pushed.
+      # Kitty keyboard protocol: pop the stack, then clear the flags outright
+      # since a crashed program may never have pushed. `CSI = 0 ; 1 u` uses
+      # mode 1, which resets every unset bit, so flags=0 disables all of them.
       "[<u"
-      "[0;3u"
+      "[=0;1u"
       # Bracketed paste
       "2004l"
     ]) "zsh should clear mouse tracking and keyboard protocol state before showing a prompt")

--- a/tests/unit/ssh-program-test.nix
+++ b/tests/unit/ssh-program-test.nix
@@ -43,11 +43,15 @@ in
       ssh.enableDefaultConfig == false
     ) "SSH default compatibility config should be disabled and copied explicitly")
 
+    # Interval x CountMax is how long a silent connection survives. A remote job
+    # that prints nothing until it finishes generates no traffic, so too short a
+    # window lets a NAT/firewall reap the session mid-run. Assert the product,
+    # not just the presence of the directives.
     (helpers.assertTest "ssh-program-keepalive-setting" (
-      ssh.settings."*".data.ServerAliveInterval == 60
-      && ssh.settings."*".data.ServerAliveCountMax == 3
+      ssh.settings."*".data.ServerAliveInterval * ssh.settings."*".data.ServerAliveCountMax >= 300
+      && ssh.settings."*".data.ServerAliveInterval <= 30
       && ssh.settings."*".data.TCPKeepAlive == "yes"
-    ) "SSH default host settings should keep explicit keepalive directives")
+    ) "SSH keepalive must tolerate at least 5 minutes of silence, probing at most every 30s")
 
     (helpers.assertTest "ssh-program-github-setting" (
       ssh.settings."github.com".data.HostName == "github.com"
@@ -60,7 +64,7 @@ in
       && lib.hasInfix "Host github.com" configText
       && lib.hasInfix "StrictHostKeyChecking no" configText
       && lib.hasInfix "Host *" configText
-      && lib.hasInfix "ServerAliveInterval 60" configText
+      && lib.hasInfix "ServerAliveInterval 15" configText
       && lib.hasInfix "TCPKeepAlive yes" configText
     ) "Generated ~/.ssh/config should keep the existing behavior")
   ];

--- a/users/shared/programs/.config/ghostty/config
+++ b/users/shared/programs/.config/ghostty/config
@@ -2,7 +2,13 @@
 # Managed via Nix Home Manager
 
 # Terminal Compatibility
-term = xterm-256color
+# Report Ghostty's real terminfo. Reporting xterm-256color instead made the
+# terminal lie about its capabilities: applications read terminfo and concluded
+# CSI u was unsupported, while Ghostty still answered runtime capability
+# queries affirmatively. Setup and teardown then disagreed, so an abnormally
+# terminated remote TUI left keyboard-protocol state behind (stray `1;1:3u`).
+# ssh-terminfo below installs this entry on remote hosts.
+term = xterm-ghostty
 
 # Font Configuration
 font-family = JetBrains Mono
@@ -18,12 +24,11 @@ window-padding-y = 10
 
 # Shell Integration
 shell-integration = true
-shell-integration-features = no-cursor,sudo,title,ssh-env
+shell-integration-features = no-cursor,sudo,title,ssh-env,ssh-terminfo
 
 # Option key as Alt for terminal keybindings (opt+t for Claude Code think toggle)
 macos-option-as-alt=left
 
 # Keybindings for Claude Code compatibility
-# Claude Code doesn't support modern keyboard protocols (CSI u, modifyOtherKeys)
 keybind = shift+enter=text:\n
 keybind = ctrl+left_bracket=text:\x1b

--- a/users/shared/programs/ssh.nix
+++ b/users/shared/programs/ssh.nix
@@ -30,8 +30,11 @@ in
           ControlPersist = "no";
           ForwardAgent = false;
           HashKnownHosts = false;
-          ServerAliveCountMax = 3;
-          ServerAliveInterval = 60;
+          # 15s x 20 = 5min. The previous 60s x 3 gave only 3 minutes, which a
+          # quiet long-running remote job (no output until completion) could
+          # not outlast once a NAT/firewall dropped the idle connection.
+          ServerAliveCountMax = 20;
+          ServerAliveInterval = 15;
           TCPKeepAlive = "yes";
           UserKnownHostsFile = "~/.ssh/known_hosts";
         };

--- a/users/shared/programs/zsh/functions.nix
+++ b/users/shared/programs/zsh/functions.nix
@@ -9,20 +9,30 @@
 # - setup_ssh_agent_for_gui(): SSH agent for GUI apps
 #
 # Note: ssh() is intentionally NOT overridden. Ghostty's shell integration
-# installs its own ssh() to use xterm-256color for remote hosts; wrapping ssh
-# here would shadow that. Keepalive options live in ~/.ssh/config
-# (programs.ssh module).
+# installs its own ssh() that ships xterm-ghostty terminfo to remote hosts
+# (ssh-terminfo); wrapping ssh here would shadow that. Keepalive options live
+# in ~/.ssh/config (programs.ssh module).
 
 ''
-  # Clear mouse-tracking modes left behind when a remote full-screen app exits
-  # without cleanup (for example, after an SSH connection reset).
-  _reset_terminal_mouse_tracking() {
+  # Clear input modes left behind when a remote full-screen app exits without
+  # cleanup (for example, after an SSH connection reset).
+  #
+  # Mouse tracking: \e[?1000l..\e[?1015l
+  # Kitty keyboard protocol: \e[<u pops the flag stack, and \e[0;3u resets the
+  #   flags outright (mode 3 = reset bits) because a crashed program may never
+  #   have pushed, leaving nothing to pop. Without this the terminal keeps
+  #   reporting keys as escape sequences and typing emits stray `1;1:3u`.
+  # Bracketed paste: \e[?2004l
+  #
+  # term = xterm-ghostty is the actual fix; this hook is the safety net for
+  # remote programs that still exit uncleanly.
+  _reset_terminal_input_modes() {
     [[ -t 1 ]] || return 0
-    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1015l'
+    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1015l\e[<u\e[0;3u\e[?2004l'
   }
 
   autoload -Uz add-zsh-hook
-  add-zsh-hook precmd _reset_terminal_mouse_tracking
+  add-zsh-hook precmd _reset_terminal_input_modes
 
   # nix shortcuts
   shell() {
@@ -48,7 +58,7 @@
 
   # autossh for long-lived connections that need auto-reconnect.
   # Plain `ssh` goes through Ghostty's shell-integration wrapper which
-  # uses xterm-256color on the remote — don't shadow it.
+  # installs xterm-ghostty terminfo on the remote — don't shadow it.
   alias assh='AUTOSSH_POLL=60 AUTOSSH_FIRST_POLL=30 autossh -M 0 -o ServerAliveInterval=30 -o ServerAliveCountMax=3'
 
   # SSH agent setup for GUI applications

--- a/users/shared/programs/zsh/functions.nix
+++ b/users/shared/programs/zsh/functions.nix
@@ -18,9 +18,11 @@
   # cleanup (for example, after an SSH connection reset).
   #
   # Mouse tracking: \e[?1000l..\e[?1015l
-  # Kitty keyboard protocol: \e[<u pops the flag stack, and \e[0;3u resets the
-  #   flags outright (mode 3 = reset bits) because a crashed program may never
-  #   have pushed, leaving nothing to pop. Without this the terminal keeps
+  # Kitty keyboard protocol: \e[<u pops the flag stack, and \e[=0;1u clears the
+  #   flags outright because a crashed program may never have pushed, leaving
+  #   nothing to pop. Flag updates take the form `CSI = flags ; mode u`; mode 1
+  #   sets every set bit and resets every unset one, so flags=0 disables all of
+  #   them, including bits kitty may add later. Without this the terminal keeps
   #   reporting keys as escape sequences and typing emits stray `1;1:3u`.
   # Bracketed paste: \e[?2004l
   #
@@ -28,7 +30,7 @@
   # remote programs that still exit uncleanly.
   _reset_terminal_input_modes() {
     [[ -t 1 ]] || return 0
-    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1015l\e[<u\e[0;3u\e[?2004l'
+    printf '\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?1015l\e[<u\e[=0;1u\e[?2004l'
   }
 
   autoload -Uz add-zsh-hook


### PR DESCRIPTION
## 문제

원격 SSH 세션이 끊긴 뒤 로컬 터미널에서 키를 누르면 문자 대신 `1;1:3u` 같은 이스케이프 잔해가 입력됨.

## 근본 원인

Ghostty가 kitty keyboard protocol을 네이티브로 지원하면서도 `term = xterm-256color`로 신고하고 있었다. 이 불일치가 capability negotiation을 둘로 쪼갠다.

- terminfo를 읽는 앱 → "CSI u 미지원"으로 판단
- 런타임으로 쿼리하는 앱 → Ghostty가 "지원함"으로 응답

프로토콜을 켜는 경로와 끄는 경로가 서로 다른 출처를 참조하게 된다. 정상 종료 시엔 드러나지 않지만, SSH가 끊겨 원격 TUI가 teardown을 못 돌리면 터미널이 확장 키 리포트 모드에 갇힌 채 남는다.

거짓 TERM을 쓴 이유는 `ssh-terminfo`가 제거되어 원격 호스트에 `xterm-ghostty` 엔트리가 없었기 때문(#1356). 이를 복원해 신고한 terminfo가 원격에도 설치되게 하면 거짓말이 불필요해진다.

부수 효과로 `tmux.nix`의 `xterm-ghostty:extkeys` / `xterm-ghostty:RGB` terminal-features가 되살아난다. TERM 불일치로 그동안 죽어 있었다.

## 변경

| 파일 | 내용 |
|---|---|
| `ghostty/config` | `term` → `xterm-ghostty`, `ssh-terminfo` 복원 |
| `ssh.nix` | keepalive 60s×3 (3분) → 15s×20 (5분) |
| `zsh/functions.nix` | precmd 훅에 키보드 프로토콜·bracketed paste 리셋 추가 (안전망) |
| 테스트 3개 | 이전 가정을 고정하던 assertion 수정, keepalive는 값이 아닌 허용 시간(≥5분)을 검증 |

keepalive를 늘린 이유: 완료 시점까지 출력이 없는 원격 작업은 트래픽을 만들지 않아, 3분은 NAT/방화벽이 idle 세션을 수거하기에 충분한 시간이었다.

precmd 훅은 terminfo 수정이 본 해결책이고, 여전히 지저분하게 종료되는 원격 프로그램에 대한 안전망으로만 남긴다.

## 검증

- `make test-build` — 135개 assertion 통과 (`--rebuild`로 재확인)
- `pre-commit run --all-files` — 15개 훅 전부 Passed
- `nix build .#darwinConfigurations.macbook-pro.system` — exit 0
- `make switch` 적용 후 `~/.config/ghostty/config`, `~/.ssh/config`, `~/.zshrc` 반영 확인

`nix flake check --all-systems`는 macOS에서 Linux 파생 평가 시 실패하지만, main에서도 동일한 store path로 재현되는 기존 문제이며 이 변경과 무관하다. CI의 Linux 러너 결과로 확인 예정.

## 롤백

```
git revert <sha> && make switch   # 이후 Ghostty 재시작
```

설정 파일 변경뿐이라 마이그레이션 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ghostty now reports its native `xterm-ghostty` terminal type and can install the corresponding terminfo entry on remote hosts.
  - SSH connections now use more resilient keepalive settings, supporting up to five minutes of idle time.
  - Shell sessions reset mouse tracking, Kitty keyboard modes, and bracketed paste after SSH disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->