### PR TITLE
feat(herdr): run wt from the new worktree key

### DIFF
--- a/tests/integration/herdr-test.nix
+++ b/tests/integration/herdr-test.nix
@@ -28,6 +28,9 @@ let
   herdrConfig = config.xdg.configFile."herdr/config.toml".text;
   parsedConfig = builtins.fromTOML herdrConfig;
   herdrConfigFile = pkgs.writeText "herdr-config.toml" herdrConfig;
+
+  worktreeCommand = builtins.head parsedConfig.keys.command;
+  newWorktreeScript = config.xdg.configFile."herdr/new-worktree.sh".text;
 in
 {
   herdr-package-installed =
@@ -35,13 +38,54 @@ in
       "Herdr should be installed through Home Manager";
 
   herdr-config-contains-tmux-bindings = helpers.assertTest "herdr-config-contains-tmux-bindings" (
-    parsedConfig.keys == {
-      prefix = "ctrl+a";
-      detach = "prefix+d";
-      split_vertical = "prefix+|";
-      split_horizontal = "prefix+minus";
-    }
+    parsedConfig.keys.prefix == "ctrl+a"
+    && parsedConfig.keys.detach == "prefix+d"
+    && parsedConfig.keys.split_vertical == "prefix+|"
+    && parsedConfig.keys.split_horizontal == "prefix+minus"
   ) "Herdr should use the selected tmux-compatible bindings";
+
+  herdr-unbinds-builtin-new-worktree = helpers.assertTest "herdr-unbinds-builtin-new-worktree" (
+    parsedConfig.keys.new_worktree == ""
+  ) "Herdr's built-in New worktree writes to ~/.herdr/worktrees, so the key belongs to wt";
+
+  herdr-binds-worktree-key-to-wt = helpers.assertTest "herdr-binds-worktree-key-to-wt" (
+    worktreeCommand.key == "prefix+shift+g"
+    # shell type runs detached and could not prompt for a branch name.
+    && worktreeCommand.type == "popup"
+  ) "prefix+shift+g should open a popup instead of Herdr's built-in worktree dialog";
+
+  # The bridge is the part that breaks quietly. Custom commands receive
+  # HERDR_ACTIVE_*, but wt gates its Herdr integration on HERDR_ENV plus
+  # HERDR_WORKSPACE_ID. Drop the bridge and wt still creates the checkout in the
+  # right place, only it falls back to plain git and the worktree never joins
+  # its parent workspace group -- invisible unless you look at the sidebar.
+  herdr-worktree-command-bridges-workspace-env =
+    helpers.assertTest "herdr-worktree-command-bridges-workspace-env"
+      (
+        lib.hasInfix "HERDR_ENV=1" newWorktreeScript
+        && lib.hasInfix "HERDR_WORKSPACE_ID=\"\${HERDR_ACTIVE_WORKSPACE_ID" newWorktreeScript
+        # wt is a zsh function; Herdr runs commands through /bin/sh.
+        && lib.hasInfix "zsh -ic" newWorktreeScript
+      )
+      "the popup script must bridge HERDR_ACTIVE_WORKSPACE_ID before calling wt";
+
+  # The branch name is attacker-adjacent only in the sense that a stray ';' or
+  # '$(...)' in a typed name would be re-parsed by zsh. Passing it positionally
+  # is what keeps 'a;echo x' one branch name instead of two commands.
+  herdr-worktree-command-passes-branch-positionally =
+    helpers.assertTest "herdr-worktree-command-passes-branch-positionally"
+      (
+        lib.hasInfix "zsh -ic 'wt \"$1\"' wt" newWorktreeScript
+        && !(lib.hasInfix "\"wt \${name" newWorktreeScript)
+      )
+      "the branch name must reach wt as a positional argument, not interpolated into the command string";
+
+  # A dangling command path would fail only at keypress time, in a popup that
+  # closes immediately.
+  herdr-worktree-command-points-at-deployed-script =
+    helpers.assertTest "herdr-worktree-command-points-at-deployed-script"
+      (worktreeCommand.command == "${config.xdg.configHome}/herdr/new-worktree.sh")
+      "prefix+shift+g must point at the script this module deploys";
 
   herdr-config-does-not-set-worktree-root =
     helpers.assertTest "herdr-config-does-not-set-worktree-root" (!(parsedConfig ? worktrees))

--- a/users/shared/programs/herdr.nix
+++ b/users/shared/programs/herdr.nix
@@ -7,12 +7,49 @@
 
 let
   cfg = config.modules.programs.herdr;
+
+  # Herdr's built-in New worktree action puts checkouts under
+  # ~/.herdr/worktrees/<repo>/<slug>, which wt does not use, so the key runs wt
+  # instead and every worktree lands in <repo>/.worktrees/<slug>.
+  #
+  # Custom commands receive HERDR_ACTIVE_* rather than the HERDR_ENV /
+  # HERDR_WORKSPACE_ID pair panes get, and wt gates its Herdr integration on the
+  # latter. Without the bridge below wt still creates the checkout in the right
+  # place, but falls back to plain git and the worktree never joins its parent
+  # workspace group.
+  #
+  # config.toml cannot reference a store path, so the script is deployed to a
+  # fixed path under the Herdr config directory instead of pkgs.writeShellScript.
+  newWorktreePath = "${config.xdg.configHome}/herdr/new-worktree.sh";
 in
 {
   options.modules.programs.herdr.enable = lib.mkEnableOption "Herdr terminal workspace manager";
 
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.herdr ];
+
+    xdg.configFile."herdr/new-worktree.sh" = {
+      executable = true;
+      text = ''
+        #!${pkgs.bash}/bin/bash
+        # Invoked by Herdr's prefix+shift+g popup. See herdr.nix.
+        cd "''${HERDR_ACTIVE_PANE_CWD:-$PWD}" || exit 1
+
+        export HERDR_ENV=1
+        export HERDR_WORKSPACE_ID="''${HERDR_ACTIVE_WORKSPACE_ID:-}"
+
+        # A failed read means EOF or Ctrl+C: cancel instead of creating a
+        # randomly named branch nobody asked for.
+        printf 'branch (empty = random): '
+        read -r name || exit 0
+
+        # wt is a zsh function from zshrc, and Herdr runs commands via /bin/sh.
+        # The branch name goes in as a positional argument, never interpolated
+        # into the command string: a name like 'a;rm -rf x' would otherwise be
+        # re-parsed by zsh as a second command.
+        exec ${pkgs.zsh}/bin/zsh -ic 'wt "$1"' wt "''${name:-new}"
+      '';
+    };
 
     xdg.configFile."herdr/config.toml".text = ''
       onboarding = false
@@ -26,6 +63,15 @@ in
       detach = "prefix+d"
       split_vertical = "prefix+|"
       split_horizontal = "prefix+minus"
+      new_worktree = ""
+
+      [[keys.command]]
+      key = "prefix+shift+g"
+      type = "popup"
+      command = "${newWorktreePath}"
+      description = "new worktree (wt)"
+      width = "80%"
+      height = "60%"
     '';
   };
 }


### PR DESCRIPTION
## 문제

`prefix+shift+g`(herdr 내장 `New worktree`)와 `wt`가 서로 다른 곳에 worktree를 만든다.

|  | 경로 | 슬러그 |
|---|---|---|
| `wt` | `<repo-root>/.worktrees/<slug>` | `/`만 `-`로, 대소문자 보존 |
| herdr 내장 | `~/.herdr/worktrees/<repo_name>/<slug>` | 비영숫자 전부 `-`로, 소문자화 |

## 왜 설정으로 못 맞추나

herdr 소스(`src/worktree.rs`, `src/config/model.rs`) 기준:

- `WorktreesConfig`는 `directory` 단일 필드이고 `<repo>/<branch-slug>` 2단 구조는 컴파일타임 고정
- 상대경로는 프로세스 CWD 기준으로 한 번 절대화된다 (리포별 재해석 아님)
- 확장은 `~`뿐. `$VAR` 치환 계층이 없다
- `worktree.created` 등 플러그인 이벤트는 전부 과거형이라 경로에 개입 불가

리포 안 `.worktrees/`는 config로 표현할 수 없어서, 키를 `wt`로 재바인딩했다.

## 덤

`wt`가 내장 액션보다 하는 일이 많다.

- base 브랜치 fetch + ff-only pull
- ref 계층 충돌 처리
- 이미 체크아웃된 브랜치면 그쪽으로 이동
- linked worktree 안에서도 동작 (내장은 메뉴에 안 나옴)
- `nix store gc`

## 함정 2개

**1. 환경변수 이름이 다르다.** 커스텀 명령은 `HERDR_ACTIVE_*`를 받지만 `wt`는 `HERDR_ENV` + `HERDR_WORKSPACE_ID`로 게이트한다. 브리지가 없으면 경로는 맞는데 워크스페이스 그룹핑이 조용히 사라진다.

**2. 브랜치명 인젝션.** `zsh -ic "wt $name"` 형태면 `a;touch x` 같은 입력이 두 번째 명령으로 재파싱된다. positional 인자로 넘겨서 막았다.

둘 다 회귀 테스트를 붙였고, 뮤테이션으로 실제로 잡는 것까지 확인했다.

## 검증

빌드:
- `all-assertions` PASS
- `darwinConfigurations.macbook-pro.system` PASS
- herdr 체크 9개 PASS (실제 `herdr config check` 실행 포함)
- 기존 `wt` 테스트 9개 PASS (`wt.nix` 미변경)

적용 후 실측 (격리된 임시 리포에서 배포된 스크립트를 popup 환경으로 실행):

| 항목 | 결과 |
|---|---|
| 경로 | `<repo>/.worktrees/feat-probe-one` |
| 브리지 | `wt`가 `through Herdr` 경로 진입 |
| 그룹핑 | `source_workspace_id`가 부모를 정확히 가리킴 |
| 인젝션 | `x;touch /tmp/PWNED_MARKER` → 전체가 브랜치명 1개, git이 거부, 마커 미생성 |

뮤테이션 2건:
- 브리지 export 제거 → `herdr-worktree-command-bridges-workspace-env` FAIL
- 인젝션 취약 형태로 복귀 → `herdr-worktree-command-passes-branch-positionally` FAIL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom workflow for creating new worktrees from the terminal.
  * Use the `prefix + Shift + G` shortcut to open a popup, enter a branch name, and create a worktree in the active workspace.
  * The workflow preserves the current Herdr workspace context and launches through the configured shell.
  * Cancelling the prompt with EOF or Ctrl+C exits without creating a worktree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->