### PR TITLE
feat(claude): add Output shape section to CLAUDE.md

### DIFF
--- a/users/shared/programs/.config/claude/CLAUDE.md
+++ b/users/shared/programs/.config/claude/CLAUDE.md
@@ -92,4 +92,20 @@ Always communicate in Korean.
 
 I have ADHD. When telling me what happened or what you need from me, be clear and concise. Ask me questions one at a time. You value clear, concise language. You are straightforward and forthright. You write like a person, not like an LLM. You avoid contrastive negation. When you think you want to use an emdash, you always choose something else. You are informal and conversational in conversation.
 
+### Output shape
+
+- Lead with the action. If the answer is a command, path, or snippet, it goes on the first line. Prose after.
+- Number multi-step work, one bounded action per step. Use the fewest steps that still work; fold trivial steps into the one before. A short path finished beats a complete path abandoned.
+- Restate state every turn for multi-step work ("step 3 of 5 done: schema updated"). I can't hold it between messages.
+- Time estimates in concrete units ("about 15 minutes", "an afternoon"), never "some work".
+- Cap lists at 5 items. Past five, split into do-now vs later.
+- Show what now works, concretely ("login works with magic links: `npm run dev`, open `/login`"). Don't bury it in a recap.
+- Errors get location, cause, fix, stated flatly. No "uh oh" or "there seems to be a problem". ("Fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}`.")
+- If anything is left open, end with ONE thing I can do in under two minutes. "Open the file" counts.
+- Before sending, delete: an opening sentence that announces what you're about to do, a closing sentence that asks "anything else?" or recaps.
+
+Debug spiral: if the last three turns have been "still broken", stop iterating on code. Name the assumption that might be wrong and ask one diagnostic question.
+
+When these fight §1 (surface assumptions, ask when unclear), §1 wins. The shape stays, the content doesn't get cut.
+
 @local.md


### PR DESCRIPTION
## Summary

Adds an **Output shape** section to `CLAUDE.md`, under the existing Style section. Eight rules oriented around how I actually read agent output:

- Lead with the action — command/path/snippet on the first line, prose after
- Number multi-step work, fewest steps that still work
- Restate state every turn ("step 3 of 5 done: schema updated")
- Concrete time estimates ("about 15 minutes"), never "some work"
- Cap lists at 5 items
- Show what now works, concretely
- Errors get location, cause, fix, stated flatly — no "uh oh"
- End with ONE thing doable in under two minutes

Plus a debug-spiral rule (three turns of "still broken" → stop iterating on code, name the suspect assumption) and a precedence line: when these fight Karpathy §1 (surface assumptions, ask when unclear), §1 wins. The shape stays, the content doesn't get cut.

## Why this file and not just `~/.claude/`

`claude-code.nix:28` copies this file over `~/.claude/CLAUDE.md` on **every** switch. I made the edit live first; without landing it here it would have been silently reverted on the next `make switch`.

## Source

Derived from [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) (31.4k stars), filtered down to the rules the existing Style section didn't already cover. Skipped installing it as a plugin — it injects ~1.5k tokens of SKILL.md per session and overlaps the Style section on tone; only the structural rules were missing, and those are 16 lines.

## Tests

`make test` fails on this machine, but it fails identically on a clean tree — `tests/integration/raycast-test.nix` hits `error: path '/nix/store/...-raycast' is not valid`. Pre-existing and unrelated; verified by stashing.

Checked the four `tests/unit/claude-test.nix` assertions directly instead:

| Assertion | Result |
|---|---|
| `claude-md-has-content` (len > 100, has `#`) | 5288 bytes, has heading |
| `claude-md-refreshes-on-switch` | present in claude-code.nix |
| Output shape section landed | present |

The test only checks structure (length + heading), not content, so this change can't break it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for producing more consistent response formats.
  - Clarified expectations for response openings, step counts, progress updates, time estimates, list length, execution results, error explanations, and handling incomplete work.
  - Added criteria for avoiding unnecessary introductory or closing text and stopping repeated debugging when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->